### PR TITLE
Browser-initiated popups (window.open) — macOS/Linux/Windows, + portable WebKitGTK 4.0/4.1 Linux loader

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,11 +113,21 @@ jobs:
               -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/linux" \
               -I./src_c \
               $(pkg-config --cflags gtk+-3.0 "$WEBKIT_PKG") \
-              src_c/webview.c src_c/webview_embed.cpp \
-              $(pkg-config --libs gtk+-3.0 "$WEBKIT_PKG") \
+              src_c/webview.c src_c/webview_embed.cpp src_c/webkit_loader.cpp \
+              $(pkg-config --libs gtk+-3.0) \
               -lX11 -ldl \
               -shared -o "natives/${{ matrix.native_dir }}/${{ matrix.lib_name }}"
           file "natives/${{ matrix.native_dir }}/${{ matrix.lib_name }}"
+          # Portability gate: the artifact MUST NOT hard-link any WebKitGTK /
+          # JavaScriptCore SONAME — those are dlopen'd at runtime (4.1 or 4.0)
+          # by src_c/webkit_loader.cpp, which is what lets one .so serve both.
+          echo "readelf -d (webkit2gtk/javascriptcoregtk NEEDED must be empty):"
+          if readelf -d "natives/${{ matrix.native_dir }}/${{ matrix.lib_name }}" \
+               | grep -iE 'NEEDED.*(webkit2gtk|javascriptcoregtk)'; then
+            echo "ERROR: libwebview.so carries a hard WebKitGTK/JSC dependency (NEEDED above)." >&2
+            exit 1
+          fi
+          echo "OK: no webkit2gtk/javascriptcoregtk NEEDED entries."
 
       # ---------------- Windows -----------------------------------------------
       - name: Set up MSVC environment

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -111,11 +111,21 @@ jobs:
               -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/linux" \
               -I./src_c \
               $(pkg-config --cflags gtk+-3.0 "$WEBKIT_PKG") \
-              src_c/webview.c src_c/webview_embed.cpp \
-              $(pkg-config --libs gtk+-3.0 "$WEBKIT_PKG") \
+              src_c/webview.c src_c/webview_embed.cpp src_c/webkit_loader.cpp \
+              $(pkg-config --libs gtk+-3.0) \
               -lX11 -ldl \
               -shared -o "natives/${{ matrix.native_dir }}/${{ matrix.lib_name }}"
           file "natives/${{ matrix.native_dir }}/${{ matrix.lib_name }}"
+          # Portability gate: the released artifact MUST NOT hard-link any
+          # WebKitGTK / JavaScriptCore SONAME — those are dlopen'd at runtime
+          # (4.1 or 4.0) by src_c/webkit_loader.cpp, so one .so serves both.
+          echo "readelf -d (webkit2gtk/javascriptcoregtk NEEDED must be empty):"
+          if readelf -d "natives/${{ matrix.native_dir }}/${{ matrix.lib_name }}" \
+               | grep -iE 'NEEDED.*(webkit2gtk|javascriptcoregtk)'; then
+            echo "ERROR: libwebview.so carries a hard WebKitGTK/JSC dependency (NEEDED above)." >&2
+            exit 1
+          fi
+          echo "OK: no webkit2gtk/javascriptcoregtk NEEDED entries."
 
       - name: Set up MSVC environment
         if: runner.os == 'Windows'

--- a/README.md
+++ b/README.md
@@ -402,13 +402,14 @@ wv.setPopupHandler(new WebViewPopupHandler() {
   return the allow/deny decision before yielding to the browser engine);
   keep it fast, thread-safe, and free of Swing access.  `popupOpened` /
   `popupClosed` are asynchronous notifications delivered on the EDT.
-* **Platform coverage (current).**  macOS heavyweight (WKWebView) opens
-  popups via the `WKUIDelegate createWebViewWithConfiguration:` /
-  `webViewDidClose:` pair (Canvas 15).  **Linux** (WebKitGTK `create`
-  signal) and **Windows** (WebView2 `NewWindowRequested`) are specified in
-  Canvas 15 but land in follow-up coverage canvases; until then
-  `window.open` stays blocked on those platforms (the handler reference is
-  held but no native callback fires).
+* **Platform coverage.**  All three engines open native, opener-linked
+  popup windows: macOS heavyweight (WKWebView) via the `WKUIDelegate
+  createWebViewWithConfiguration:` / `webViewDidClose:` pair (Canvas 15);
+  **Linux** heavyweight *and* lightweight (WebKitGTK `create` /
+  `ready-to-show` / `close` signals, Canvas 16); and **Windows**
+  (WebView2 `NewWindowRequested` + the child's `WindowCloseRequested`,
+  Canvas 17).  `setPopupHandler(null)` blocks `window.open` on every
+  platform.
 
 See [`demos/WebViewPopupDemo/`](demos/WebViewPopupDemo/README.md) for a
 runnable example that exercises the allow / custom / block modes.

--- a/README.md
+++ b/README.md
@@ -365,6 +365,54 @@ See [`demos/WebViewDialogDemo/`](demos/WebViewDialogDemo/README.md)
 for a runnable example that exercises all four dialog kinds in each
 of the three handler modes (default, custom, drop).
 
+## Browser-initiated popups (`window.open`)
+
+Pages can call `window.open(url, name, features)` or click a link / form
+with `target="_blank"`.  `WebViewComponent.setPopupHandler` lets the host
+application allow, observe, or block those popups:
+
+```java
+wv.setPopupHandler(new WebViewPopupHandler() {
+    @Override public boolean popupRequested(WebViewPopupEvent e) {
+        return e.targetUrl().startsWith("https://");   // allow only https
+    }
+    @Override public void popupOpened(WebViewPopupEvent e) {
+        System.out.println("popup: " + e.targetUrl());
+    }
+});
+```
+
+* **Native-owned window.**  When a popup is allowed the *native engine*
+  creates the child web view **linked to the opener** and hosts it in a
+  fresh native top-level window that the engine sizes, shows, and
+  destroys.  The opener linkage is what makes OAuth "sign-in with popup"
+  flows work — the popup calls `window.opener.postMessage(...)` then
+  `window.close()`, which only succeed when the popup is a real linked
+  view rather than an independent tab.  The handler only decides *policy*
+  (`popupRequested`) and *observes* the lifecycle (`popupOpened` /
+  `popupClosed`); it does not open, host, or size the window.
+* **Default behaviour.**  With no handler installed every popup is allowed.
+* **Blocking popups.**  Pass `null`: `wv.setPopupHandler(null)` blocks all
+  popups (`window.open` returns `null`) — the pre-feature behaviour,
+  available as an explicit opt-out.  To reset to the framework default
+  (allow), pass `WebViewPopupHandler.DEFAULT` explicitly — `null` is NOT a
+  reset.
+* **Threading.**  `popupRequested` runs on the **native UI thread**,
+  synchronously and **off the EDT** (the platform popup callback must
+  return the allow/deny decision before yielding to the browser engine);
+  keep it fast, thread-safe, and free of Swing access.  `popupOpened` /
+  `popupClosed` are asynchronous notifications delivered on the EDT.
+* **Platform coverage (current).**  macOS heavyweight (WKWebView) opens
+  popups via the `WKUIDelegate createWebViewWithConfiguration:` /
+  `webViewDidClose:` pair (Canvas 15).  **Linux** (WebKitGTK `create`
+  signal) and **Windows** (WebView2 `NewWindowRequested`) are specified in
+  Canvas 15 but land in follow-up coverage canvases; until then
+  `window.open` stays blocked on those platforms (the handler reference is
+  held but no native callback fires).
+
+See [`demos/WebViewPopupDemo/`](demos/WebViewPopupDemo/README.md) for a
+runnable example that exercises the allow / custom / block modes.
+
 ## Demo
 
 See [`demos/WebViewHeavyweightDemo/`](demos/WebViewHeavyweightDemo/README.md)

--- a/README.md
+++ b/README.md
@@ -18,12 +18,18 @@ Add the dependency to your `pom.xml`:
 ```
 
 The jar bundles the native libraries for macOS, Linux, and Windows — no
-additional native install step is required, with one exception:
+additional native install step is required beyond the platform's system
+web engine:
 
 * **Windows** requires the system-wide Microsoft Edge WebView2 Runtime,
   which ships with current Windows 11 / Edge.  On older Windows, install
   the Evergreen Runtime from
   <https://developer.microsoft.com/microsoft-edge/webview2/>.
+* **Linux** requires a system WebKitGTK — either **4.1** (Ubuntu 22.04+)
+  or **4.0** (Ubuntu 20.04).  The bundled `libwebview.so` resolves
+  whichever is present at load time (no `webkit2gtk` SONAME is
+  hard-linked), so a single jar runs on both.
+* **macOS** needs nothing extra — WKWebView ships with the OS.
 
 ## Platform support
 

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -11,11 +11,14 @@ fi
 JAWT_LIB=(-L"${JAVA_HOME}/lib" -ljawt)
 g++ -I"${JAVA_HOME}/include" -I"${JAVA_HOME}/include/linux" -fPIC -std=c++11 -Wall -Wextra -pedantic -I./src_c -DWEBVIEW_GTK=1 \
     `pkg-config --cflags gtk+-3.0 $WEBKIT_PKG` \
-    src_c/webview.c src_c/webview_embed.cpp \
+    src_c/webview.c src_c/webview_embed.cpp src_c/webkit_loader.cpp \
     $LDFLAGS \
-    `pkg-config --libs gtk+-3.0 $WEBKIT_PKG` \
-    "${JAWT_LIB[@]}" -lX11 \
+    `pkg-config --libs gtk+-3.0` \
+    "${JAWT_LIB[@]}" -lX11 -ldl \
     -shared -o libwebview.so
+# NOTE: WebKitGTK/JavaScriptCore are intentionally NOT linked (only --cflags
+# for the headers). They are dlopen'd at runtime (4.1 preferred, 4.0 fallback)
+# by src_c/webkit_loader.cpp, so this single libwebview.so runs on both.
 mkdir -p natives/linux_64
 mv libwebview.so natives/linux_64/
 mvn -DskipTests package

--- a/demos/WebViewPopupDemo/README.md
+++ b/demos/WebViewPopupDemo/README.md
@@ -38,11 +38,15 @@ ant run
 Requires a built `dist/WebView.jar` at the project root (run any
 `run-{linux,mac,windows}-demo.sh` once first to produce it).
 
-## Platform status (this iteration)
+## Platform status
 
-macOS heavyweight (WKWebView) is wired in Canvas 15 — popups open in a
-native window linked to the opener.  On **Linux** and **Windows** the
-embedded engine still blocks `window.open` until the follow-up coverage
-canvases land (WebKitGTK `create` signal / WebView2 `NewWindowRequested`);
-on those platforms the demo's mode switcher still updates the log pane, but
-the embedded engine does not yet open popups.
+All three platforms open a native, opener-linked popup window when a popup
+is allowed:
+
+- **macOS** — WKWebView `createWebViewWithConfiguration:` (Canvas 15).
+- **Linux** — WebKitGTK `create` signal, heavyweight *and* lightweight
+  (Canvas 16).
+- **Windows** — WebView2 `NewWindowRequested` (Canvas 17).
+
+`setPopupHandler(null)` blocks `window.open` (it returns `null`) on every
+platform.

--- a/demos/WebViewPopupDemo/README.md
+++ b/demos/WebViewPopupDemo/README.md
@@ -1,0 +1,48 @@
+# WebViewPopupDemo
+
+Exercises the browser-initiated **popup** API (`window.open`) introduced by
+[`spdd/prompt/15-20260802-1000-[Feat]-Browser-Initiated-Popups-Window-Open.md`](../../spdd/prompt/15-20260802-1000-%5BFeat%5D-Browser-Initiated-Popups-Window-Open.md)
+(Canvas 15).
+
+The embedded page has a `window.open(...)` button and a `<a target="_blank">`
+link.  A combo box at the top switches among three handler modes:
+
+| Mode | What happens |
+|---|---|
+| **Default handler** | Allow all popups.  The native engine opens each in a separate native window, linked to the opener. |
+| **Custom handler** | Allow + record `popupOpened` / `popupClosed` to the log pane. |
+| **Block handler** | `setPopupHandler(null)` — `window.open` returns `null` (the pre-feature behaviour). |
+
+The bottom log pane shows every captured `console.log` line plus the
+handler's `popupOpened` / `popupClosed` notices, so you can see whether the
+popup opened (allowed) or `window.open` returned null (blocked).
+
+## What to verify
+
+| Check | Verification |
+|---|---|
+| Allow (default) | Mode = Default; click the button → a separate native window opens loading example.com. |
+| Opener linkage | In the popup's dev console, `window.opener` is non-null (this is what makes OAuth `signInWithPopup` postMessage-to-opener work). |
+| Notifications | Mode = Custom; open then close a popup → log shows `[opened] ...` then `[closed] ...`. |
+| Requested size | Mode = Custom; `window.open(..., 'width=520,height=640')` → `[opened]` line reports `520x640`. |
+| Block | Mode = Block; click the button → log shows `window.open returned null (blocked)`. |
+| `getPopupHandler()` non-null | Implicit; the mode switcher always reads a real handler value. |
+| `window.close()` | From the popup page call `window.close()` → the native window closes and `[closed]` is logged. |
+
+## Build & run
+
+```sh
+ant run
+```
+
+Requires a built `dist/WebView.jar` at the project root (run any
+`run-{linux,mac,windows}-demo.sh` once first to produce it).
+
+## Platform status (this iteration)
+
+macOS heavyweight (WKWebView) is wired in Canvas 15 — popups open in a
+native window linked to the opener.  On **Linux** and **Windows** the
+embedded engine still blocks `window.open` until the follow-up coverage
+canvases land (WebKitGTK `create` signal / WebView2 `NewWindowRequested`);
+on those platforms the demo's mode switcher still updates the log pane, but
+the embedded engine does not yet open popups.

--- a/demos/WebViewPopupDemo/build.xml
+++ b/demos/WebViewPopupDemo/build.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="WebViewPopupDemo" default="run" basedir=".">
+    <description>Build and run the browser-initiated popups demo.</description>
+
+    <property name="src.dir" value="src"/>
+    <property name="build.dir" value="build"/>
+    <property name="classes.dir" value="${build.dir}/classes"/>
+    <property name="webview.jar" value="../../dist/WebView.jar"/>
+    <property name="main.class" value="ca.weblite.webview.demos.WebViewPopupDemo"/>
+
+    <target name="check-webview-jar">
+        <available file="${webview.jar}" property="webview.jar.exists"/>
+        <fail unless="webview.jar.exists">
+WebView.jar not found at ${webview.jar}.
+Build it first from the project root, e.g. ./run-linux-demo.sh once to
+produce dist/WebView.jar, or invoke a platform run-*-demo.sh / .bat at
+the repo root.
+        </fail>
+    </target>
+
+    <target name="compile" depends="check-webview-jar">
+        <mkdir dir="${classes.dir}"/>
+        <javac srcdir="${src.dir}" destdir="${classes.dir}"
+               includeantruntime="false" source="1.8" target="1.8">
+            <classpath>
+                <pathelement location="${webview.jar}"/>
+            </classpath>
+        </javac>
+    </target>
+
+    <target name="run" depends="compile">
+        <java classname="${main.class}" fork="true">
+            <classpath>
+                <pathelement location="${classes.dir}"/>
+                <pathelement location="${webview.jar}"/>
+            </classpath>
+        </java>
+    </target>
+
+    <target name="clean">
+        <delete dir="${build.dir}"/>
+    </target>
+</project>

--- a/demos/WebViewPopupDemo/src/ca/weblite/webview/demos/WebViewPopupDemo.java
+++ b/demos/WebViewPopupDemo/src/ca/weblite/webview/demos/WebViewPopupDemo.java
@@ -80,10 +80,6 @@ public class WebViewPopupDemo {
           + "}"
           + "</script></body></html>";
 
-        wv.addOnBeforeLoad(
-            "document.open();document.write("
-          + toJsString(html) + ");document.close();");
-
         final JTextArea log = new JTextArea();
         log.setEditable(false);
         wv.addConsoleListener(new ConsoleListener() {
@@ -140,7 +136,14 @@ public class WebViewPopupDemo {
         f.setLocationRelativeTo(null);
         f.setVisible(true);
 
-        wv.setUrl("about:blank");
+        // Load the inline page via a base64-encoded data: URL, mirroring
+        // WebViewDialogDemo.  Base64 avoids the WKWebView blank-page
+        // pitfalls of addOnBeforeLoad + about:blank and of raw/percent-
+        // encoded data: bodies (literal "%20" text; truncation at the
+        // first '#' in CSS colours) and decodes reliably on every engine.
+        String b64 = java.util.Base64.getEncoder().encodeToString(
+            html.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        wv.setUrl("data:text/html;charset=utf-8;base64," + b64);
     }
 
     private static void append(JTextArea log, String line) {
@@ -148,21 +151,5 @@ public class WebViewPopupDemo {
             log.append(line + "\n");
             log.setCaretPosition(log.getDocument().getLength());
         });
-    }
-
-    /** Encode an HTML string as a JS string literal for document.write. */
-    private static String toJsString(String s) {
-        StringBuilder b = new StringBuilder("\"");
-        for (int i = 0; i < s.length(); i++) {
-            char c = s.charAt(i);
-            switch (c) {
-                case '"':  b.append("\\\""); break;
-                case '\\': b.append("\\\\"); break;
-                case '\n': b.append("\\n"); break;
-                case '\r': break;
-                default:   b.append(c);
-            }
-        }
-        return b.append("\"").toString();
     }
 }

--- a/demos/WebViewPopupDemo/src/ca/weblite/webview/demos/WebViewPopupDemo.java
+++ b/demos/WebViewPopupDemo/src/ca/weblite/webview/demos/WebViewPopupDemo.java
@@ -1,0 +1,168 @@
+/*
+ * MIT License
+ *
+ * Exercises the browser-initiated popup API (window.open) on
+ * WebViewComponent — Canvas 15.
+ *
+ * Switch among three handler modes via the combo box at the top:
+ *   - Default   : allow all popups (the native engine opens each in a
+ *                 separate window linked to the opener).
+ *   - Custom    : allow + log popupOpened / popupClosed to the pane.
+ *   - Block     : setPopupHandler(null) — window.open returns null.
+ *
+ * macOS coverage is wired in Canvas 15 (this demo's reference).  On Linux
+ * and Windows window.open stays blocked until the follow-up coverage
+ * canvases land.
+ *
+ * Manual checks:
+ *   - Default / Custom: clicking "window.open(...)" opens a native popup
+ *     window loading example.com; the log line reports opener !== null
+ *     (proving the child is linked, so OAuth postMessage-to-opener works).
+ *   - Block: clicking the button logs "window.open returned null".
+ */
+package ca.weblite.webview.demos;
+
+import ca.weblite.webview.ConsoleListener;
+import ca.weblite.webview.ConsoleMessage;
+import ca.weblite.webview.WebViewPopupEvent;
+import ca.weblite.webview.WebViewPopupHandler;
+import ca.weblite.webview.swing.WebViewComponent;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import javax.swing.ToolTipManager;
+
+public class WebViewPopupDemo {
+
+    private static final String MODE_DEFAULT = "Default handler (allow popups)";
+    private static final String MODE_CUSTOM  = "Custom handler (allow + log)";
+    private static final String MODE_BLOCK   = "Block handler (window.open == null)";
+
+    public static void main(String[] args) {
+        // Heavyweight popups so any nested Swing menus render above the
+        // WebView region on macOS / Windows heavyweight.
+        JPopupMenu.setDefaultLightWeightPopupEnabled(false);
+        ToolTipManager.sharedInstance().setLightWeightPopupEnabled(false);
+        EventQueue.invokeLater(WebViewPopupDemo::run);
+    }
+
+    private static void run() {
+        final WebViewComponent wv = WebViewComponent.create();
+
+        // Inline test page: a window.open button, a target=_blank link, and
+        // a button that reports whether window.open returned null (blocked)
+        // or a Window (allowed) plus whether the child is linked to us.
+        final String html =
+            "<!doctype html><html><head><meta charset='utf-8'>"
+          + "<title>WebView Popup Demo</title>"
+          + "<style>body{font:14px sans-serif;padding:16px}"
+          + "button,a{display:block;margin:8px 0;font-size:14px}</style>"
+          + "</head><body>"
+          + "<h3>window.open popup demo</h3>"
+          + "<button onclick=\"openPopup()\">window.open(example.com, 520x640)</button>"
+          + "<a href='https://example.org' target='_blank'>&lt;a target=_blank&gt; link</a>"
+          + "<script>"
+          + "function openPopup(){"
+          + "  var w = window.open('https://example.com','demo','width=520,height=640');"
+          + "  if(!w){console.log('window.open returned null (blocked)');return;}"
+          + "  console.log('window.open ok; opener-linked child opened');"
+          + "}"
+          + "</script></body></html>";
+
+        wv.addOnBeforeLoad(
+            "document.open();document.write("
+          + toJsString(html) + ");document.close();");
+
+        final JTextArea log = new JTextArea();
+        log.setEditable(false);
+        wv.addConsoleListener(new ConsoleListener() {
+            @Override public void onMessage(ConsoleMessage m) {
+                append(log, "[page] " + m.getText());
+            }
+        });
+
+        // Handler modes.
+        final WebViewPopupHandler custom = new WebViewPopupHandler() {
+            @Override public boolean popupRequested(WebViewPopupEvent e) {
+                return true; // allow
+            }
+            @Override public void popupOpened(WebViewPopupEvent e) {
+                append(log, "[opened] " + e.targetUrl()
+                    + " (" + e.width() + "x" + e.height() + ")");
+            }
+            @Override public void popupClosed(WebViewPopupEvent e) {
+                append(log, "[closed] " + e.targetUrl());
+            }
+        };
+
+        final JComboBox<String> mode = new JComboBox<String>(
+            new String[] { MODE_DEFAULT, MODE_CUSTOM, MODE_BLOCK });
+        mode.addActionListener(ev -> {
+            Object sel = mode.getSelectedItem();
+            if (MODE_CUSTOM.equals(sel)) {
+                wv.setPopupHandler(custom);
+                append(log, "-- custom handler installed --");
+            } else if (MODE_BLOCK.equals(sel)) {
+                wv.setPopupHandler(null);
+                append(log, "-- popups blocked (setPopupHandler(null)) --");
+            } else {
+                wv.setPopupHandler(WebViewPopupHandler.DEFAULT);
+                append(log, "-- default handler (allow) --");
+            }
+        });
+
+        JPanel top = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        top.add(new JLabel("Popup handler:"));
+        top.add(mode);
+
+        wv.setPreferredSize(new Dimension(700, 420));
+        JSplitPane split = new JSplitPane(JSplitPane.VERTICAL_SPLIT,
+            wv, new JScrollPane(log));
+        split.setResizeWeight(0.7);
+
+        JFrame f = new JFrame("WebView Popup Demo");
+        f.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        f.setLayout(new BorderLayout());
+        f.add(top, BorderLayout.NORTH);
+        f.add(split, BorderLayout.CENTER);
+        f.setSize(760, 640);
+        f.setLocationRelativeTo(null);
+        f.setVisible(true);
+
+        wv.setUrl("about:blank");
+    }
+
+    private static void append(JTextArea log, String line) {
+        SwingUtilities.invokeLater(() -> {
+            log.append(line + "\n");
+            log.setCaretPosition(log.getDocument().getLength());
+        });
+    }
+
+    /** Encode an HTML string as a JS string literal for document.write. */
+    private static String toJsString(String s) {
+        StringBuilder b = new StringBuilder("\"");
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"':  b.append("\\\""); break;
+                case '\\': b.append("\\\\"); break;
+                case '\n': b.append("\\n"); break;
+                case '\r': break;
+                default:   b.append(c);
+            }
+        }
+        return b.append("\"").toString();
+    }
+}

--- a/run-linux-async-callback-demo.sh
+++ b/run-linux-async-callback-demo.sh
@@ -180,7 +180,6 @@ export GDK_BACKEND=x11
 # compatibility with older WebKit builds where it was named differently.
 export WEBKIT_DISABLE_DMABUF_RENDERER=1
 export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
-export WEBKIT_FORCE_SANDBOX=0
 
 # Uncomment to enable verbose paint-pipeline diagnostics inside our
 # embed code (per-frame draw / frame-clock-phase logging and widget

--- a/run-linux-async-callback-demo.sh
+++ b/run-linux-async-callback-demo.sh
@@ -107,7 +107,7 @@ NEED_SO=0
 if [ ! -f "$SO" ]; then
     NEED_SO=1
 else
-    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp; do
+    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp src_c/webkit_loader.cpp src_c/webkit_loader.h src_c/webkit_shim.h; do
         if [ "$src" -nt "$SO" ]; then NEED_SO=1; break; fi
     done
 fi
@@ -125,8 +125,8 @@ if [ "$NEED_SO" = "1" ]; then
         -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/linux" \
         -I./src_c \
         $(pkg-config --cflags gtk+-3.0 "$WEBKIT_PKG") \
-        src_c/webview.c src_c/webview_embed.cpp \
-        $(pkg-config --libs gtk+-3.0 "$WEBKIT_PKG") \
+        src_c/webview.c src_c/webview_embed.cpp src_c/webkit_loader.cpp \
+        $(pkg-config --libs gtk+-3.0) \
         -lX11 -ldl \
         -shared -o "$SO"
     echo "Built $SO"

--- a/run-linux-console-demo.sh
+++ b/run-linux-console-demo.sh
@@ -180,7 +180,6 @@ export GDK_BACKEND=x11
 # compatibility with older WebKit builds where it was named differently.
 export WEBKIT_DISABLE_DMABUF_RENDERER=1
 export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
-export WEBKIT_FORCE_SANDBOX=0
 
 # Uncomment to enable verbose paint-pipeline diagnostics inside our
 # embed code (per-frame draw / frame-clock-phase logging and widget

--- a/run-linux-console-demo.sh
+++ b/run-linux-console-demo.sh
@@ -107,7 +107,7 @@ NEED_SO=0
 if [ ! -f "$SO" ]; then
     NEED_SO=1
 else
-    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp; do
+    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp src_c/webkit_loader.cpp src_c/webkit_loader.h src_c/webkit_shim.h; do
         if [ "$src" -nt "$SO" ]; then NEED_SO=1; break; fi
     done
 fi
@@ -125,8 +125,8 @@ if [ "$NEED_SO" = "1" ]; then
         -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/linux" \
         -I./src_c \
         $(pkg-config --cflags gtk+-3.0 "$WEBKIT_PKG") \
-        src_c/webview.c src_c/webview_embed.cpp \
-        $(pkg-config --libs gtk+-3.0 "$WEBKIT_PKG") \
+        src_c/webview.c src_c/webview_embed.cpp src_c/webkit_loader.cpp \
+        $(pkg-config --libs gtk+-3.0) \
         -lX11 -ldl \
         -shared -o "$SO"
     echo "Built $SO"

--- a/run-linux-data-smoketest.sh
+++ b/run-linux-data-smoketest.sh
@@ -180,7 +180,6 @@ export GDK_BACKEND=x11
 # compatibility with older WebKit builds where it was named differently.
 export WEBKIT_DISABLE_DMABUF_RENDERER=1
 export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
-export WEBKIT_FORCE_SANDBOX=0
 
 # Uncomment to enable verbose paint-pipeline diagnostics inside our
 # embed code (per-frame draw / frame-clock-phase logging and widget

--- a/run-linux-data-smoketest.sh
+++ b/run-linux-data-smoketest.sh
@@ -107,7 +107,7 @@ NEED_SO=0
 if [ ! -f "$SO" ]; then
     NEED_SO=1
 else
-    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp; do
+    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp src_c/webkit_loader.cpp src_c/webkit_loader.h src_c/webkit_shim.h; do
         if [ "$src" -nt "$SO" ]; then NEED_SO=1; break; fi
     done
 fi
@@ -125,8 +125,8 @@ if [ "$NEED_SO" = "1" ]; then
         -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/linux" \
         -I./src_c \
         $(pkg-config --cflags gtk+-3.0 "$WEBKIT_PKG") \
-        src_c/webview.c src_c/webview_embed.cpp \
-        $(pkg-config --libs gtk+-3.0 "$WEBKIT_PKG") \
+        src_c/webview.c src_c/webview_embed.cpp src_c/webkit_loader.cpp \
+        $(pkg-config --libs gtk+-3.0) \
         -lX11 -ldl \
         -shared -o "$SO"
     echo "Built $SO"

--- a/run-linux-demo.sh
+++ b/run-linux-demo.sh
@@ -180,7 +180,6 @@ export GDK_BACKEND=x11
 # compatibility with older WebKit builds where it was named differently.
 export WEBKIT_DISABLE_DMABUF_RENDERER=1
 export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
-export WEBKIT_FORCE_SANDBOX=0
 
 # Uncomment to enable verbose paint-pipeline diagnostics inside our
 # embed code (per-frame draw / frame-clock-phase logging and widget

--- a/run-linux-demo.sh
+++ b/run-linux-demo.sh
@@ -107,7 +107,7 @@ NEED_SO=0
 if [ ! -f "$SO" ]; then
     NEED_SO=1
 else
-    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp; do
+    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp src_c/webkit_loader.cpp src_c/webkit_loader.h src_c/webkit_shim.h; do
         if [ "$src" -nt "$SO" ]; then NEED_SO=1; break; fi
     done
 fi
@@ -125,8 +125,8 @@ if [ "$NEED_SO" = "1" ]; then
         -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/linux" \
         -I./src_c \
         $(pkg-config --cflags gtk+-3.0 "$WEBKIT_PKG") \
-        src_c/webview.c src_c/webview_embed.cpp \
-        $(pkg-config --libs gtk+-3.0 "$WEBKIT_PKG") \
+        src_c/webview.c src_c/webview_embed.cpp src_c/webkit_loader.cpp \
+        $(pkg-config --libs gtk+-3.0) \
         -lX11 -ldl \
         -shared -o "$SO"
     echo "Built $SO"

--- a/run-linux-dialog-demo.sh
+++ b/run-linux-dialog-demo.sh
@@ -122,7 +122,7 @@ NEED_SO=0
 if [ ! -f "$SO" ]; then
     NEED_SO=1
 else
-    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp; do
+    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp src_c/webkit_loader.cpp src_c/webkit_loader.h src_c/webkit_shim.h; do
         if [ "$src" -nt "$SO" ]; then NEED_SO=1; break; fi
     done
 fi
@@ -134,8 +134,8 @@ if [ "$NEED_SO" = "1" ]; then
         -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/linux" \
         -I./src_c \
         $(pkg-config --cflags gtk+-3.0 "$WEBKIT_PKG") \
-        src_c/webview.c src_c/webview_embed.cpp \
-        $(pkg-config --libs gtk+-3.0 "$WEBKIT_PKG") \
+        src_c/webview.c src_c/webview_embed.cpp src_c/webkit_loader.cpp \
+        $(pkg-config --libs gtk+-3.0) \
         -lX11 -ldl \
         -shared -o "$SO"
     echo "Built $SO"

--- a/run-linux-dialog-demo.sh
+++ b/run-linux-dialog-demo.sh
@@ -182,7 +182,6 @@ echo "Launching WebViewDialogDemo (mode=$MODE) ..."
 export GDK_BACKEND=x11
 export WEBKIT_DISABLE_DMABUF_RENDERER=1
 export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
-export WEBKIT_FORCE_SANDBOX=0
 
 exec "$JAVA" \
     "-Dca.weblite.webview.mode=$MODE" \

--- a/run-linux-popup-demo.sh
+++ b/run-linux-popup-demo.sh
@@ -191,7 +191,6 @@ echo "Launching WebViewPopupDemo (mode=$MODE) ..."
 export GDK_BACKEND=x11
 export WEBKIT_DISABLE_DMABUF_RENDERER=1
 export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
-export WEBKIT_FORCE_SANDBOX=0
 
 exec "$JAVA" \
     "-Dca.weblite.webview.mode=$MODE" \

--- a/run-linux-popup-demo.sh
+++ b/run-linux-popup-demo.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+# One-shot script: build the Linux native lib, build WebView.jar, compile
+# and run the browser-initiated popup demo (WebViewPopupDemo).
+#
+# Exercises window.open(url, name, features) and <a target="_blank"> across
+# three handler modes (Default = allow, Custom = allow + log
+# popupOpened/popupClosed, Block = setPopupHandler(null) => window.open
+# returns null).  See demos/WebViewPopupDemo/README.md for the AC-mapped
+# manual test checklist (allow, opener linkage, notifications, requested
+# size, block, window.close()).
+#
+# On Linux the allowed popup is created from WebKitGTK's "create" signal and
+# hosted in a native GTK top-level window linked to the opener; window.close()
+# fires the child's "close" signal, which tears the popup window down.
+#
+# NOTE: this builds libwebview.so WITHOUT linking WebKitGTK/JavaScriptCore
+# (they are dlopen'd at runtime, 4.1 preferred / 4.0 fallback, by
+# src_c/webkit_loader.cpp), so it also exercises that runtime-resolution path.
+#
+# Usage:    ./run-linux-popup-demo.sh             # lightweight (default)
+#           ./run-linux-popup-demo.sh heavyweight # force heavyweight mode
+#           ./run-linux-popup-demo.sh lightweight # force lightweight mode
+#           WEBVIEW_MODE=heavyweight ./run-linux-popup-demo.sh
+#
+# Popups work in BOTH embedding modes on Linux; run the script twice (once
+# per mode) to cover the full matrix.
+#
+# Override JDK:  JAVA_HOME=/path/to/jdk ./run-linux-popup-demo.sh
+#
+# Required packages:
+#   - g++, pkg-config
+#   - libgtk-3-dev
+#   - libwebkit2gtk-4.1-dev (Ubuntu 24.04+) or libwebkit2gtk-4.0-dev (older)
+#   - libx11-dev
+#   - libxt-dev   <-- pulled in because JDK 8's jawt_md.h includes X11/Intrinsic.h
+set -e
+set -o pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR"
+
+# ---------------------------------------------------------------------------
+# 0. Mode selection
+# ---------------------------------------------------------------------------
+MODE="${1:-${WEBVIEW_MODE:-lightweight}}"
+case "$MODE" in
+    heavyweight|lightweight) ;;
+    *)
+        echo "Unknown mode: $MODE" >&2
+        echo "Usage: $0 [heavyweight|lightweight]" >&2
+        exit 1
+        ;;
+esac
+echo "Mode: $MODE"
+
+# ---------------------------------------------------------------------------
+# 1. Resolve JAVA_HOME
+# ---------------------------------------------------------------------------
+if [ -z "$JAVA_HOME" ]; then
+    if command -v javac >/dev/null 2>&1; then
+        JAVAC_PATH="$(readlink -f "$(command -v javac)" 2>/dev/null || command -v javac)"
+        JAVA_HOME="$(dirname "$(dirname "$JAVAC_PATH")")"
+    fi
+fi
+if [ -z "$JAVA_HOME" ] || [ ! -d "$JAVA_HOME" ]; then
+    echo "JAVA_HOME is not set and could not be resolved automatically." >&2
+    echo "Install a JDK and export JAVA_HOME, e.g. via mise / asdf:" >&2
+    echo "  mise install   # picks up .tool-versions" >&2
+    exit 1
+fi
+export JAVA_HOME
+echo "Using JAVA_HOME=$JAVA_HOME"
+JAVAC="$JAVA_HOME/bin/javac"
+JAVA="$JAVA_HOME/bin/java"
+JAR="$JAVA_HOME/bin/jar"
+for tool in "$JAVAC" "$JAVA" "$JAR"; do
+    if [ ! -x "$tool" ]; then
+        echo "Missing tool: $tool" >&2; exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 2. Pick a WebKit pkg-config name (for HEADERS only; not linked)
+# ---------------------------------------------------------------------------
+if pkg-config --exists webkit2gtk-4.1; then
+    WEBKIT_PKG=webkit2gtk-4.1
+elif pkg-config --exists webkit2gtk-4.0; then
+    WEBKIT_PKG=webkit2gtk-4.0
+else
+    echo "Neither webkit2gtk-4.1 nor webkit2gtk-4.0 was found via pkg-config." >&2
+    echo "Install one of the following with your package manager:" >&2
+    echo "  Debian/Ubuntu 24.04+:  sudo apt install libgtk-3-dev libwebkit2gtk-4.1-dev libx11-dev libxt-dev" >&2
+    echo "  Debian/Ubuntu older:   sudo apt install libgtk-3-dev libwebkit2gtk-4.0-dev libx11-dev libxt-dev" >&2
+    echo "  Fedora:                sudo dnf install gtk3-devel webkit2gtk4.1-devel libX11-devel libXt-devel" >&2
+    exit 1
+fi
+if ! pkg-config --exists gtk+-3.0; then
+    echo "gtk+-3.0 (libgtk-3-dev) is required." >&2
+    exit 1
+fi
+echo "Using WebKit package (headers only): $WEBKIT_PKG"
+
+if ! printf '#include <X11/Intrinsic.h>\nint main(){return 0;}\n' | \
+        g++ -E -x c++ - >/dev/null 2>&1; then
+    echo "" >&2
+    echo "ERROR: <X11/Intrinsic.h> not found." >&2
+    echo "" >&2
+    echo "JDK 8 on Linux pulls X11 Intrinsics in via jawt_md.h.  Install:" >&2
+    echo "  Debian/Ubuntu:  sudo apt install libxt-dev" >&2
+    echo "  Fedora:         sudo dnf install libXt-devel" >&2
+    echo "  Arch:           sudo pacman -S libxt" >&2
+    echo "" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Build libwebview.so for the current arch
+# ---------------------------------------------------------------------------
+case "$(uname -m)" in
+    x86_64|amd64)   NATIVE_DIR=linux_64 ;;
+    aarch64|arm64)  NATIVE_DIR=linux_arm64 ;;
+    armv7l|armv7)   NATIVE_DIR=linux_arm ;;
+    i?86)           NATIVE_DIR=linux_32 ;;
+    *)              NATIVE_DIR=linux_64 ;;
+esac
+echo "Native dir: $NATIVE_DIR (arch: $(uname -m))"
+mkdir -p "$REPO_DIR/src/$NATIVE_DIR"
+SO="$REPO_DIR/src/$NATIVE_DIR/libwebview.so"
+
+NEED_SO=0
+if [ ! -f "$SO" ]; then
+    NEED_SO=1
+else
+    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp src_c/webkit_loader.cpp src_c/webkit_loader.h src_c/webkit_shim.h; do
+        if [ "$src" -nt "$SO" ]; then NEED_SO=1; break; fi
+    done
+fi
+
+if [ "$NEED_SO" = "1" ]; then
+    echo "Building libwebview.so ..."
+    g++ -fPIC -std=c++11 -Wall \
+        -DWEBVIEW_GTK=1 \
+        -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/linux" \
+        -I./src_c \
+        $(pkg-config --cflags gtk+-3.0 "$WEBKIT_PKG") \
+        src_c/webview.c src_c/webview_embed.cpp src_c/webkit_loader.cpp \
+        $(pkg-config --libs gtk+-3.0) \
+        -lX11 -ldl \
+        -shared -o "$SO"
+    echo "Built $SO"
+else
+    echo "libwebview.so up to date."
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Compile WebView Java sources
+# ---------------------------------------------------------------------------
+BUILD_DIR="$REPO_DIR/build"
+WV_CLASSES="$BUILD_DIR/classes-webview"
+WV_JAR="$REPO_DIR/dist/WebView.jar"
+mkdir -p "$WV_CLASSES" "$REPO_DIR/dist"
+echo "Compiling WebView Java sources ..."
+find src -name '*.java' > "$BUILD_DIR/wv-sources.txt"
+"$JAVAC" -d "$WV_CLASSES" -classpath "lib/*" @"$BUILD_DIR/wv-sources.txt"
+
+# ---------------------------------------------------------------------------
+# 5. Build WebView.jar -- classes + linux_*/libwebview.so at jar root
+# ---------------------------------------------------------------------------
+echo "Building WebView.jar ..."
+STAGE="$BUILD_DIR/stage-webview"
+rm -rf "$STAGE"
+mkdir -p "$STAGE/$NATIVE_DIR"
+cp -R "$WV_CLASSES"/. "$STAGE"/
+cp "$SO" "$STAGE/$NATIVE_DIR/libwebview.so"
+( cd "$STAGE" && "$JAR" cf "$WV_JAR" . )
+echo "Built $WV_JAR"
+
+# ---------------------------------------------------------------------------
+# 6. Compile and run the popup demo
+# ---------------------------------------------------------------------------
+DEMO_DIR="$REPO_DIR/demos/WebViewPopupDemo"
+DEMO_CLASSES="$BUILD_DIR/classes-popup-demo"
+mkdir -p "$DEMO_CLASSES"
+echo "Compiling demo ..."
+"$JAVAC" -d "$DEMO_CLASSES" -classpath "$WV_JAR" \
+    "$DEMO_DIR/src/ca/weblite/webview/demos/WebViewPopupDemo.java"
+
+echo "Launching WebViewPopupDemo (mode=$MODE) ..."
+# Force the X11 GDK backend; embedding via XReparentWindow needs a real X11
+# GdkDisplay on both sides.
+export GDK_BACKEND=x11
+export WEBKIT_DISABLE_DMABUF_RENDERER=1
+export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
+export WEBKIT_FORCE_SANDBOX=0
+
+exec "$JAVA" \
+    "-Dca.weblite.webview.mode=$MODE" \
+    -cp "$DEMO_CLASSES:$WV_JAR" \
+    ca.weblite.webview.demos.WebViewPopupDemo

--- a/run-mac-popup-demo.sh
+++ b/run-mac-popup-demo.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# One-shot script: build the macOS native lib, build WebView.jar, compile
+# and run the browser-initiated popup demo (WebViewPopupDemo).
+#
+# Exercises window.open(url, name, features) and <a target="_blank"> across
+# three handler modes (Default = allow, Custom = allow + log
+# popupOpened/popupClosed, Block = setPopupHandler(null) => window.open
+# returns null).  See demos/WebViewPopupDemo/README.md for the AC-mapped
+# manual test checklist (allow, opener linkage, notifications, requested
+# size, block, window.close()).
+#
+# The popup feature adds a NEW native symbol (cocoa_set_popup_callback plus
+# the createWebViewWithConfiguration: / webViewDidClose: selectors), so the
+# dylib MUST be recompiled on this Mac -- a stale prebuilt lib will not have
+# it.  This script rebuilds libwebview.dylib whenever src_c/* is newer.
+#
+# Usage:    ./run-mac-popup-demo.sh
+# Override: JAVA_HOME=/path/to/jdk ./run-mac-popup-demo.sh
+#
+set -e
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR"
+
+# ---------------------------------------------------------------------------
+# 1. Resolve JAVA_HOME
+# ---------------------------------------------------------------------------
+if [ -z "$JAVA_HOME" ]; then
+    if [ -x /usr/libexec/java_home ]; then
+        JAVA_HOME="$(/usr/libexec/java_home)"
+    fi
+fi
+if [ -z "$JAVA_HOME" ] || [ ! -d "$JAVA_HOME" ]; then
+    echo "JAVA_HOME is not set and could not be resolved automatically." >&2
+    echo "Install a JDK and export JAVA_HOME, e.g.:" >&2
+    echo "  brew install --cask temurin" >&2
+    echo "  export JAVA_HOME=\"\$(/usr/libexec/java_home)\"" >&2
+    exit 1
+fi
+export JAVA_HOME
+echo "Using JAVA_HOME=$JAVA_HOME"
+JAVAC="$JAVA_HOME/bin/javac"
+JAVA="$JAVA_HOME/bin/java"
+JAR="$JAVA_HOME/bin/jar"
+for tool in "$JAVAC" "$JAVA" "$JAR"; do
+    if [ ! -x "$tool" ]; then
+        echo "Missing tool: $tool" >&2; exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 2. Build libwebview.dylib if missing or source is newer
+# ---------------------------------------------------------------------------
+case "$(uname -m)" in
+    arm64|aarch64) NATIVE_DIR=osx_arm64 ;;
+    x86_64)        NATIVE_DIR=osx_64 ;;
+    *)             NATIVE_DIR=osx_64 ;;
+esac
+echo "Native dir: $NATIVE_DIR"
+mkdir -p "$REPO_DIR/src/$NATIVE_DIR"
+DYLIB="$REPO_DIR/src/$NATIVE_DIR/libwebview.dylib"
+NEED_DYLIB=0
+if [ ! -f "$DYLIB" ]; then
+    NEED_DYLIB=1
+else
+    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp; do
+        if [ "$src" -nt "$DYLIB" ]; then NEED_DYLIB=1; break; fi
+    done
+fi
+
+if [ "$NEED_DYLIB" = "1" ]; then
+    echo "Building libwebview.dylib (arch: $(uname -m)) ..."
+    c++ \
+        -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/darwin" \
+        -dynamiclib \
+        src_c/webview_embed.cpp \
+        -o "$DYLIB" \
+        -DWEBVIEW_COCOA=1 \
+        -std=c++11 \
+        -framework WebKit -framework Cocoa -framework QuartzCore \
+        -Wl,-undefined,dynamic_lookup
+    echo "Built $DYLIB"
+else
+    echo "libwebview.dylib up to date."
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Compile WebView Java sources
+# ---------------------------------------------------------------------------
+BUILD_DIR="$REPO_DIR/build"
+WV_CLASSES="$BUILD_DIR/classes-webview"
+WV_JAR="$REPO_DIR/dist/WebView.jar"
+mkdir -p "$WV_CLASSES" "$REPO_DIR/dist"
+echo "Compiling WebView Java sources ..."
+find src -name '*.java' > "$BUILD_DIR/wv-sources.txt"
+"$JAVAC" -d "$WV_CLASSES" \
+    -classpath "lib/*" @"$BUILD_DIR/wv-sources.txt"
+
+# ---------------------------------------------------------------------------
+# 4. Build WebView.jar -- classes + osx_*/libwebview.dylib at the jar root
+# ---------------------------------------------------------------------------
+echo "Building WebView.jar ..."
+STAGE="$BUILD_DIR/stage-webview"
+rm -rf "$STAGE"
+mkdir -p "$STAGE/$NATIVE_DIR"
+cp -R "$WV_CLASSES"/. "$STAGE"/
+cp "$DYLIB" "$STAGE/$NATIVE_DIR/libwebview.dylib"
+( cd "$STAGE" && "$JAR" cf "$WV_JAR" . )
+echo "Built $WV_JAR"
+
+# ---------------------------------------------------------------------------
+# 5. Compile and run the popup demo
+# ---------------------------------------------------------------------------
+DEMO_DIR="$REPO_DIR/demos/WebViewPopupDemo"
+DEMO_CLASSES="$BUILD_DIR/classes-popup-demo"
+mkdir -p "$DEMO_CLASSES"
+echo "Compiling demo ..."
+"$JAVAC" -d "$DEMO_CLASSES" \
+    -classpath "$WV_JAR" \
+    "$DEMO_DIR/src/ca/weblite/webview/demos/WebViewPopupDemo.java"
+
+echo "Launching WebViewPopupDemo ..."
+exec "$JAVA" \
+    -cp "$DEMO_CLASSES:$WV_JAR" \
+    ca.weblite.webview.demos.WebViewPopupDemo

--- a/run-windows-popup-demo.bat
+++ b/run-windows-popup-demo.bat
@@ -1,0 +1,224 @@
+@echo off
+REM ============================================================================
+REM run-windows-popup-demo.bat
+REM
+REM One-shot build & launch of WebViewPopupDemo on Windows.  Builds the
+REM WebView2-backed native DLL, packages WebView.jar, compiles the demo, and
+REM runs it.  No Ant required.
+REM
+REM Exercises window.open(url, name, features) and <a target="_blank"> across
+REM three handler modes (Default = allow, Custom = allow + log
+REM popupOpened/popupClosed, Block = setPopupHandler(null) => window.open
+REM returns null).  See demos\WebViewPopupDemo\README.md for the AC-mapped
+REM manual test checklist (allow, opener linkage, notifications, requested
+REM size, block, window.close()).
+REM
+REM On Windows the allowed popup opens as a separate top-level window via
+REM WebView2's NewWindowRequested event, linked to the opener (so
+REM window.opener / postMessage work -- the mechanism OAuth signInWithPopup
+REM uses); window.close() raises WindowCloseRequested, which closes the
+REM native window and tears the child engine down.  The popup feature adds a
+REM new native symbol, so the DLL MUST be rebuilt on this machine -- a stale
+REM prebuilt webview.dll will not have it.
+REM
+REM Requires:
+REM   - JAVA_HOME set to a JDK 8+ install.
+REM   - Visual Studio 2019 or newer with "Desktop development with C++".
+REM   - The WebView2 runtime (ships with Windows 11; install Evergreen on
+REM     older Windows: https://aka.ms/webview2 ).
+REM ============================================================================
+setlocal enabledelayedexpansion
+
+set "REPO_DIR=%~dp0"
+if "%REPO_DIR:~-1%"=="\" set "REPO_DIR=%REPO_DIR:~0,-1%"
+echo Repo: %REPO_DIR%
+
+REM ---------------------------------------------------------------------------
+REM 1. Resolve JAVA_HOME
+REM ---------------------------------------------------------------------------
+if "%JAVA_HOME%"=="" (
+    echo.
+    echo JAVA_HOME is not set.  Set it to your JDK install and re-run, e.g.:
+    echo.
+    echo     set "JAVA_HOME=C:\Program Files\Amazon Corretto\jdk1.8.0_xxx"
+    echo     run-windows-popup-demo.bat
+    echo.
+    exit /b 1
+)
+if not exist "%JAVA_HOME%\bin\javac.exe" (
+    echo ERROR: javac.exe not found in "%JAVA_HOME%\bin".
+    echo Check that JAVA_HOME points at the JDK root, not the JRE.
+    exit /b 1
+)
+echo Using JAVA_HOME=%JAVA_HOME%
+
+REM ---------------------------------------------------------------------------
+REM 2. Locate Visual Studio via vswhere
+REM ---------------------------------------------------------------------------
+set "vswhere=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%vswhere%" set "vswhere=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%vswhere%" (
+    echo ERROR: vswhere.exe not found.
+    echo Install Visual Studio 2019 or newer with the
+    echo "Desktop development with C++" workload.
+    exit /b 1
+)
+set "vc_dir="
+for /f "usebackq tokens=*" %%i in (`"%vswhere%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+    set "vc_dir=%%i"
+)
+if "%vc_dir%"=="" (
+    echo ERROR: Could not locate a Visual Studio installation with VC tools x86/x64.
+    exit /b 1
+)
+echo Visual Studio: %vc_dir%
+
+REM ---------------------------------------------------------------------------
+REM 3. Activate the MSVC x64 environment
+REM ---------------------------------------------------------------------------
+call "%vc_dir%\Common7\Tools\vsdevcmd.bat" -arch=x64 -host_arch=x64
+if errorlevel 1 (
+    echo ERROR: vsdevcmd.bat failed.
+    exit /b 1
+)
+
+set "SDK_OK="
+for %%I in ("%INCLUDE:;=";"%") do (
+    if exist "%%~I\windows.h" set "SDK_OK=1"
+)
+
+if defined SDK_OK goto :sdk_check_done
+set "KITS_ROOT=C:\Program Files (x86)\Windows Kits\10"
+set "SDK_VER="
+if not exist "%KITS_ROOT%\Include" goto :sdk_check_done
+for /f "delims=" %%V in ('dir /b /ad /on "%KITS_ROOT%\Include" 2^>nul') do (
+    if exist "%KITS_ROOT%\Include\%%V\um\windows.h" set "SDK_VER=%%V"
+)
+if "%SDK_VER%"=="" goto :sdk_check_done
+echo NOTE: vsdevcmd did not register a Windows SDK, but one is present
+echo       on disk.  Manually adding Windows SDK %SDK_VER% at %KITS_ROOT%.
+set "INCLUDE=%INCLUDE%;%KITS_ROOT%\Include\%SDK_VER%\ucrt;%KITS_ROOT%\Include\%SDK_VER%\um;%KITS_ROOT%\Include\%SDK_VER%\shared;%KITS_ROOT%\Include\%SDK_VER%\winrt;%KITS_ROOT%\Include\%SDK_VER%\cppwinrt"
+set "LIB=%LIB%;%KITS_ROOT%\Lib\%SDK_VER%\ucrt\x64;%KITS_ROOT%\Lib\%SDK_VER%\um\x64"
+set "SDK_OK=1"
+:sdk_check_done
+
+if defined SDK_OK goto :build_dll
+echo.
+echo ERROR: Windows SDK headers not found on the cl.exe INCLUDE path.
+echo        vsdevcmd activated successfully but no SDK provides windows.h.
+echo.
+echo Fix: open the Visual Studio Installer, click Modify on your VS install,
+echo and on the "Individual components" tab tick a "Windows 11 SDK" or
+echo "Windows 10 SDK" entry, then re-run this script.
+echo.
+exit /b 1
+:build_dll
+
+REM ---------------------------------------------------------------------------
+REM 4. Build webview.dll (x64)
+REM ---------------------------------------------------------------------------
+set "NATIVE_DIR=windows_64"
+set "DLL_OUT=%REPO_DIR%\src\%NATIVE_DIR%"
+if not exist "%DLL_OUT%" mkdir "%DLL_OUT%"
+set "BUILD_DIR=%REPO_DIR%\build"
+if not exist "%BUILD_DIR%" mkdir "%BUILD_DIR%"
+set "WEBVIEW2_VERSION=1.0.2592.51"
+set "WEBVIEW2_DIR=%REPO_DIR%\windows\script\Microsoft.Web.WebView2.%WEBVIEW2_VERSION%"
+set "WEBVIEW2_NUPKG=%WEBVIEW2_DIR%\Microsoft.Web.WebView2.%WEBVIEW2_VERSION%.nupkg"
+set "WEBVIEW2_URL=https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/%WEBVIEW2_VERSION%"
+
+set "PWSH=%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe"
+if not exist "%PWSH%" set "PWSH=powershell.exe"
+
+if exist "%WEBVIEW2_DIR%\build\native\include\WebView2.h" goto :webview2_ready
+if not exist "%WEBVIEW2_DIR%" mkdir "%WEBVIEW2_DIR%"
+if exist "%WEBVIEW2_NUPKG%" goto :webview2_extract
+echo Downloading Microsoft.Web.WebView2 %WEBVIEW2_VERSION% from NuGet ...
+"%PWSH%" -NoProfile -Command "$ProgressPreference='SilentlyContinue'; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri '%WEBVIEW2_URL%' -OutFile '%WEBVIEW2_NUPKG%' -UseBasicParsing"
+if not exist "%WEBVIEW2_NUPKG%" (
+    echo ERROR: failed to download WebView2 SDK from %WEBVIEW2_URL%.
+    exit /b 1
+)
+:webview2_extract
+echo Extracting Microsoft.Web.WebView2.%WEBVIEW2_VERSION%.nupkg ...
+"%PWSH%" -NoProfile -Command "Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory('%WEBVIEW2_NUPKG%', '%WEBVIEW2_DIR%')"
+if not exist "%WEBVIEW2_DIR%\build\native\include\WebView2.h" (
+    echo ERROR: failed to extract WebView2 SDK.
+    exit /b 1
+)
+:webview2_ready
+
+echo Building webview.dll (x64) ...
+cl /nologo ^
+    /D "WEBVIEW_API=__declspec(dllexport)" ^
+    /D "_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS" ^
+    /I "%JAVA_HOME%\include" ^
+    /I "%JAVA_HOME%\include\win32" ^
+    /I "%REPO_DIR%\windows" ^
+    /I "%WEBVIEW2_DIR%\build\native\include" ^
+    /std:c++17 /EHsc ^
+    /Fo"%BUILD_DIR%\\" ^
+    "%REPO_DIR%\windows\webview.cc" ^
+    "%REPO_DIR%\windows\webview_embed.cc" ^
+    /link /DLL ^
+    "%WEBVIEW2_DIR%\build\native\x64\WebView2LoaderStatic.lib" ^
+    "%JAVA_HOME%\lib\jawt.lib" ^
+    advapi32.lib ole32.lib oleaut32.lib shlwapi.lib shell32.lib user32.lib version.lib winhttp.lib ^
+    /OUT:"%BUILD_DIR%\webview.dll"
+if errorlevel 1 (
+    echo ERROR: cl.exe build failed.
+    exit /b 1
+)
+copy /Y "%BUILD_DIR%\webview.dll" "%DLL_OUT%\webview.dll" >nul
+echo Built %DLL_OUT%\webview.dll
+
+REM ---------------------------------------------------------------------------
+REM 5. Compile WebView Java sources
+REM ---------------------------------------------------------------------------
+set "WV_CLASSES=%BUILD_DIR%\classes-webview"
+if exist "%WV_CLASSES%" rmdir /s /q "%WV_CLASSES%"
+mkdir "%WV_CLASSES%"
+echo Compiling WebView Java sources ...
+dir /s /b "%REPO_DIR%\src\*.java" > "%BUILD_DIR%\wv-sources.txt"
+"%JAVA_HOME%\bin\javac.exe" -d "%WV_CLASSES%" -classpath "%REPO_DIR%\lib\*" @"%BUILD_DIR%\wv-sources.txt"
+if errorlevel 1 (
+    echo ERROR: javac failed.
+    exit /b 1
+)
+
+REM ---------------------------------------------------------------------------
+REM 6. Build WebView.jar
+REM ---------------------------------------------------------------------------
+set "WV_JAR=%REPO_DIR%\dist\WebView.jar"
+if not exist "%REPO_DIR%\dist" mkdir "%REPO_DIR%\dist"
+set "STAGE=%BUILD_DIR%\stage-webview"
+if exist "%STAGE%" rmdir /s /q "%STAGE%"
+mkdir "%STAGE%\%NATIVE_DIR%"
+"%SystemRoot%\System32\xcopy.exe" /e /q /y "%WV_CLASSES%\*" "%STAGE%\" >nul
+if errorlevel 1 (
+    echo ERROR: xcopy of compiled classes into the jar staging dir failed.
+    exit /b 1
+)
+copy /Y "%DLL_OUT%\webview.dll" "%STAGE%\%NATIVE_DIR%\webview.dll" >nul
+pushd "%STAGE%"
+"%JAVA_HOME%\bin\jar.exe" cf "%WV_JAR%" .
+popd
+echo Built %WV_JAR%
+
+REM ---------------------------------------------------------------------------
+REM 7. Compile and launch the popup demo
+REM ---------------------------------------------------------------------------
+set "DEMO_DIR=%REPO_DIR%\demos\WebViewPopupDemo"
+set "DEMO_CLASSES=%BUILD_DIR%\classes-popup-demo"
+if not exist "%DEMO_CLASSES%" mkdir "%DEMO_CLASSES%"
+echo Compiling demo ...
+"%JAVA_HOME%\bin\javac.exe" -d "%DEMO_CLASSES%" -classpath "%WV_JAR%" "%DEMO_DIR%\src\ca\weblite\webview\demos\WebViewPopupDemo.java"
+if errorlevel 1 (
+    echo ERROR: javac failed on demo.
+    exit /b 1
+)
+
+echo Launching WebViewPopupDemo ...
+"%JAVA_HOME%\bin\java.exe" -cp "%DEMO_CLASSES%;%WV_JAR%" ca.weblite.webview.demos.WebViewPopupDemo
+
+endlocal

--- a/spdd/prompt/15-20260802-1000-[Feat]-Browser-Initiated-Popups-Window-Open.md
+++ b/spdd/prompt/15-20260802-1000-[Feat]-Browser-Initiated-Popups-Window-Open.md
@@ -1,0 +1,891 @@
+---
+generated_at: 2026-08-02T10:00:00-07:00
+---
+
+# REASONS Canvas: Browser-Initiated Popups (`window.open`) — Java API + macOS / Linux / Windows Coverage
+
+## R · Requirements
+
+- Establish the cross-platform Java contract for browser-initiated
+  **popups** originating inside the embedded page — `window.open(url,
+  name, features)` and clicks on `<a target="_blank">` / `<form
+  target="_blank">` — and ship working macOS (WKWebView), Linux
+  (WebKitGTK), and Windows (WebView2) implementations of that contract.
+  Today all three platforms silently drop `window.open`: no
+  `WKUIDelegate createWebViewWithConfiguration:` selector is installed
+  (`src_c/webview_embed.cpp` `get_webview_embed_ui_delegate_cls`
+  installs only the four dialog selectors), no WebKitGTK `create`
+  signal is connected, and no WebView2 `NewWindowRequested` handler is
+  registered. WebKit's default `createWebViewWithConfiguration:`
+  returns `nil`, so `window.open` returns `null` to JavaScript and
+  OAuth "sign-in with popup" flows fail with
+  `auth/popup-blocked`. This canvas closes exactly the gap that
+  [[browser-initiated-ui-dialogs-and-macos-coverage]] (Canvas 11)
+  listed as an explicit non-goal ("`window.open(url, name, features)`
+  popup handling … a different channel, out of scope").
+
+- **Presentation model: the native engine owns the popup window.**
+  When a popup is allowed, the native layer creates the child web view
+  **linked to the opener** (WKWebView built from the exact
+  `WKWebViewConfiguration` WebKit passes to the delegate; WebKitGTK
+  `webkit_web_view_new_with_related_view`; WebView2 `put_NewWindow`
+  with a controller from the same environment) and hosts it in a fresh
+  **native top-level window** that the engine creates, shows, sizes,
+  and destroys. The opener linkage is mandatory: OAuth popups call
+  `window.opener.postMessage(...)` and `window.close()`, which only
+  work when the popup is a WebKit-created *related* view, not an
+  independent browser tab. Java is NOT asked to host the popup in a
+  Swing surface — the existing engines cannot be created detached and
+  reparented into a new JAWT parent (creation binds to a live
+  `NSView` / X11 drawable / `HWND`), so a native-owned window is the
+  correct, deadlock-free model and matches the caller's "separate
+  popup window" expectation.
+
+- Expose a single public functional-style interface
+  `ca.weblite.webview.WebViewPopupHandler` with three `default`
+  methods:
+  - `boolean popupRequested(WebViewPopupEvent event)` — the policy
+    gate. Returns `true` to allow the popup (the engine opens the
+    native window) or `false` to block it (`window.open` returns
+    `null`, exactly as today). The default returns `true`.
+    **This method runs on the native UI thread, synchronously**,
+    because the platform popup callbacks must return the child web
+    view (or a block decision) before yielding back to WebKit and
+    cannot round-trip to the Swing EDT without risking an
+    AppKit-main/EDT deadlock. Its Javadoc MUST state: runs off the
+    EDT, must be fast and thread-safe, and must not touch Swing
+    state.
+  - `void popupOpened(WebViewPopupEvent event)` — notification that a
+    popup window has been created and shown. Runs on the EDT
+    (`invokeLater`). Default is a no-op. Lets applications log or
+    track open popups.
+  - `void popupClosed(WebViewPopupEvent event)` — notification that a
+    popup window has closed (the popup page called `window.close()`,
+    or the user closed the native window). Runs on the EDT
+    (`invokeLater`). Default is a no-op.
+  - `static WebViewPopupHandler DEFAULT = new WebViewPopupHandler() {};`
+    — allows every popup, no-op notifications; installed when no
+    caller has set a handler.
+
+- Expose one immutable event POJO
+  `ca.weblite.webview.WebViewPopupEvent` carrying: `source`
+  (the opener `WebViewComponent`, never null), `targetUrl` (the URL
+  the popup will load; empty when `window.open()` is called with no
+  URL), `targetName` (the window name / target; empty when
+  unspecified), `userGesture` (whether a user gesture initiated the
+  popup), `width` / `height` (requested size from the window
+  features, or `-1` when unspecified), and `pageUrl` (the opener page
+  URL, for per-origin policy). Accessors use the no-`get` style to
+  match `WebViewMouseEvent` / `WebViewAlertEvent`.
+
+- Expose `setPopupHandler(WebViewPopupHandler)` /
+  `getPopupHandler()` on `WebViewComponent` as concrete `final`
+  methods. Passing `null` to the setter installs an internal `DROP`
+  handler whose `popupRequested` returns `false` (all popups
+  blocked — the pre-feature behaviour, available as an explicit
+  opt-out) and whose notifications are no-ops. `getPopupHandler()`
+  MUST NEVER return `null`; it returns `WebViewPopupHandler.DEFAULT`
+  when no caller has set one. `setPopupHandler(null)` is NOT
+  identity-equal to `setPopupHandler(WebViewPopupHandler.DEFAULT)`;
+  callers reset to the framework default by passing `DEFAULT`
+  explicitly. This mirrors the `setDialogHandler` contract from
+  Canvas 11 exactly.
+
+- Wire the contract to all three heavyweight engines and the Linux
+  offscreen engine via a new internal JNI callback
+  `WebViewPopupCallback` with three methods:
+  - `boolean onPopupRequested(String targetUrl, String targetName,
+    boolean userGesture, int width, int height, String pageUrl)` —
+    invoked **synchronously on the native UI thread**; the return
+    value decides allow/deny.
+  - `void onPopupOpened(long popupId, String targetUrl, String
+    targetName, boolean userGesture, int width, int height, String
+    pageUrl)` — invoked after the native window is shown; `popupId`
+    is an engine-assigned opaque handle correlating open/close.
+  - `void onPopupClosed(long popupId, String targetUrl, String
+    pageUrl)` — invoked after the native popup window is destroyed.
+  The callback follows the existing `WebViewDialogCallback` /
+  `WebViewFocusCallback` / `WebViewClickCallback` precedent and is
+  public only because the JNI bridge in `src_c/webview_embed.cpp`
+  and `windows/webview_embed.cc` calls it.
+
+- Add two new native method declarations on `WebViewNative`,
+  following the `webview_embed_set_dialog_callback` /
+  `webview_offscreen_set_dialog_callback` precedent
+  (`WebViewNative.java:284, 393`):
+  - `native static void webview_embed_set_popup_callback(long w, WebViewPopupCallback cb)`.
+  - `native static void webview_offscreen_set_popup_callback(long peer, WebViewPopupCallback cb)`.
+
+- Add `setPopupCallback(WebViewPopupCallback)` to both
+  `EmbeddedWebView` and `OffscreenWebView`, anchoring the callback in
+  the wrapper's `heap` list so the JVM does not collect the adapter
+  while the native side holds a global ref (mirrors
+  `setDialogCallback` at `EmbeddedWebView.java:503`). The callback is
+  cleared (`webview_embed_set_popup_callback(peer, null)`) in
+  `dispose()` before the native peer is destroyed.
+
+- Install the popup adapter at peer-attach time in
+  `WebViewHeavyweightComponent.createPeer()` (after the existing
+  dialog adapter) and `WebViewLightweightComponent.addNotify()`,
+  delegating each callback method to the per-component
+  `PopupDispatcher`. The heavyweight/lightweight `dispose()` paths
+  call `popupDispatcher.disposeAll()` alongside the existing
+  `dialogDispatcher.disposeAll()`.
+
+- **Threading contract.** `popupRequested` (allow/deny) runs on the
+  native UI thread with no EDT hop — the dispatcher calls the handler
+  directly and returns its boolean synchronously, because the
+  platform popup callback must return the decision before yielding to
+  WebKit. `popupOpened` / `popupClosed` are asynchronous
+  notifications and DO marshal to the EDT via
+  `SwingUtilities.invokeLater` (matching the focus/click notification
+  pattern, which uses `invokeLater`, not the dialog `invokeAndWait`).
+  This split is the crux of the design and MUST be documented on
+  `WebViewPopupHandler`, `WebViewPopupCallback`, and
+  `PopupDispatcher`.
+
+- The implementation MUST NOT introduce a JSON-parsing dependency;
+  all payloads are primitives (`String`, `boolean`, `int`, `long`).
+  No JS shim is installed and no reserved `__webview_*` binding is
+  added — `window.open` interception is a native-delegate channel,
+  not a page-injected bridge.
+
+- Definition of Done:
+  - `window.open(url, ...)` from the embedded page opens a native
+    top-level window loading `url`, linked to the opener
+    (`window.opener` is non-null; `postMessage` to the opener
+    works), on all three platforms. `window.close()` from the popup
+    closes the native window.
+  - `setPopupHandler(null)` blocks all popups (`window.open` returns
+    `null`), restoring the pre-feature behaviour as an explicit
+    opt-out.
+  - `getPopupHandler()` never returns null; `setPopupHandler(null)`
+    installs DROP; `setPopupHandler(DEFAULT)` resets.
+  - A `WebViewPopupDemo` under `demos/` exercises allow / block /
+    custom-notification modes.
+  - README grows a "Browser-initiated popups" subsection (sibling of
+    "Browser-initiated dialogs") documenting the `setPopupHandler`
+    API, the native-owned-window model, and the opener-linkage
+    guarantee that makes OAuth popups work.
+  - `PopupDispatcherTest` validates the Java contract:
+    handler registration, DROP semantics, `getHandler() != null`
+    invariant, `popupRequested` synchronous return + off-EDT
+    execution, `popupOpened` / `popupClosed` EDT marshaling and
+    exception isolation, event field plumbing, `-1` size defaults,
+    and dispose fallbacks. Native window creation is
+    integration-tested via the demo (consistent with the
+    no-automated-GUI-tests policy).
+
+- Out of scope (explicit non-goals):
+  - Hosting the popup inside a Swing surface / as a tab in the
+    opener's window. The existing engines cannot be created
+    detached and reparented into a new JAWT parent; a native-owned
+    window is the model. A future canvas may add an "adopt into a
+    provided `WebViewComponent`" path if a caller needs Swing
+    integration.
+  - Per-popup window chrome customisation (toolbars, address bar).
+    The native window is a bare top-level host for the child web
+    view.
+  - Blocking / allow decisions that require asynchronous user
+    interaction (e.g. a Swing confirmation dialog) inside
+    `popupRequested`. The gate is synchronous and off-EDT; a handler
+    needing async confirmation should allow the popup and close it
+    later, or pre-compute policy.
+  - `window.open` feature strings beyond `width` / `height`
+    (`left`, `top`, `menubar`, `toolbar`, `resizable`, …). Only size
+    is surfaced on the event; the native window uses platform
+    defaults for the rest.
+  - HTTP auth challenges, download interception, and permission
+    prompts — separate channels, each a future canvas.
+  - Adding the popup API to the standalone in-process `WebView`
+    class — this canvas only touches the embedded
+    `WebViewComponent` surface (same boundary Canvas 11 drew).
+
+## E · Entities
+
+- **WebViewPopupEvent** (new public final class,
+  `src/ca/weblite/webview/WebViewPopupEvent.java`). Immutable value
+  type. Fields (all `final`, package-private constructor):
+  - `source` : `WebViewComponent` — the opener; never null
+    (constructor throws NPE named `"source"`).
+  - `targetUrl` : `String` — never null, may be empty.
+  - `targetName` : `String` — never null, may be empty.
+  - `userGesture` : `boolean`.
+  - `width` : `int` — `-1` when unspecified.
+  - `height` : `int` — `-1` when unspecified.
+  - `pageUrl` : `String` — never null, may be empty.
+  Accessors: `source()`, `targetUrl()`, `targetName()`,
+  `userGesture()`, `width()`, `height()`, `pageUrl()`.
+  `toString()` returns a single-line debug summary
+  (`WebViewPopupEvent[url=<...>, name=<...>, size=WxH]`, url
+  truncated to 80 chars). No `equals` / `hashCode`.
+
+- **WebViewPopupHandler** (new public interface,
+  `src/ca/weblite/webview/WebViewPopupHandler.java`).
+  Functional-style — three `default` methods, no required abstract
+  method. NOT `@FunctionalInterface` (more than one method).
+  - `default boolean popupRequested(WebViewPopupEvent event)` —
+    returns `true` (allow). Javadoc: runs on the native UI thread,
+    synchronously, off the EDT; must be fast, thread-safe, no Swing.
+  - `default void popupOpened(WebViewPopupEvent event)` — no-op.
+    Javadoc: runs on the EDT.
+  - `default void popupClosed(WebViewPopupEvent event)` — no-op.
+    Javadoc: runs on the EDT.
+  - `static WebViewPopupHandler DEFAULT = new WebViewPopupHandler() {};`.
+
+- **WebViewPopupCallback** (new public interface,
+  `src/ca/weblite/webview/WebViewPopupCallback.java`). Internal JNI
+  bridge — public only because the native layer calls it. NOT
+  `@FunctionalInterface` (three methods).
+  - `boolean onPopupRequested(String targetUrl, String targetName, boolean userGesture, int width, int height, String pageUrl)`.
+  - `void onPopupOpened(long popupId, String targetUrl, String targetName, boolean userGesture, int width, int height, String pageUrl)`.
+  - `void onPopupClosed(long popupId, String targetUrl, String pageUrl)`.
+  Class Javadoc: invoked from the native UI thread (AppKit main /
+  GTK main / WebView2 worker); `onPopupRequested` returns
+  synchronously and MUST NOT be marshalled to the EDT (the native
+  side is blocked awaiting the decision); `onPopupOpened` /
+  `onPopupClosed` are fire-and-forget notifications the dispatcher
+  marshals to the EDT. Not intended for application implementation —
+  customise via `WebViewComponent.setPopupHandler`.
+
+- **PopupDispatcher** (new public final class,
+  `src/ca/weblite/webview/PopupDispatcher.java`). Per-component
+  fan-out hub. Public-because-cross-package (same rationale as
+  `DialogDispatcher`). Fields:
+  - `private final WebViewComponent source;` — non-null.
+  - `private volatile WebViewPopupHandler handler = WebViewPopupHandler.DEFAULT;`.
+  - `private volatile boolean disposed = false;`.
+  - `private final java.util.concurrent.ConcurrentHashMap<Long, WebViewPopupEvent> openPopups = new ConcurrentHashMap<Long, WebViewPopupEvent>();`
+    — correlates `onPopupOpened` → `onPopupClosed` so `popupClosed`
+    receives the same rich event.
+  - `static final WebViewPopupHandler DROP` — package-private
+    singleton: `popupRequested` returns `false`, notifications
+    no-op.
+  Methods: `setHandler`, `getHandler`, `isDisposed`, `disposeAll`,
+  and the three `dispatch*` entry points (Operations 4).
+
+- **WebViewComponent** (modified,
+  `src/ca/weblite/webview/swing/WebViewComponent.java`). Gains:
+  - `protected final PopupDispatcher popupDispatcher = new PopupDispatcher(this);`
+    (adjacent to `dialogDispatcher`, `WebViewComponent.java:77`).
+  - `public final WebViewComponent setPopupHandler(WebViewPopupHandler handler)`.
+  - `public final WebViewPopupHandler getPopupHandler()`.
+
+- **EmbeddedWebView** (modified,
+  `src/ca/weblite/webview/EmbeddedWebView.java`). Gains
+  `public EmbeddedWebView setPopupCallback(WebViewPopupCallback cb)`
+  mirroring `setDialogCallback` (`:503`): anchors `cb` in `heap`,
+  calls `WebViewNative.webview_embed_set_popup_callback(peer, cb)`.
+  `dispose()` clears it (`webview_embed_set_popup_callback(p, null)`)
+  before `webview_embed_destroy`.
+
+- **OffscreenWebView** (modified). Gains
+  `public OffscreenWebView setPopupCallback(WebViewPopupCallback cb)`
+  calling `WebViewNative.webview_offscreen_set_popup_callback`.
+
+- **WebViewNative** (modified,
+  `src/ca/weblite/webview/WebViewNative.java`). Gains two
+  `native static` declarations after the dialog ones, with a block
+  comment documenting per-platform delivery (macOS WKUIDelegate
+  `createWebViewWithConfiguration:` + `webViewDidClose:`; Linux
+  WebKitGTK `create` + `ready-to-show` + `close`; Windows WebView2
+  `add_NewWindowRequested` + child `add_WindowCloseRequested`).
+
+- **`src_c/webview_embed.cpp`** (modified — macOS + Linux). See
+  Operations 9 (macOS) and 10 (Linux). Adds, per Engine, a
+  `jobject popup_callback` field; for child (popup) engines a
+  native-window handle field (`id popup_window` on macOS,
+  `GtkWidget *popup_window` on GTK) and a `jlong popup_id`; the
+  `createWebViewWithConfiguration:` + `webViewDidClose:` selector
+  IMPs (added to the shared UI-delegate class) on macOS; the
+  `create` / `ready-to-show` / `close` signal handlers on GTK; the
+  `cocoa_set_popup_callback` / `gtk_set_popup_callback` /
+  `gtk_off_set_popup_callback` setters; and the two JNI bridge
+  functions (in an `extern "C"` block, matching the dialog bridges
+  at `:4544`).
+
+- **`windows/webview_embed.cc`** (modified — Windows). See
+  Operation 11. Adds `jobject popup_callback` and
+  `EventRegistrationToken new_window_token`; a
+  `NewWindowRequestedHandler` (deferral pattern); child-window
+  creation + `add_WindowCloseRequested`; `set_popup_callback`; and
+  the JNI bridge.
+
+- **WebViewPopupDemo** (new demo,
+  `demos/WebViewPopupDemo/src/ca/weblite/webview/demos/WebViewPopupDemo.java`
+  + `build.xml` + `README.md`). Mirrors `WebViewDialogDemo` layout.
+
+- **README.md** (modified): "Browser-initiated popups" subsection +
+  demo listing.
+
+- **PopupDispatcherTest** (new JUnit 4 test,
+  `test/ca/weblite/webview/PopupDispatcherTest.java`). Mirrors
+  `DialogDispatcherTest`.
+
+```mermaid
+classDiagram
+direction TB
+
+class WebViewPopupHandler {
+    <<interface>>
+    +popupRequested(WebViewPopupEvent) boolean
+    +popupOpened(WebViewPopupEvent) void
+    +popupClosed(WebViewPopupEvent) void
+    +DEFAULT WebViewPopupHandler$
+}
+class WebViewPopupEvent {
+    +source() WebViewComponent
+    +targetUrl() String
+    +targetName() String
+    +userGesture() boolean
+    +width() int
+    +height() int
+    +pageUrl() String
+}
+class PopupDispatcher {
+    -source WebViewComponent
+    -handler WebViewPopupHandler
+    -disposed boolean
+    -openPopups Map~Long,WebViewPopupEvent~
+    +setHandler(WebViewPopupHandler) void
+    +getHandler() WebViewPopupHandler
+    +dispatchPopupRequested(String,String,boolean,int,int,String) boolean
+    +dispatchPopupOpened(long,String,String,boolean,int,int,String) void
+    +dispatchPopupClosed(long,String,String) void
+    +disposeAll() void
+}
+class WebViewPopupCallback {
+    <<interface>>
+    +onPopupRequested(String,String,boolean,int,int,String) boolean
+    +onPopupOpened(long,String,String,boolean,int,int,String) void
+    +onPopupClosed(long,String,String) void
+}
+class WebViewComponent {
+    #popupDispatcher PopupDispatcher
+    +setPopupHandler(WebViewPopupHandler) WebViewComponent
+    +getPopupHandler() WebViewPopupHandler
+}
+class EmbeddedWebView {
+    +setPopupCallback(WebViewPopupCallback) EmbeddedWebView
+}
+class OffscreenWebView {
+    +setPopupCallback(WebViewPopupCallback) OffscreenWebView
+}
+
+WebViewComponent "1" *-- "1" PopupDispatcher : owns
+PopupDispatcher "1" --> "1" WebViewPopupHandler : invokes
+PopupDispatcher ..> WebViewPopupEvent : constructs
+EmbeddedWebView ..> WebViewPopupCallback : invokes via JNI
+OffscreenWebView ..> WebViewPopupCallback : invokes via JNI
+WebViewPopupCallback ..> PopupDispatcher : delegates to
+```
+
+## A · Approach
+
+1. **Native-owns-window model, and why.** WebKit's popup channel
+   hands the delegate a *linked* child web view to drive (macOS: a
+   `WKWebView` built from the passed `WKWebViewConfiguration`; GTK:
+   `webkit_web_view_new_with_related_view`; WebView2:
+   `put_NewWindow`). That linkage is what makes `window.opener`
+   non-null and `postMessage`-to-opener work — the exact mechanism
+   Firebase `signInWithPopup` uses to return its result. An
+   independent tab loading the same URL is NOT linked and the OAuth
+   handshake fails. The extraction of the engine-create paths
+   confirms the heavyweight engines cannot be created detached and
+   later reparented into a Swing surface (creation binds to a live
+   `NSView` / X11 drawable / `HWND`). Therefore the engine both
+   creates the linked child and hosts it in a native top-level window
+   it owns — this is deadlock-free, requires no JAWT reparenting, and
+   is precisely the "separate popup window" experience.
+
+2. **Threading split (the crux).** `popupRequested` is a synchronous
+   allow/deny decision: on macOS `createWebViewWithConfiguration:`
+   must return the `WKWebView` (or nil) before yielding to WebKit, so
+   the decision cannot be deferred to a worker thread or the EDT the
+   way the dialog completion-handler path is. The dispatcher
+   therefore calls `handler.popupRequested(event)` **directly on the
+   native UI thread** and returns its boolean synchronously. A
+   well-behaved policy method (return a constant, or inspect
+   `pageUrl`) is fast and side-effect free; the Javadoc forbids Swing
+   access and blocking. By contrast, `popupOpened` / `popupClosed`
+   need no return value and are marshalled to the EDT with
+   `SwingUtilities.invokeLater` — matching the focus/click
+   notification adapters (`WebViewHeavyweightComponent.java:534-560`),
+   which also use `invokeLater`. This asymmetry is intentional and
+   documented.
+
+3. **Allow/deny reduces to handler presence by default.** With the
+   DEFAULT handler `popupRequested` returns `true`, so popups work
+   out of the box once the library is wired. `setPopupHandler(null)`
+   installs DROP whose `popupRequested` returns `false`, restoring
+   the pre-feature "popups blocked" behaviour as an explicit opt-out.
+   A custom handler can gate per-URL. The native side treats a
+   missing `popup_callback` (no adapter installed) as "block" —
+   identical to today — so the feature is inert until the wiring in
+   `createPeer()` / `addNotify()` installs the adapter.
+
+4. **macOS selector strategy.** Add two selectors to the existing
+   shared UI-delegate class built by
+   `get_webview_embed_ui_delegate_cls()`
+   (`src_c/webview_embed.cpp:2969`), so both the opener engine's
+   delegate and each child engine's delegate handle them:
+   - `webView:createWebViewWithConfiguration:forNavigationAction:windowFeatures:`
+     → `impl_create_web_view`. Recover `Engine* e` via the associated
+     `"eng"` object. Read `navigationAction.request.URL.absoluteString`
+     (targetUrl), `navigationAction` user-gesture (best effort; pass
+     `true` — `window.open` requires a gesture in practice), size from
+     `windowFeatures.width` / `.height` (`NSNumber`, `nil` → `-1`),
+     `pageUrl` from `webView.URL.absoluteString`. If `e->popup_callback`
+     is null → return `nil`. Else call Java `onPopupRequested`
+     synchronously (attach the thread if needed, `GetMethodID`,
+     `CallBooleanMethod`, exception-sanitize); if `false` → return
+     `nil`. Otherwise build the child:
+     `id child = [[WKWebView alloc] initWithFrame:CGRectMake(0,0,W,H) configuration:configuration]`
+     (W/H default to 500×650 — a typical auth-popup size — when
+     unspecified). Create an `NSWindow`
+     (`NSWindowStyleMaskTitled|Closable|Resizable`, contentRect W×H),
+     set its `contentView` to `child`, `center`, and
+     `makeKeyAndOrderFront:`. Build a child `Engine` (webview=child,
+     jvm, config=configuration, manager=child's
+     `configuration.userContentController`, `popup_callback` and
+     `dialog_callback` inherited as fresh global refs, a new
+     UI-delegate instance associated to the child engine assigned via
+     `setUIDelegate:`, `popup_window` = the NSWindow,
+     `popup_id = (jlong)(intptr_t)child`), register it in
+     `g_webview_map`. Fire `onPopupOpened(popupId, …)` asynchronously
+     on a detached worker thread (the established JNI-hop pattern).
+     Return `child`.
+   - `webViewDidClose:` → `impl_web_view_did_close`. Recover the child
+     `Engine`, `[popup_window close]`, fire
+     `onPopupClosed(popupId, …)` async, then tear down the child
+     engine (remove from `g_webview_map`, `setUIDelegate:nil`, delete
+     global refs, release window + delegate).
+
+5. **Linux (WebKitGTK) signal strategy.** Connect three signals on
+   every `WebKitWebView` created by `gtk_create_engine`
+   (`src_c/webview_embed.cpp:871`) and `gtk_off_create_engine`
+   (`:1513`), at the same sites the dialog signals are connected
+   (`:1021`, `:1567`):
+   - `create` → `on_create_web_view`. Read the request URI and
+     user-gesture from the `WebKitNavigationAction*`. If the engine's
+     `popup_callback` is null or Java `onPopupRequested` returns
+     `false`, return `NULL` (blocked). Else
+     `WebKitWebView* child = WEBKIT_WEB_VIEW(webkit_web_view_new_with_related_view(e->web))`,
+     put it in a new `GTK_WINDOW_TOPLEVEL`, connect the child's
+     `ready-to-show` and `close`, connect `create` /
+     `script-dialog` / `run-file-chooser` on the child too (nested
+     popups + dialogs), build the child `Engine`, register it, and
+     return the child web view (WebKit adopts the reference).
+   - `ready-to-show` → size the window from
+     `webkit_web_view_get_window_properties` (fallback 500×650),
+     `gtk_widget_show_all` + `gtk_window_present`, then fire
+     `onPopupOpened` async.
+   - `close` → `gtk_widget_destroy` the window, fire `onPopupClosed`
+     async, tear down the child engine.
+
+6. **Windows (WebView2) event strategy.** Register
+   `add_NewWindowRequested` at the controller-ready site
+   (`windows/webview_embed.cc`, alongside `add_WebMessageReceived`),
+   storing `new_window_token`. The handler `Invoke`:
+   1. `args->GetDeferral(&deferral)` (WebView2 supports async here).
+   2. Read `args->get_Uri`, `args->get_IsUserInitiated`,
+      `args->get_WindowFeatures` (width/height/hasSize).
+   3. Decide allow/deny (sync via `popup_callback`
+      `onPopupRequested`). If deny: `put_Handled(TRUE)` with no
+      `NewWindow` (blocks), `Complete` the deferral, return `S_OK`.
+   4. If allow: create a new top-level `HWND`, then
+      `CreateCoreWebView2Controller` on it from the SAME environment;
+      in that completion, `controller->get_CoreWebView2(&child)`,
+      `args->put_NewWindow(child)`, `args->put_Handled(TRUE)`,
+      `deferral->Complete()`, show the window, connect the child's
+      `add_WindowCloseRequested` → `DestroyWindow` + `onPopupClosed`,
+      and fire `onPopupOpened`. Follow the `CallbackBase<Iface>`
+      template used by `FocusHandler` / `MsgHandler`.
+
+7. **JNI mechanics.** `onPopupRequested` runs on the native UI thread
+   and returns a value, so it attaches the thread, resolves the
+   `jmethodID` per call (mirroring the dialog selectors), calls
+   `CallBooleanMethod`, and sanitizes exceptions (`ExceptionCheck` →
+   `Describe` → `Clear`) — a leaked exception into ObjC/GTK/COM
+   crashes the process. `onPopupOpened` / `onPopupClosed` fire from a
+   detached worker thread (macOS) or directly on the GTK/WebView2
+   worker (which are already decoupled from the EDT) via
+   `CallVoidMethod`. Global refs for `popup_callback` follow the
+   `cocoa_set_dialog_callback` delete-old / new-global-ref lifecycle
+   (`:3006`).
+
+8. **Dispatcher exception isolation.** `dispatchPopupRequested` wraps
+   the direct handler call in `try/catch(Throwable)` → forwards to
+   `Thread.getDefaultUncaughtExceptionHandler()` and returns `false`
+   (safe default: block on error). `dispatchPopupOpened` /
+   `dispatchPopupClosed` wrap the EDT-marshalled invocation the same
+   way (return void). Matches `DialogDispatcher.forwardUncaught`.
+
+## S · Structure
+
+### Inheritance Relationships
+1. `WebViewPopupHandler` — public interface, three `default` methods,
+   `DEFAULT` constant. No required abstract method.
+2. `WebViewPopupEvent` — public final class, no inheritance (matches
+   `WebViewAlertEvent`).
+3. `WebViewPopupCallback` — public interface, three methods, not
+   `@FunctionalInterface`.
+4. `PopupDispatcher` — public final class (matches `DialogDispatcher`).
+5. `WebViewComponent` (abstract) gains one field + two `final`
+   methods; no change to the abstract surface.
+6. `EmbeddedWebView` / `OffscreenWebView` each gain one
+   `setPopupCallback` method.
+
+### Dependencies
+1. `WebViewPopupHandler` → none beyond `WebViewPopupEvent` (defaults
+   are trivial; no Swing imports — the default does not open the
+   window, the native side does).
+2. `PopupDispatcher` → `javax.swing.SwingUtilities`
+   (`invokeLater`, `isEventDispatchThread`),
+   `java.util.concurrent.ConcurrentHashMap`, `WebViewPopupEvent`,
+   `WebViewPopupHandler`, `WebViewComponent`.
+3. `WebViewComponent` → `PopupDispatcher`, `WebViewPopupHandler`.
+4. `WebViewHeavyweightComponent.createPeer()` /
+   `WebViewLightweightComponent.addNotify()` → `EmbeddedWebView` /
+   `OffscreenWebView`, `PopupDispatcher`, `WebViewPopupCallback`.
+5. `EmbeddedWebView.setPopupCallback` →
+   `WebViewNative.webview_embed_set_popup_callback`.
+6. Native selectors/signals/events → `Engine::popup_callback` jobject
+   → JNI `CallBooleanMethod` / `CallVoidMethod` → Java
+   `WebViewPopupCallback` → `PopupDispatcher.dispatch*` →
+   (`popupRequested` inline / `popupOpened`+`popupClosed` on EDT) →
+   `WebViewPopupHandler`.
+
+### Layered Architecture
+1. **Native engine layer** (`src_c/webview_embed.cpp`,
+   `windows/webview_embed.cc`): popup selector/signal/event handlers,
+   native window creation, child-engine lifecycle, `set_popup_callback`
+   setters, JNI bridges.
+2. **JNI surface** (`WebViewNative`): two `native static` decls.
+3. **Engine wrapper layer** (`EmbeddedWebView`, `OffscreenWebView`):
+   `setPopupCallback`.
+4. **Dispatcher layer** (`PopupDispatcher`): per-component hub;
+   synchronous allow/deny, async EDT notifications, exception
+   isolation, open-popup correlation.
+5. **Component API layer** (`WebViewComponent`): `setPopupHandler` /
+   `getPopupHandler`.
+6. **Public contract layer** (`WebViewPopupHandler`,
+   `WebViewPopupEvent`, `WebViewPopupCallback`).
+7. **Wiring layer** (`WebViewHeavyweightComponent.createPeer()`,
+   `WebViewLightweightComponent.addNotify()`).
+8. **Demo layer** (`demos/WebViewPopupDemo/`).
+
+## O · Operations
+
+### 1. Create Value Object — WebViewPopupEvent
+File: `src/ca/weblite/webview/WebViewPopupEvent.java`
+1. Immutable carrier of one popup request. Package-private
+   constructor `WebViewPopupEvent(WebViewComponent source, String
+   targetUrl, String targetName, boolean userGesture, int width, int
+   height, String pageUrl)`: null-check `source` (NPE named
+   `"source"`); coerce null `targetUrl` / `targetName` / `pageUrl`
+   to empty; store `width` / `height` verbatim (callers pass `-1`
+   for unspecified). Store all fields in `final` ivars.
+2. Accessors: `source()`, `targetUrl()`, `targetName()`,
+   `userGesture()`, `width()`, `height()`, `pageUrl()`.
+3. `toString()` — single-line summary, `targetUrl` truncated to 80
+   chars. No `equals` / `hashCode`.
+
+### 2. Create Handler Interface — WebViewPopupHandler
+File: `src/ca/weblite/webview/WebViewPopupHandler.java`
+1. Public interface, three `default` methods, `DEFAULT` constant.
+2. `default boolean popupRequested(WebViewPopupEvent event) { return true; }`
+   — Javadoc: allow/deny gate, runs on the native UI thread
+   synchronously (off the EDT); must be fast, thread-safe, no Swing.
+3. `default void popupOpened(WebViewPopupEvent event) { }` — Javadoc:
+   runs on the EDT.
+4. `default void popupClosed(WebViewPopupEvent event) { }` — Javadoc:
+   runs on the EDT.
+5. `WebViewPopupHandler DEFAULT = new WebViewPopupHandler() {};`.
+6. Class Javadoc documents: the native-owned-window model; that the
+   library opens/sizes/closes the window (the handler only decides
+   policy and observes); the opener-linkage guarantee that makes
+   OAuth popups work; the `setPopupHandler(null)` drop shortcut; and
+   the threading split.
+
+### 3. Create JNI Callback Interface — WebViewPopupCallback
+File: `src/ca/weblite/webview/WebViewPopupCallback.java`
+1. Public interface, three methods (signatures in Entities). Javadoc
+   per Entities. Method Javadoc: `onPopupRequested` returns the
+   allow/deny decision synchronously and MUST NOT be EDT-marshalled;
+   `onPopupOpened` / `onPopupClosed` are notifications.
+
+### 4. Create Dispatcher — PopupDispatcher
+File: `src/ca/weblite/webview/PopupDispatcher.java`
+1. `public final class`. Fields per Entities. DROP singleton:
+   `popupRequested` → `false`, notifications no-op.
+2. Constructor `PopupDispatcher(WebViewComponent source)`:
+   null-check `source`.
+3. `setHandler(WebViewPopupHandler h)`: store `h`, or DROP if null.
+4. `getHandler()`: return the volatile handler (never null).
+5. `isDisposed()` / `disposeAll()`: as `DialogDispatcher`.
+6. `boolean dispatchPopupRequested(String targetUrl, String
+   targetName, boolean userGesture, int width, int height, String
+   pageUrl)`:
+   - If `disposed`, return `false`.
+   - Build a `WebViewPopupEvent`.
+   - Call `handler.popupRequested(event)` **directly** (no EDT hop)
+     inside `try { return handler.popupRequested(event); } catch
+     (Throwable t) { forwardUncaught(t); return false; }`.
+7. `void dispatchPopupOpened(long popupId, String targetUrl, String
+   targetName, boolean userGesture, int width, int height, String
+   pageUrl)`:
+   - If `disposed`, return.
+   - Build the event, `openPopups.put(popupId, event)`.
+   - `runOnEdtLater(() -> handler.popupOpened(event))`.
+8. `void dispatchPopupClosed(long popupId, String targetUrl, String
+   pageUrl)`:
+   - If `disposed`, return.
+   - `WebViewPopupEvent event = openPopups.remove(popupId);` — if
+     null, build a minimal event from `targetUrl` / `pageUrl` (empty
+     name, `-1` sizes).
+   - `runOnEdtLater(() -> handler.popupClosed(event))`.
+9. Private `runOnEdtLater(Runnable r)`: if
+   `SwingUtilities.isEventDispatchThread()` run inline (wrapped in
+   try/catch → `forwardUncaught`); else
+   `SwingUtilities.invokeLater(wrapped)` where `wrapped` catches and
+   forwards. Private static `forwardUncaught(Throwable)` identical to
+   `DialogDispatcher`.
+
+### 5. Extend WebViewComponent
+File: `src/ca/weblite/webview/swing/WebViewComponent.java`
+1. Add `protected final PopupDispatcher popupDispatcher = new PopupDispatcher(this);`
+   next to `dialogDispatcher`.
+2. `public final WebViewComponent setPopupHandler(WebViewPopupHandler handler) { popupDispatcher.setHandler(handler); return this; }`.
+3. `public final WebViewPopupHandler getPopupHandler() { return popupDispatcher.getHandler(); }`.
+   Javadoc mirrors `setDialogHandler`/`getDialogHandler`.
+
+### 6. Extend EmbeddedWebView with setPopupCallback
+File: `src/ca/weblite/webview/EmbeddedWebView.java`
+1. `public EmbeddedWebView setPopupCallback(WebViewPopupCallback cb)`
+   — `checkAlive()`; if `cb != null` `heap.add(cb)`;
+   `WebViewNative.webview_embed_set_popup_callback(peer, cb)`;
+   `return this;`. Mirrors `setDialogCallback` (`:503`).
+2. In `dispose()`, before `webview_embed_destroy(p)` and alongside
+   the focus/click clears, add
+   `WebViewNative.webview_embed_set_popup_callback(p, null);`.
+
+### 7. Extend OffscreenWebView with setPopupCallback
+File: `src/ca/weblite/webview/OffscreenWebView.java`
+1. `public OffscreenWebView setPopupCallback(WebViewPopupCallback cb)`
+   mirroring the offscreen dialog setter; calls
+   `WebViewNative.webview_offscreen_set_popup_callback(peer, cb)`.
+
+### 8. Extend WebViewNative
+File: `src/ca/weblite/webview/WebViewNative.java`
+1. Add, after the dialog natives (with a documenting block comment):
+   `native static void webview_embed_set_popup_callback(long w, WebViewPopupCallback cb);`
+   `native static void webview_offscreen_set_popup_callback(long peer, WebViewPopupCallback cb);`
+
+### 9. macOS native — createWebView + webViewDidClose + setter + JNI
+File: `src_c/webview_embed.cpp` (Cocoa)
+1. Add `jobject popup_callback = nullptr;`, `id popup_window = nullptr;`,
+   `jlong popup_id = 0;` to the Cocoa `Engine` struct.
+2. `cocoa_set_popup_callback(Engine*, JNIEnv*, jobject)` — verbatim
+   copy of `cocoa_set_dialog_callback` against `popup_callback`.
+3. In `get_webview_embed_ui_delegate_cls()` add two
+   `class_addMethod`s: `webView:createWebViewWithConfiguration:forNavigationAction:windowFeatures:`
+   (`impl_create_web_view`, return-type `@`) and `webViewDidClose:`
+   (`impl_web_view_did_close`, `v@:@`).
+4. Implement `impl_create_web_view` and `impl_web_view_did_close` per
+   Approach §4. Reuse `ensure_jni_env` / the detached-worker JNI hop
+   for the async `onPopupOpened` / `onPopupClosed`; do the synchronous
+   `onPopupRequested` inline on AppKit main. Every path either returns
+   a valid child or `nil`; a child engine's `dialog_callback` and
+   `popup_callback` are inherited so the popup itself supports dialogs
+   and nested popups.
+5. JNI bridges `Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1popup_1callback`
+   and `…_webview_1offscreen_1set_1popup_1callback` in the existing
+   `extern "C"` block (`:4544`), `#ifdef`-dispatching to
+   `cocoa_set_popup_callback` / `gtk_set_popup_callback` /
+   `gtk_off_set_popup_callback`.
+
+### 10. Linux native — create/ready-to-show/close signals + setter
+File: `src_c/webview_embed.cpp` (GTK)
+1. Add `jobject popup_callback = nullptr;` to the GTK `Engine` /
+   `OffEngine` structs; a `GtkWidget *popup_window` + `jlong popup_id`
+   on child engines.
+2. `gtk_set_popup_callback` / `gtk_off_set_popup_callback` mirroring
+   the GTK dialog setters.
+3. `on_create_web_view_engine` / `on_ready_to_show_engine` /
+   `on_close_engine` per Approach §5. Connect them in
+   `gtk_create_engine` (`:1021` region) and `gtk_off_create_engine`
+   (`:1567` region) alongside the dialog signal connects.
+
+### 11. Windows native — NewWindowRequested + setter + JNI
+File: `windows/webview_embed.cc`
+1. Add `jobject popup_callback` and `EventRegistrationToken
+   new_window_token` to `Engine`; a child-window `HWND` + `jlong
+   popup_id` on child engines.
+2. `set_popup_callback(Engine*, JNIEnv*, jobject)` mirroring the
+   Windows dialog setter.
+3. `NewWindowRequestedHandler : CallbackBase<ICoreWebView2NewWindowRequestedEventHandler>`
+   with `Invoke` per Approach §6; register via
+   `webview->add_NewWindowRequested(handler, &e->new_window_token)`
+   at the controller-ready site. Child `add_WindowCloseRequested` →
+   destroy + `onPopupClosed`.
+4. JNI bridge `Java_…_webview_1embed_1set_1popup_1callback` in
+   `windows/webview_embed.cc`.
+
+### 12. Wire the popup adapter (heavyweight + lightweight)
+Files: `src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java`,
+`src/ca/weblite/webview/swing/WebViewLightweightComponent.java`
+1. In `createPeer()` (heavyweight), after the dialog adapter
+   (`:560` region), install:
+   `embedded.setPopupCallback(new WebViewPopupCallback() {`
+   `  public boolean onPopupRequested(String u, String n, boolean g, int w, int h, String p) { return popupDispatcher.dispatchPopupRequested(u, n, g, w, h, p); }`
+   `  public void onPopupOpened(long id, String u, String n, boolean g, int w, int h, String p) { popupDispatcher.dispatchPopupOpened(id, u, n, g, w, h, p); }`
+   `  public void onPopupClosed(long id, String u, String p) { popupDispatcher.dispatchPopupClosed(id, u, p); }`
+   `});`
+2. In `addNotify()` (lightweight), inside the `engine != null`
+   branch after the dialog install, the same adapter via
+   `engine.setPopupCallback(...)`.
+3. In both `dispose()` paths, add `popupDispatcher.disposeAll();`
+   next to `dialogDispatcher.disposeAll();`.
+
+### 13. Demo — WebViewPopupDemo
+Files: `demos/WebViewPopupDemo/…`
+1. `JPopupMenu.setDefaultLightWeightPopupEnabled(false)` +
+   `ToolTipManager…setLightWeightPopupEnabled(false)` at startup.
+2. Inline page (via `addOnBeforeLoad` + `about:blank`) with buttons:
+   `window.open('https://example.com','_blank','width=520,height=640')`,
+   a `target=_blank` link, and a button that reports
+   `window.open(...) === null` to a console line (verifies allow vs
+   block). A JComboBox switches handler modes: Default (allow),
+   Block (`setPopupHandler(null)`), Custom (logs
+   `popupOpened`/`popupClosed`).
+3. `build.xml` + `README.md` mirror `WebViewDialogDemo`.
+
+### 14. README
+File: `README.md`
+1. New "Browser-initiated popups" subsection after
+   "Browser-initiated dialogs" (`:306`): documents `setPopupHandler`,
+   the native-owned-window model, the opener-linkage guarantee (OAuth
+   popups), and `setPopupHandler(null)` as the block opt-out.
+2. List `WebViewPopupDemo` under Demos.
+
+### 15. Tests — PopupDispatcherTest
+File: `test/ca/weblite/webview/PopupDispatcherTest.java`
+1. Reuse the `StubComponent` pattern from `DialogDispatcherTest`.
+2. Cover: default handler is DEFAULT; `getHandler()` never null;
+   `setHandler(null)` installs DROP and DROP `dispatchPopupRequested`
+   returns `false`; custom handler returned by getter;
+   `setHandler(DEFAULT)` resets; `dispatchPopupRequested` returns the
+   handler's boolean **and runs off the EDT** (assert
+   `!isEventDispatchThread()` inside the handler when called from a
+   non-EDT thread); event field plumbing (url/name/gesture/w/h/page,
+   `source` identity, `-1` sizes); `dispatchPopupOpened` /
+   `dispatchPopupClosed` invoke the handler **on the EDT**
+   (latch-verified) and `popupClosed` receives the same event
+   instance stored at open (correlation via `popupId`); exception
+   isolation for all three (forwarded to the uncaught handler;
+   `dispatchPopupRequested` returns `false` on handler exception);
+   disposed dispatcher returns `false` / no-ops without invoking the
+   handler; `disposeAll` idempotent; constructor rejects null source.
+
+## N · Norms
+
+- **Mirror the `DialogDispatcher` skeleton**, diverging in exactly
+  two documented places: (1) `popupRequested` runs the handler
+  **inline on the calling (native UI) thread**, never on the EDT,
+  because the platform popup callback needs the decision
+  synchronously; (2) `popupOpened` / `popupClosed` use
+  `SwingUtilities.invokeLater` (async notifications), not
+  `invokeAndWait`. Document both in `PopupDispatcher`'s Javadoc.
+- **Accessor naming** — no-`get` style (`event.targetUrl()`,
+  `event.userGesture()`), matching `WebViewAlertEvent`.
+- **Null discipline** — `targetUrl` / `targetName` / `pageUrl` use
+  empty string for "no value", never null. `width` / `height` use
+  `-1` for "unspecified". `source` is never null.
+- **`getPopupHandler() != null` is a never-relax invariant**, even
+  after `setPopupHandler(null)` (returns DROP) and after
+  `disposeAll()` (returns the last-set handler).
+- **`setPopupHandler(null) != setPopupHandler(DEFAULT)`** — null
+  installs DROP (block all popups); DEFAULT allows. Document on
+  `setPopupHandler` Javadoc.
+- **No JSON parser dependency; no `__webview_*` binding; no JS
+  shim.** `window.open` is a native-delegate channel.
+- **Per-call `jmethodID` resolution** in the native selectors,
+  matching the dialog selectors.
+- **JNI exception sanitization** after every `CallBooleanMethod` /
+  `CallVoidMethod` (`ExceptionCheck` → `Describe` → `Clear`); a
+  leaked exception into ObjC / GTK / COM crashes the process.
+- **`pom.xml` Java 8 target stays in force** — `default` methods,
+  `ConcurrentHashMap`, `invokeLater` are all Java 8.
+- **Demo heavyweight-popup prerequisite** — the demo sets
+  `JPopupMenu.setDefaultLightWeightPopupEnabled(false)` and the
+  tooltip equivalent at startup.
+- **No automated tests for GUI integration** — the native
+  window-creation paths are verified by running `WebViewPopupDemo`
+  on each platform; `PopupDispatcherTest` covers the Java contract
+  (consistent with Canvas 11 and the embedding canvases).
+
+## S · Safeguards
+
+- **Constructor null-checks.** `WebViewPopupEvent` and
+  `PopupDispatcher` reject null `source` with an NPE named
+  `"source"`. Other Strings coerce null → empty; sizes accept `-1`.
+- **Block-on-error default.** If a handler's `popupRequested` throws,
+  the dispatcher forwards to the uncaught handler and returns
+  `false` — a thrown policy decision blocks the popup rather than
+  leaking an exception into the native UI thread. `popupOpened` /
+  `popupClosed` exceptions are forwarded and swallowed (notifications
+  cannot fail the popup).
+- **Native returns nil/NULL on every non-allow path.** Missing
+  `popup_callback`, JNI attach failure, `onPopupRequested == false`,
+  or any exception → the selector/signal/event returns
+  `nil`/`NULL`/no-`NewWindow`, i.e. `window.open` returns `null`.
+  Never return a half-constructed child web view.
+- **Child-engine teardown ordering.** `webViewDidClose:` /
+  `close` / `WindowCloseRequested` MUST clear the child's UI delegate
+  (`setUIDelegate:nil` etc.) before releasing the delegate and
+  window, and remove the child from `g_webview_map`, so no in-flight
+  selector dereferences a freed engine. Delete the inherited
+  `popup_callback` / `dialog_callback` global refs on teardown.
+- **`popupId` correlation is best-effort.** `dispatchPopupClosed`
+  tolerates a missing map entry (builds a minimal event); a close
+  without a prior open never NPEs.
+- **Disposed dispatcher is inert.** After `disposeAll()`, all three
+  `dispatch*` return the safe value (`false` / void) without invoking
+  the handler, even mid-teardown, so a native popup event racing with
+  component disposal cannot resurrect the handler.
+- **Opener linkage is mandatory.** The child web view MUST be created
+  from the WebKit-provided configuration / related-view /
+  `put_NewWindow` so `window.opener` and `postMessage` work. Creating
+  an independent view loading the same URL is a defect (breaks
+  OAuth).
+- **No `setDebug` coupling.** Popup handling works in release builds;
+  the delegate/signals/events are installed unconditionally.
+- **Reserved-prefix protection preserved.** No new binding is added.
+- **Headless construction.** Constructing `WebViewComponent`,
+  calling `setPopupHandler`, and constructing `PopupDispatcher` must
+  not throw `HeadlessException`; the default handler opens no Swing
+  UI (the native side owns the window), so even the DEFAULT handler
+  is headless-safe.
+
+- **Native coverage status (per-iteration, mirrors Canvas 11).** The
+  full Java contract (Operations 1–8, 12) and the **macOS** native
+  implementation (Operation 9) ship in this iteration; the demo
+  (13), README (14) and `PopupDispatcherTest` (15) land with them.
+  The **Linux** (Operation 10) and **Windows** (Operation 11) native
+  callback sites are specified here but land in follow-up canvases
+  (16 / 17), exactly as the dialog feature staged macOS → Linux →
+  Windows across Canvases 11 → 12 → 13. Until those land,
+  `setPopupHandler` registrations on Linux / Windows are inert (the
+  handler reference is held in the dispatcher but no native callback
+  is wired), so `window.open` continues to be blocked there. The
+  Java layer introduced here is designed so the Linux / Windows
+  stories wire their native callbacks without re-shaping the Java
+  side. A maintainer who lands Linux / Windows coverage MUST update
+  this note and the README caveat in lockstep. The native code in
+  this repository is validated on-device via `WebViewPopupDemo`
+  under the project's no-automated-GUI-tests policy; the sandbox
+  that generated this iteration had no native toolchain, so the
+  macOS selector code is pattern-faithful to the shipped dialog
+  selectors but MUST be built and exercised on a macOS device before
+  release.

--- a/spdd/prompt/15-20260802-1000-[Feat]-Browser-Initiated-Popups-Window-Open.md
+++ b/spdd/prompt/15-20260802-1000-[Feat]-Browser-Initiated-Popups-Window-Open.md
@@ -870,22 +870,21 @@ File: `test/ca/weblite/webview/PopupDispatcherTest.java`
 
 - **Native coverage status (per-iteration, mirrors Canvas 11).** The
   full Java contract (Operations 1–8, 12) and the **macOS** native
-  implementation (Operation 9) ship in this iteration; the demo
-  (13), README (14) and `PopupDispatcherTest` (15) land with them.
-  The **Linux** (Operation 10) and **Windows** (Operation 11) native
-  callback sites are specified here but land in follow-up canvases
-  (16 / 17), exactly as the dialog feature staged macOS → Linux →
-  Windows across Canvases 11 → 12 → 13. Until those land,
-  `setPopupHandler` registrations on Linux / Windows are inert (the
-  handler reference is held in the dispatcher but no native callback
-  is wired), so `window.open` continues to be blocked there. The
-  Java layer introduced here is designed so the Linux / Windows
-  stories wire their native callbacks without re-shaping the Java
-  side. A maintainer who lands Linux / Windows coverage MUST update
-  this note and the README caveat in lockstep. The native code in
-  this repository is validated on-device via `WebViewPopupDemo`
-  under the project's no-automated-GUI-tests policy; the sandbox
-  that generated this iteration had no native toolchain, so the
-  macOS selector code is pattern-faithful to the shipped dialog
-  selectors but MUST be built and exercised on a macOS device before
-  release.
+  implementation (Operation 9) shipped in the first iteration; the demo
+  (13), README (14) and `PopupDispatcherTest` (15) landed with them.
+  The **Linux** (Operation 10) native callback site landed in Canvas 16
+  ([[browser-initiated-popups-linux-coverage]]) and the **Windows**
+  (Operation 11) native callback site landed in Canvas 17
+  ([[browser-initiated-popups-windows-coverage]]), exactly as the dialog
+  feature staged macOS → Linux → Windows across Canvases 11 → 12 → 13.
+  **All three platforms are now wired**: `window.open` opens a native,
+  opener-linked popup window on macOS (WKWebView), Linux (WebKitGTK), and
+  Windows (WebView2), and `setPopupHandler(null)` blocks it everywhere.
+  The Java layer introduced here was designed so the Linux / Windows
+  stories wired their native callbacks without re-shaping the Java side,
+  which is how it played out. The native code in this repository is
+  validated on-device via `WebViewPopupDemo` under the project's
+  no-automated-GUI-tests policy; the sandbox that generated each
+  iteration had no native toolchain, so the selector / signal / event
+  code is pattern-faithful to the shipped dialog handlers but MUST be
+  built and exercised on each target device before release.

--- a/spdd/prompt/15-20260802-1000-[Feat]-Browser-Initiated-Popups-Window-Open.md
+++ b/spdd/prompt/15-20260802-1000-[Feat]-Browser-Initiated-Popups-Window-Open.md
@@ -752,7 +752,15 @@ Files: `src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java`,
 Files: `demos/WebViewPopupDemo/…`
 1. `JPopupMenu.setDefaultLightWeightPopupEnabled(false)` +
    `ToolTipManager…setLightWeightPopupEnabled(false)` at startup.
-2. Inline page (via `addOnBeforeLoad` + `about:blank`) with buttons:
+2. Inline page loaded via a **base64-encoded `data:` URL** — build
+   the HTML string, base64-encode it (`java.util.Base64`), and call
+   `setUrl("data:text/html;charset=utf-8;base64," + b64)`, exactly as
+   `WebViewDialogDemo` does. Do **not** use `addOnBeforeLoad` +
+   `about:blank`: that path renders a blank page on macOS WKWebView
+   (empty content area, no controls), and raw/percent-encoded `data:`
+   bodies hit two WKWebView pitfalls the dialog demo documents (literal
+   `%20` text; truncation at the first `#` in CSS colours). Base64 is
+   cross-engine reliable and sidesteps both. The page has buttons:
    `window.open('https://example.com','_blank','width=520,height=640')`,
    a `target=_blank` link, and a button that reports
    `window.open(...) === null` to a console line (verifies allow vs

--- a/spdd/prompt/15-20260802-1000-[Feat]-Browser-Initiated-Popups-Window-Open.md
+++ b/spdd/prompt/15-20260802-1000-[Feat]-Browser-Initiated-Popups-Window-Open.md
@@ -767,7 +767,14 @@ Files: `demos/WebViewPopupDemo/…`
    block). A JComboBox switches handler modes: Default (allow),
    Block (`setPopupHandler(null)`), Custom (logs
    `popupOpened`/`popupClosed`).
-3. `build.xml` + `README.md` mirror `WebViewDialogDemo`.
+3. `build.xml` + `README.md` mirror `WebViewDialogDemo`. The demo
+   `README.md`'s platform-status section mirrors the **Native coverage
+   status** note (Safeguards): all three platforms open a native,
+   opener-linked popup — macOS (WKWebView, Canvas 15), Linux (WebKitGTK
+   `create`, heavyweight *and* lightweight, Canvas 16), Windows (WebView2
+   `NewWindowRequested`, Canvas 17) — and `setPopupHandler(null)` blocks
+   `window.open` on every platform. It must not describe Linux/Windows as
+   unimplemented or "follow-up".
 
 ### 14. README
 File: `README.md`

--- a/spdd/prompt/16-20260802-1600-[Feat]-Browser-Initiated-Popups-Linux-Coverage.md
+++ b/spdd/prompt/16-20260802-1600-[Feat]-Browser-Initiated-Popups-Linux-Coverage.md
@@ -1,0 +1,316 @@
+---
+generated_at: 2026-08-02T16:00:00-07:00
+---
+
+# REASONS Canvas: Browser-Initiated Popups (`window.open`) — Linux WebKitGTK Coverage (Heavyweight + Lightweight)
+
+## R · Requirements
+
+- Wire the existing `WebViewPopupHandler` contract — designed and
+  shipped for the Java layer plus macOS (WKWebView) in
+  [[browser-initiated-popups-window-open]] (Canvas 15) — to the Linux
+  WebKitGTK engines so `window.open(url, name, features)` and clicks on
+  `<a target="_blank">` / `<form target="_blank">` open a native
+  top-level popup window **linked to the opener** (so `window.opener`
+  is non-null and `window.opener.postMessage(...)` works), and
+  `window.close()` from the popup destroys that window. This closes
+  the Linux half of the "Native coverage status" note Canvas 15 left
+  open (Operation 10), exactly as Canvas 12 added Linux coverage for
+  the dialog feature after Canvas 11 shipped the Java layer + macOS.
+- Both Linux engines are in scope:
+  - **Heavyweight** (`WebViewHeavyweightComponent` → `EmbeddedWebView`
+    → `gtk_create_engine` in `src_c/webview_embed.cpp`).
+  - **Lightweight** (`WebViewLightweightComponent` → `OffscreenWebView`
+    → `gtk_off_create_engine`).
+- Connect one new signal, `create`, on every `WebKitWebView` created by
+  either engine, at the same sites the dialog signals (`script-dialog`,
+  `run-file-chooser`) are connected (`gtk_create_engine` ~line 1021,
+  `gtk_off_create_engine` ~line 1567):
+  - `create` (`WebKitNavigationAction *`) — fires for `window.open` and
+    `target="_blank"`. Returning a new `WebKitWebView*` tells WebKitGTK
+    to drive that (linked) view for the popup; returning `NULL` blocks
+    the popup (`window.open` returns `null`), which is the pre-feature
+    behaviour and the behaviour when `popup_callback` is unset.
+- The child (popup) `WebKitWebView` MUST be created with
+  `webkit_web_view_new_with_related_view(opener)` so it shares the
+  opener's network/session context and keeps the `window.opener`
+  linkage — creating a bare `webkit_web_view_new()` loading the same
+  URL is a defect (breaks OAuth `signInWithPopup`). It is hosted in an
+  engine-owned `GTK_WINDOW_TOPLEVEL` the native layer creates, sizes,
+  shows, and destroys — Java is never asked to host it in a Swing
+  surface (same native-owned-window model Canvas 15 established for
+  macOS).
+- Two further signals are connected on the **child** popup web view:
+  - `ready-to-show` — size the window from
+    `webkit_web_view_get_window_properties` (fallback 500×650, a typical
+    auth-popup size), `gtk_widget_show_all` + `gtk_window_present`, then
+    fire `onPopupOpened` (async / EDT-marshalled on the Java side).
+  - `close` — `gtk_widget_destroy` the window, fire `onPopupClosed`,
+    tear the child popup engine down.
+  The child also gets `create` / `script-dialog` / `run-file-chooser`
+  connected so nested popups and dialogs raised from inside the popup
+  work, inheriting the opener's `popup_callback` / `dialog_callback`.
+- The `create` handler MUST be shared code (single inner C function)
+  invoked from three thin per-engine wrappers keyed by the `user_data`
+  pointer (`Engine*`, `OffEngine*`, and the new `PopupEngine*` for
+  nested popups), exactly as `handle_script_dialog` /
+  `handle_run_file_chooser` are shared across
+  `on_script_dialog_engine` / `on_script_dialog_off_engine`.
+- Each engine struct (`Engine`, `OffEngine`) already documents a
+  `dialog_callback` field; add a parallel `jobject popup_callback`
+  field to each, populated by the new `gtk_set_popup_callback` /
+  `gtk_off_set_popup_callback` setters and cleared in
+  `gtk_destroy_engine` / `gtk_off_destroy_engine`, mirroring the
+  `dialog_callback` lifecycle exactly.
+- The `WebViewNative.webview_embed_set_popup_callback` /
+  `webview_offscreen_set_popup_callback` JNI bridges (already present
+  from Canvas 15, currently a no-op on the non-Cocoa branch) gain a
+  `WEBVIEW_GTK` branch dispatching to `gtk_set_popup_callback` /
+  `gtk_off_set_popup_callback`. No Java-side change is required — the
+  contract, dispatcher, adapter wiring, event POJO, and `EmbeddedWebView`
+  / `OffscreenWebView` setters all shipped in Canvas 15.
+
+### Threading
+
+- The `create` signal handler runs on the **GTK main thread**. The
+  allow/deny hop (`onPopupRequested`) is invoked **synchronously** on
+  that thread with `CallBooleanMethod` — the handler must return the
+  child web view (or `NULL`) before yielding back to WebKitGTK, exactly
+  like the `script-dialog` confirm path calls `fire_dialog_confirm`
+  synchronously. The `PopupDispatcher.dispatchPopupRequested` runs the
+  application handler inline and returns its boolean; no EDT hop.
+- `onPopupOpened` / `onPopupClosed` are fire-and-forget: the native
+  side calls them with `CallVoidMethod` directly on the GTK main thread,
+  and the Java `PopupDispatcher` marshals them to the EDT via
+  `SwingUtilities.invokeLater` (non-blocking), so the GTK main thread is
+  never blocked awaiting the EDT. This matches the Canvas 15 threading
+  split; no detached worker thread is needed on GTK (unlike macOS, where
+  AppKit main must not be blocked even briefly — GTK's `invokeLater`
+  path already returns immediately).
+
+### Definition of Done
+
+- `window.open(url, ...)` from a page in a heavyweight OR lightweight
+  Linux `WebViewComponent` opens a native GTK top-level window loading
+  `url`, linked to the opener (`window.opener` non-null; `postMessage`
+  to the opener works); `window.close()` from the popup closes it.
+- `setPopupHandler(null)` blocks all popups on Linux (`window.open`
+  returns `null`); the DEFAULT handler allows them.
+- `onPopupOpened` / `onPopupClosed` reach the Java handler on the EDT;
+  `popupClosed` receives the same correlated event stored at open (via
+  the `openPopups` map keyed on `popupId`).
+- No Java-side change beyond what Canvas 15 shipped; `PopupDispatcherTest`
+  still passes unchanged. Native window creation is validated on-device
+  by running `WebViewPopupDemo` on Linux (no-automated-GUI-tests policy).
+- Canvas 15's "Native coverage status" note and the README popups
+  caveat are updated in lockstep to mark Linux ✅.
+
+### Out of scope (unchanged from Canvas 15)
+
+- Hosting the popup in a Swing surface / as a tab; per-popup window
+  chrome; async user interaction inside `popupRequested`; feature-string
+  keys beyond `width`/`height`; Windows coverage (Canvas 17). The
+  standalone in-process `WebView` class is untouched.
+
+## E · Entities
+
+- **`src_c/webview_embed.cpp`** (modified, GTK sections). Adds:
+  - `jobject popup_callback = nullptr;` on `struct Engine` (~line 410,
+    after `dialog_callback`) and `struct OffEngine` (~line 1455).
+  - A new `struct PopupEngine` — the child popup's state: `GtkWidget
+    *window` (the `GTK_WINDOW_TOPLEVEL`), `WebKitWebView *web`, `JavaVM
+    *jvm`, `jobject popup_callback` (inherited global ref), `jobject
+    dialog_callback` (inherited global ref, may be null), `jlong
+    popup_id`.
+  - `fire_popup_requested(JavaVM*, jobject cb, url, name, gesture, w, h,
+    page)` → `bool` — synchronous `CallBooleanMethod` into
+    `WebViewPopupCallback.onPopupRequested`, GTK-main-thread, exception
+    sanitized, returns `false` on any error/attach-failure.
+  - `fire_gtk_popup_opened(JavaVM*, jobject cb, popup_id, url, name,
+    gesture, w, h, page)` and `fire_gtk_popup_closed(JavaVM*, jobject
+    popup_cb, jobject dialog_cb, popup_id, url, page)` — `CallVoidMethod`
+    into `onPopupOpened` / `onPopupClosed`. `fire_gtk_popup_closed` does
+    NOT delete the inherited refs (the caller frees them after it
+    returns — the call is synchronous on GTK, unlike the macOS detached
+    worker which owns them).
+  - Shared inner `handle_create_web_view(JavaVM*, jobject popup_cb,
+    jobject dialog_cb, WebKitWebView *opener, WebKitNavigationAction*)`
+    → `GtkWidget*`.
+  - `on_ready_to_show_popup` / `on_close_popup` (keyed on `PopupEngine*`).
+  - Per-engine `create` wrappers: `on_create_web_view_engine`
+    (`Engine*`), `on_create_web_view_off_engine` (`OffEngine*`),
+    `on_create_web_view_popup` (`PopupEngine*`); plus
+    `on_script_dialog_popup` / `on_run_file_chooser_popup` reusing the
+    shared dialog inner handlers with `PopupEngine::dialog_callback`.
+  - `gtk_set_popup_callback` / `gtk_off_set_popup_callback` mirroring the
+    dialog setters; `popup_callback` clears in the two destroy funcs.
+  - Signal connects for `create` in `gtk_create_engine` and
+    `gtk_off_create_engine`.
+  - `WEBVIEW_GTK` branch added to the two popup JNI bridges (~line 4882).
+
+## A · Approach
+
+1. **Struct fields + setters + teardown (storage lifecycle first).**
+   Add `popup_callback` to `Engine` and `OffEngine` verbatim-parallel to
+   `dialog_callback`. Add `gtk_set_popup_callback` /
+   `gtk_off_set_popup_callback` as delete-old-ref / new-global-ref
+   setters copied from `gtk_set_dialog_callback` /
+   `gtk_off_set_dialog_callback`. In `gtk_destroy_engine` /
+   `gtk_off_destroy_engine`, clear `popup_callback` in the same
+   attach/DeleteGlobalRef/detach block that already clears
+   `dialog_callback`. Point the two popup JNI bridges at these setters
+   under `#ifdef WEBVIEW_GTK`.
+
+2. **Shared create handler.** `handle_create_web_view`:
+   - If `popup_cb` is null → `return NULL` (blocked — inert until wired).
+   - Read `uri` from `webkit_uri_request_get_uri(
+     webkit_navigation_action_get_request(nav))` (empty if absent);
+     `gesture` from `webkit_navigation_action_is_user_gesture(nav)`;
+     `page` from `webkit_web_view_get_uri(opener)`.
+   - `fire_popup_requested(...)` synchronously; if it returns false →
+     `return NULL`.
+   - `GtkWidget *childw = webkit_web_view_new_with_related_view(opener);`
+     `WebKitWebView *child = WEBKIT_WEB_VIEW(childw);`
+   - `GtkWidget *win = gtk_window_new(GTK_WINDOW_TOPLEVEL);`
+     `gtk_window_set_title(GTK_WINDOW(win), "Popup");`
+     `gtk_container_add(GTK_CONTAINER(win), childw);`
+   - Build a `PopupEngine` (`window=win`, `web=child`, `jvm`,
+     `popup_id = (jlong)(intptr_t)pe`), inheriting fresh global refs of
+     `popup_cb` and (if non-null) `dialog_cb`.
+   - Connect on `child`: `create` → `on_create_web_view_popup`,
+     `script-dialog` → `on_script_dialog_popup`, `run-file-chooser` →
+     `on_run_file_chooser_popup`, `ready-to-show` →
+     `on_ready_to_show_popup`, `close` → `on_close_popup` — all with the
+     `PopupEngine*` as `user_data`.
+   - `return childw;` — WebKitGTK adopts the floating reference; do NOT
+     `g_object_ref`/sink it ourselves.
+
+3. **ready-to-show → size, show, notify-open.** Read
+   `webkit_web_view_get_window_properties(child)` →
+   `webkit_window_properties_get_geometry(&GdkRectangle)`; use
+   `width`/`height` when > 0, else 500×650.
+   `gtk_window_set_default_size`, `gtk_widget_show_all(win)`,
+   `gtk_window_present(GTK_WINDOW(win))`. Then `fire_gtk_popup_opened`
+   with the child's current URI and the resolved W×H.
+
+4. **close → destroy, notify-closed, teardown.** Read the child URI,
+   `fire_gtk_popup_closed(jvm, pe->popup_callback, pe->dialog_callback,
+   pe->popup_id, uri, "")` (synchronous — `onPopupClosed` returns after
+   `invokeLater` schedules the EDT run), `gtk_widget_destroy(pe->window)`,
+   then delete the two inherited global refs and `delete pe`. Because
+   the JNI call is synchronous and the Java side only reads the event it
+   stored at open time (correlated by `popupId`), freeing the refs
+   immediately after the call is safe — no ownership transfer to a
+   detached worker is needed (the macOS divergence does not apply on
+   GTK).
+
+5. **Signal wiring at the two engine sites.** In `gtk_create_engine`,
+   after the `run-file-chooser` connect (~line 1024):
+   `g_signal_connect(WEBKIT_WEB_VIEW(e->web), "create",
+   (GCallback)on_create_web_view_engine, e);`. Same in
+   `gtk_off_create_engine` (~line 1570) with
+   `on_create_web_view_off_engine`. The `create` signal is
+   `G_SIGNAL_RUN_LAST` returning a `GtkWidget*`; the first non-NULL
+   handler return wins.
+
+## S · Structure
+
+### Dependencies
+- `on_create_web_view_engine` / `_off_engine` / `_popup` →
+  `handle_create_web_view` → `fire_popup_requested`
+  (`WebViewPopupCallback.onPopupRequested`, JNI) +
+  `webkit_web_view_new_with_related_view` + GTK window.
+- `on_ready_to_show_popup` → `fire_gtk_popup_opened`
+  (`onPopupOpened`); `on_close_popup` → `fire_gtk_popup_closed`
+  (`onPopupClosed`) + `gtk_widget_destroy` + ref frees + `delete pe`.
+- `on_script_dialog_popup` / `on_run_file_chooser_popup` →
+  existing `handle_script_dialog` / `handle_run_file_chooser` with
+  `PopupEngine::dialog_callback`.
+- JNI bridge (`WEBVIEW_GTK`) → `gtk_set_popup_callback` /
+  `gtk_off_set_popup_callback` → `Engine`/`OffEngine::popup_callback`.
+
+### Layered Architecture
+- Native engine layer only (`src_c/webview_embed.cpp` GTK). No Java,
+  JNI-surface, wrapper, dispatcher, component, contract, or demo change
+  — all of those shipped in Canvas 15. The GTK bridge dispatch gains one
+  `#ifdef` branch each.
+
+## O · Operations
+
+### 1. Add `popup_callback` to `Engine` and `OffEngine`
+Parallel to `dialog_callback`, with an equivalent doc comment noting the
+`create`-signal wiring is what invokes it.
+
+### 2. `PopupEngine` struct + notify helpers
+`struct PopupEngine { GtkWidget *window; WebKitWebView *web; JavaVM *jvm;
+jobject popup_callback; jobject dialog_callback; jlong popup_id; };`
+`fire_popup_requested` (bool, sync, `CallBooleanMethod`, exception
+sanitize → false on error); `fire_gtk_popup_opened` /
+`fire_gtk_popup_closed` (`CallVoidMethod`, exception sanitize). Method
+signatures:
+`onPopupRequested (Ljava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)Z`,
+`onPopupOpened (JLjava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)V`,
+`onPopupClosed (JLjava/lang/String;Ljava/lang/String;)V`.
+
+### 3. `handle_create_web_view` + `on_create_web_view_{engine,off_engine,popup}`
+Per Approach §2. The three wrappers pull `jvm` + `popup_callback` +
+`dialog_callback` from their respective struct and call the shared inner.
+
+### 4. `on_ready_to_show_popup` + `on_close_popup` + `on_script_dialog_popup` + `on_run_file_chooser_popup`
+Per Approach §3–4. The dialog wrappers reuse the shared inner dialog
+handlers with `PopupEngine::dialog_callback`.
+
+### 5. `gtk_set_popup_callback` / `gtk_off_set_popup_callback`
+Delete-old / new-global-ref, copied from the dialog setters against
+`popup_callback`.
+
+### 6. Clear `popup_callback` in `gtk_destroy_engine` / `gtk_off_destroy_engine`
+Same attach/`DeleteGlobalRef`/detach block as `dialog_callback`.
+
+### 7. Connect `create` in `gtk_create_engine` + `gtk_off_create_engine`
+After the `run-file-chooser` connect at each site.
+
+### 8. `WEBVIEW_GTK` branch in the two popup JNI bridges
+`webview_embed_set_popup_callback` → `gtk_set_popup_callback`;
+`webview_offscreen_set_popup_callback` → `gtk_off_set_popup_callback`.
+
+## N · Norms
+
+- **Mirror the dialog Linux coverage (Canvas 12) exactly**: one shared
+  inner handler, thin per-engine wrappers keyed by `user_data`, storage
+  lifecycle in the setters + destroy funcs, JNI bridge `#ifdef` branch.
+- **Opener linkage is mandatory** — `webkit_web_view_new_with_related_view`,
+  never a bare new view. Documented on `handle_create_web_view`.
+- **Return NULL on every non-allow path** — null `popup_callback`, JNI
+  attach failure, `onPopupRequested == false`, or exception. Never return
+  a half-built child.
+- **Per-call `jmethodID` resolution** + **JNI exception sanitization**
+  (`ExceptionCheck` → `Describe` → `Clear`) after every
+  `CallBooleanMethod` / `CallVoidMethod`; a leaked exception into GTK
+  crashes the process.
+- **No JS shim, no `__webview_*` binding, no JSON parser** — `create` is
+  a native-signal channel; payloads are primitives.
+- **No Java-side change** — the Canvas 15 Java contract is frozen; this
+  canvas only lights up the GTK native callback sites.
+
+## S · Safeguards
+
+- **Storage-first ordering** — fields + setters + teardown before the
+  signal handlers, so the JNI bridge stays linkable at every commit.
+- **Child-engine teardown ordering** — `close` destroys the GTK window
+  and frees the inherited `popup_callback` / `dialog_callback` global
+  refs after the synchronous `onPopupClosed` returns; `delete pe` last.
+  A `close` without a prior `ready-to-show` (popup blocked before shown)
+  still frees cleanly.
+- **`popupId` correlation is best-effort** — the Java `dispatchPopupClosed`
+  tolerates a missing map entry, so a close firing before open never NPEs.
+- **Disabled-until-wired** — with no `popup_callback` set, `create`
+  returns `NULL` and `window.open` stays blocked, identical to today.
+- **No `setDebug` coupling** — the `create`/`ready-to-show`/`close`
+  signals are connected unconditionally, so popups work in release builds.
+- **On-device validation required** — the sandbox has no WebKitGTK
+  toolchain; this GTK code is pattern-faithful to the shipped dialog
+  signal handlers and the macOS popup selectors but MUST be built and
+  exercised via `WebViewPopupDemo` on Linux before release. A maintainer
+  who lands this MUST flip Canvas 15's coverage note and the README
+  caveat to mark Linux done in the same commit.

--- a/spdd/prompt/17-20260802-1615-[Feat]-Browser-Initiated-Popups-Windows-Coverage.md
+++ b/spdd/prompt/17-20260802-1615-[Feat]-Browser-Initiated-Popups-Windows-Coverage.md
@@ -1,0 +1,299 @@
+---
+generated_at: 2026-08-02T16:15:00-07:00
+---
+
+# REASONS Canvas: Browser-Initiated Popups (`window.open`) — Windows WebView2 Coverage
+
+## R · Requirements
+
+- Wire the existing `WebViewPopupHandler` contract — designed and
+  shipped for the Java layer + macOS (WKWebView) in
+  [[browser-initiated-popups-window-open]] (Canvas 15) and extended to
+  Linux (WebKitGTK) in [[browser-initiated-popups-linux-coverage]]
+  (Canvas 16) — to the Windows WebView2 engine so `window.open(url,
+  name, features)` and clicks on `<a target="_blank">` /
+  `<form target="_blank">` open a native top-level popup window
+  **linked to the opener** (`window.opener` non-null;
+  `window.opener.postMessage(...)` works), and `window.close()` from the
+  popup destroys that window. This closes the Windows half of the
+  Canvas 15 "Native coverage status" note (Operation 11), exactly as
+  Canvas 13 added Windows coverage for the dialog feature after
+  Canvas 11 / 12.
+- The Windows engine is `windows/webview_embed.cc`, which hosts an
+  `ICoreWebView2` controller created lazily in the controller-ready
+  callback inside `engine_thread` (the per-engine WebView2 worker
+  thread with its own message pump). The new wiring lives in that
+  callback plus a new `NewWindowRequestedHandler` class defined
+  alongside the existing `FocusHandler` / `MsgHandler` /
+  `ScriptDialogHandler`.
+- The `Engine` struct already carries a `jobject popup_callback`
+  field and its `set_popup_callback` JNI bridge (both shipped in
+  Canvas 15). Add:
+  - `EventRegistrationToken new_window_token{}` — for the
+    `add_NewWindowRequested` registration.
+  - `ICoreWebView2Environment *environment = nullptr` — AddRef'd at
+    environment-ready, so the `NewWindowRequested` handler can create
+    the child controller from the **same** environment (this is what
+    makes the popup a linked view — `put_NewWindow` with a controller
+    from a different environment does NOT link the opener).
+- Register a `NewWindowRequestedHandler` (implementing
+  `ICoreWebView2NewWindowRequestedEventHandler`) via
+  `webview->add_NewWindowRequested(handler, &e->new_window_token)` in
+  the controller-ready callback, right after the existing
+  `add_ScriptDialogOpening` / `add_GotFocus` / `add_LostFocus` sites.
+  Follow the `CallbackBase<Iface>` template used by the other handlers.
+- The handler's `Invoke` runs on the WebView2 worker thread. It MUST
+  use the **deferral** pattern (the worker thread must keep pumping
+  while Java decides, so `Invoke` cannot block synchronously):
+  1. Read `args->get_Uri`, `args->get_IsUserInitiated`, and
+     `args->get_WindowFeatures` → `get_HasSize` / `get_Width` /
+     `get_Height`.
+  2. `args->GetDeferral(&deferral)`; on failure log and `return S_OK`
+     (WebView2 opens its own default window — the pre-feature fallback).
+  3. `args->AddRef()`, `deferral` held; spawn a short-lived
+     `std::thread` for the allow/deny JNI hop
+     (`onPopupRequested` via `popup_callback` — off the EDT,
+     synchronous relative to the deferred `window.open`).
+  4. `return S_OK` immediately.
+  5. On the worker JNI thread, once Java answers, marshal back onto the
+     WebView2 worker via `dispatch_to_thread(e, …)` (COM objects are
+     apartment-bound to the worker):
+     - **Deny**: `args->put_Handled(TRUE)` with no `NewWindow` (blocks;
+       `window.open` returns `null`), `deferral->Complete()`, release
+       `deferral` + `args`.
+     - **Allow**: create a native top-level popup `HWND`, then
+       `environment->CreateCoreWebView2Controller(hwnd,
+       ControllerHandler)` (same environment → linked). In that
+       completion: `get_CoreWebView2(&child)`,
+       `args->put_NewWindow(child)`, `args->put_Handled(TRUE)`,
+       `deferral->Complete()`, size + `ShowWindow` the popup, connect
+       the child's `add_WindowCloseRequested` → `DestroyWindow` +
+       `onPopupClosed`, fire `onPopupOpened`, release `deferral` +
+       `args`.
+- The child popup web view MUST be created via `put_NewWindow` with a
+  controller from the SAME `ICoreWebView2Environment` — never a fresh
+  environment / independent window loading the same URL (breaks OAuth
+  `signInWithPopup`). The engine owns the popup `HWND`, sizes it
+  (window features, fallback 500×650), shows it, and destroys it.
+- The child popup web view gets its own `add_NewWindowRequested`
+  (nested popups) and `add_ScriptDialogOpening` +
+  `put_AreDefaultScriptDialogsEnabled(FALSE)` (dialogs inside the
+  popup), both bound to the **opener** `Engine` so they reuse the
+  opener's `popup_callback` / `dialog_callback` — mirroring the
+  inherited-callbacks model on macOS / Linux.
+- No Java-side change is required — the contract, dispatcher, adapter
+  wiring, event POJO, and `EmbeddedWebView.setPopupCallback` all shipped
+  in Canvas 15, and the `webview_embed_set_popup_callback` JNI bridge
+  already stores the ref on Windows.
+
+### Threading
+
+- `Invoke` runs on the WebView2 worker thread and must not block it
+  (the completion-side `dispatch_to_thread` would self-deadlock, and the
+  worker also services rendering / JS / dispatch messages). The deferral
+  + worker-thread-JNI-hop + `dispatch_to_thread`-back pattern is the
+  same one `ScriptDialogHandler` uses and is the SDK-supported approach.
+- `onPopupRequested` runs on the short-lived JNI worker thread (off the
+  EDT), synchronous relative to the deferred `window.open`.
+  `onPopupOpened` / `onPopupClosed` are fired via `CallVoidMethod`; the
+  Java `PopupDispatcher` marshals them to the EDT via `invokeLater`.
+
+### Definition of Done
+
+- `window.open(url, ...)` from a page in a Windows `WebViewComponent`
+  opens a native top-level window loading `url`, linked to the opener
+  (`window.opener` non-null; `postMessage` to the opener works);
+  `window.close()` from the popup closes it.
+- `setPopupHandler(null)` blocks all popups on Windows (`window.open`
+  returns `null`); the DEFAULT handler allows them.
+- `onPopupOpened` / `onPopupClosed` reach the Java handler on the EDT;
+  `popupClosed` receives the correlated event stored at open.
+- No Java-side change; `PopupDispatcherTest` still passes unchanged.
+  Native window creation is validated on-device by running
+  `WebViewPopupDemo` on Windows (no-automated-GUI-tests policy).
+- Canvas 15's "Native coverage status" note and the README popups
+  caveat are updated in lockstep to mark Windows ✅ (completing all
+  three platforms).
+
+### Out of scope (unchanged from Canvas 15)
+
+- Hosting the popup in a Swing surface / as a tab; per-popup window
+  chrome; async user interaction inside `popupRequested`; feature-string
+  keys beyond `width`/`height`. The standalone in-process `WebView`
+  class is untouched. Windows has no offscreen engine, so the
+  `webview_offscreen_set_popup_callback` bridge stays a stub.
+
+## E · Entities
+
+- **`windows/webview_embed.cc`** (modified). Adds:
+  - `Engine::new_window_token` (`EventRegistrationToken`) and
+    `Engine::environment` (`ICoreWebView2Environment*`, AddRef'd at
+    env-ready, Release'd in `destroy_engine`).
+  - `struct PopupWindow` — the child popup's native state: `HWND hwnd`,
+    `ICoreWebView2Controller *controller`, `ICoreWebView2 *webview`,
+    `Engine *opener` (for `jvm` + `popup_callback`), `jlong popup_id`,
+    `std::string url`, `EventRegistrationToken close_token`.
+  - `PopupWndProc` + `ensure_popup_class_registered` (window class
+    `"WebViewEmbedPopup"`): `WM_SIZE` → `controller->put_Bounds`;
+    `WM_DESTROY` → release controller/webview + `delete` the
+    `PopupWindow`.
+  - JNI helpers `fire_popup_requested_win(Engine*, url, gesture, w, h,
+    page) -> bool`, `fire_popup_opened_win(Engine*, popup_id, url,
+    gesture, w, h, page)`, `fire_popup_closed_win(Engine*, popup_id,
+    url, page)` — the same method IDs / signatures as macOS / Linux,
+    exception-sanitized.
+  - `NewWindowRequestedHandler : CallbackBase<
+    ICoreWebView2NewWindowRequestedEventHandler>` (Approach §), and
+    `PopupCloseHandler : CallbackBase<
+    ICoreWebView2WindowCloseRequestedEventHandler>` for the child's
+    `WindowCloseRequested`.
+  - Registration of `add_NewWindowRequested` in the controller-ready
+    callback; `e->environment` AddRef at env-ready; `popup_callback`
+    global-ref clear + `environment` Release in `destroy_engine`.
+
+## A · Approach
+
+1. **Struct fields + env capture + teardown first.** Add
+   `new_window_token` and `environment` to `Engine`. In the
+   environment-ready lambda, `e->environment = env; env->AddRef();`
+   before creating the controller. In `destroy_engine`, clear
+   `popup_callback` (attach / `DeleteGlobalRef` / detach, same block as
+   `dialog_callback`) and `if (e->environment) { e->environment->Release();
+   e->environment = nullptr; }`.
+
+2. **Popup window class.** `ensure_popup_class_registered` registers
+   `"WebViewEmbedPopup"` with `PopupWndProc`. `PopupWndProc` stores the
+   `PopupWindow*` via `GWLP_USERDATA`; `WM_SIZE` resizes the controller;
+   `WM_DESTROY` releases the controller + webview and deletes the
+   `PopupWindow`.
+
+3. **NewWindowRequestedHandler::Invoke** (worker thread) — deferral
+   pattern per Requirements. Copy `uri` (UTF-8), read
+   `IsUserInitiated` and window features (`HasSize` → `Width`/`Height`,
+   else −1). `GetDeferral`; on failure `return S_OK`. `args->AddRef()`.
+   Spawn `std::thread`:
+   - `bool allow = fire_popup_requested_win(e, uri, gesture, w, h,
+     page)` (page = opener document URL via `webview->get_Source`, best
+     effort empty).
+   - `dispatch_to_thread(e, [...] { ... })` onto the worker:
+     - Deny → `args->put_Handled(TRUE); deferral->Complete();
+       deferral->Release(); args->Release();`.
+     - Allow → `HWND popup = CreateWindowEx(WS_OVERLAPPEDWINDOW …)`
+       (size from features / 500×650), build a `PopupWindow` (`opener =
+       e`, `popup_id = (jlong)(intptr_t)pw`), `SetWindowLongPtr(popup,
+       GWLP_USERDATA, pw)`. `e->environment->CreateCoreWebView2Controller(
+       popup, new ControllerHandler([...] {`
+       - `ctrl->get_CoreWebView2(&child)`; store on `pw`.
+       - `args->put_NewWindow(child); args->put_Handled(TRUE);
+         deferral->Complete();`.
+       - Size the controller bounds to the client rect, `put_IsVisible(
+         TRUE)`, `ShowWindow(popup, SW_SHOW)`.
+       - On the child: `add_NewWindowRequested(new
+         NewWindowRequestedHandler(e), …)` (nested), settings
+         `put_AreDefaultScriptDialogsEnabled(FALSE)` +
+         `add_ScriptDialogOpening(new ScriptDialogHandler(e), …)`
+         (dialogs), and `add_WindowCloseRequested(new
+         PopupCloseHandler(pw), &pw->close_token)`.
+       - `fire_popup_opened_win(e, pw->popup_id, uri, gesture, W, H,
+         page)`.
+       - `deferral->Release(); args->Release();`.
+       `}))`. On `CreateCoreWebView2Controller` failure: destroy the
+       window, `args->put_Handled(TRUE)` (blocked), `Complete` +
+       release.
+
+4. **PopupCloseHandler::Invoke** (`WindowCloseRequested`, worker
+   thread) — `fire_popup_closed_win(pw->opener, pw->popup_id, pw->url,
+   "")`, then `DestroyWindow(pw->hwnd)` (which triggers `WM_DESTROY` →
+   `PopupWndProc` releases the controller/webview and deletes `pw`).
+
+5. **Registration site.** In the controller-ready callback, after
+   `add_LostFocus`, add:
+   `auto *nwh = new NewWindowRequestedHandler(e);
+   e->webview->add_NewWindowRequested(nwh, &e->new_window_token);
+   nwh->Release();`.
+
+## S · Structure
+
+### Dependencies
+- Controller-ready → `add_NewWindowRequested(NewWindowRequestedHandler)`.
+- `NewWindowRequestedHandler::Invoke` → `GetDeferral` + JNI worker
+  (`fire_popup_requested_win` → `onPopupRequested`) + `dispatch_to_thread`
+  → `environment->CreateCoreWebView2Controller` → `put_NewWindow` +
+  child event registrations + `fire_popup_opened_win`.
+- `PopupCloseHandler::Invoke` → `fire_popup_closed_win` +
+  `DestroyWindow` → `PopupWndProc` `WM_DESTROY` → controller/webview
+  release + `delete PopupWindow`.
+- `set_popup_callback` JNI bridge (already present) →
+  `Engine::popup_callback`.
+
+### Layered Architecture
+- Native engine layer only (`windows/webview_embed.cc`). No Java,
+  JNI-surface, wrapper, dispatcher, component, contract, or demo change
+  — all shipped in Canvas 15.
+
+## O · Operations
+
+### 1. `Engine::new_window_token` + `Engine::environment`; env capture + teardown
+Add the two fields. `env->AddRef()` at env-ready. In `destroy_engine`,
+clear `popup_callback` (same attach/DeleteGlobalRef block as
+`dialog_callback`) and `environment->Release()`.
+
+### 2. `PopupWindow` + `PopupWndProc` + `ensure_popup_class_registered`
+Per Approach §2.
+
+### 3. JNI helpers `fire_popup_requested_win` / `fire_popup_opened_win` / `fire_popup_closed_win`
+Method signatures identical to macOS / Linux
+(`onPopupRequested (…)Z`, `onPopupOpened (J…)V`, `onPopupClosed
+(JLjava/lang/String;Ljava/lang/String;)V`). `fire_popup_requested_win`
+returns false on null callback / attach failure / exception.
+
+### 4. `NewWindowRequestedHandler` + `PopupCloseHandler`
+Per Approach §3–4, using the `CallbackBase<Iface>` template.
+
+### 5. Register `add_NewWindowRequested` in the controller-ready callback
+Per Approach §5.
+
+## N · Norms
+
+- **Mirror the dialog Windows coverage (Canvas 13)**: deferral pattern,
+  `CallbackBase<Iface>` handlers, JNI hop on a worker thread,
+  `dispatch_to_thread` back to the WebView2 worker for COM calls.
+- **Opener linkage is mandatory** — `put_NewWindow` with a controller
+  created from the SAME `ICoreWebView2Environment`.
+- **`put_Handled(TRUE)` on every decided path** (allow and deny) so the
+  default WebView2 window is suppressed; only the un-deferrable failure
+  path (`GetDeferral` failed) falls through to the default window.
+- **AddRef `args` + hold `deferral` across the async hop; Release both
+  in the completion** — exactly as `ScriptDialogHandler`.
+- **Per-call `jmethodID` resolution** + **JNI exception sanitization**
+  after every `CallBooleanMethod` / `CallVoidMethod`.
+- **No JS shim, no `__webview_*` binding, no JSON parser.**
+- **No Java-side change** — the Canvas 15 contract is frozen.
+
+## S · Safeguards
+
+- **Worker thread never blocks** — the deferral pattern keeps the pump
+  alive; blocking `Invoke` is rejected (self-deadlock with
+  `dispatch_to_thread`), matching the dialog canvas.
+- **Popup window teardown ordering** — `WindowCloseRequested` fires
+  `onPopupClosed` first, then `DestroyWindow`; `WM_DESTROY` in
+  `PopupWndProc` releases the controller + webview and deletes the
+  `PopupWindow`. A destroy without a prior show still releases cleanly.
+- **`popupId` correlation is best-effort** — the Java
+  `dispatchPopupClosed` tolerates a missing map entry.
+- **Disabled-until-set** — with no `popup_callback`,
+  `fire_popup_requested_win` returns false → deny path → `window.open`
+  returns `null`, identical to today.
+- **Environment lifetime** — `environment` is AddRef'd at env-ready and
+  Release'd in `destroy_engine`; a popup created just before disposal
+  holds its own controller ref, so worker-thread teardown does not
+  free a live child out from under it.
+- **No `setDebug` coupling** — `add_NewWindowRequested` is registered
+  unconditionally, so popups work in release builds.
+- **On-device validation required** — the sandbox has no MSVC /
+  WebView2 SDK; this code is pattern-faithful to the shipped
+  `ScriptDialogHandler` / `FocusHandler` and the macOS / Linux popup
+  paths but MUST be built and exercised via `WebViewPopupDemo` on
+  Windows before release. The maintainer who lands this MUST flip
+  Canvas 15's coverage note and the README caveat to mark Windows done
+  (all three platforms complete) in the same commit.

--- a/spdd/prompt/8-20260516-0719-[Feat]-Native-Library-Loading-And-Packaging.md
+++ b/spdd/prompt/8-20260516-0719-[Feat]-Native-Library-Loading-And-Packaging.md
@@ -392,6 +392,12 @@ Files: `src_c/webkit_loader.h`, `src_c/webkit_loader.cpp`,
    job if any `NEEDED` entry matches `webkit2gtk` or
    `javascriptcoregtk` — the machine-checked proof the artifact
    carries no hard WebKit dependency.
+6. README: the "Platform support" preamble documents the Linux
+   runtime requirement as a single portable binary — the bundled
+   `libwebview.so` loads on either WebKitGTK **4.1** (Ubuntu 22.04+)
+   or **4.0** (Ubuntu 20.04) present at load time, with no separate
+   per-version build, alongside the existing Windows WebView2-Runtime
+   note.
 
 ## N · Norms
 - The developer `build-*.sh` scripts must quote every shell

--- a/spdd/prompt/8-20260516-0719-[Feat]-Native-Library-Loading-And-Packaging.md
+++ b/spdd/prompt/8-20260516-0719-[Feat]-Native-Library-Loading-And-Packaging.md
@@ -122,6 +122,16 @@ generated_at: 2026-05-16T07:19:13-07:00
   `WebView2Loader.lib` is statically linked into `webview.dll`
   on Windows so no separate `WebView2Loader.dll` ships in the jar
   (`.github/workflows/build.yml:171`).
+- `src_c/webkit_loader.h`, `src_c/webkit_loader.cpp`,
+  `src_c/webkit_shim.h` — the **Linux-only runtime WebKitGTK /
+  JavaScriptCore loader** (Operation 7). After this,
+  `libwebview.so` carries **no** `DT_NEEDED` on
+  `libwebkit2gtk-4.{0,1}` or `libjavascriptcoregtk-4.{0,1}`; those
+  are `dlopen`ed at `JNI_OnLoad` (4.1 preferred, 4.0 fallback) and
+  every WebKit/JSC call site is routed through function pointers
+  via `webkit_shim.h`. GTK3/GLib remain normally linked. macOS
+  (WKWebView) and Windows (WebView2) builds are untouched — the
+  loader compiles only under `WEBVIEW_GTK` / `__linux__`.
 - `pom.xml:65-75` — Maven resource entries that copy each
   per-architecture directory from `natives/<arch>/` into
   `target/classes/<arch>/` at JAR-build time, so they land at the
@@ -300,6 +310,88 @@ Files: `.github/workflows/build.yml`,
    - `build.yml` runs on every push/PR to `master`, producing
      a downloadable jar artifact but not publishing. Only
      `maven-release.yml` publishes, gated on `v*` tag pushes.
+   - The Linux `native` job asserts, via `readelf -d` on the
+     built `libwebview.so`, that it has **no** `NEEDED` entry
+     matching `webkit2gtk` or `javascriptcoregtk` (4.0 or 4.1)
+     — a machine-checked guarantee of the single-portable-binary
+     property (Operation 7). A hard WebKit/JSC link dependency
+     fails the build.
+
+### 7. Runtime WebKitGTK / JavaScriptCore Resolution (Linux)
+Files: `src_c/webkit_loader.h`, `src_c/webkit_loader.cpp`,
+`src_c/webkit_shim.h`, `src_c/webview.h`, `src_c/webview_embed.cpp`,
+`build-linux.sh`, `.github/workflows/build.yml`,
+`.github/workflows/maven-release.yml`, `run-linux-*.sh`
+
+1. Responsibility: ship a **single** `libwebview.so` that loads and
+   works on both WebKitGTK 4.1 hosts (Ubuntu 22.04+) and WebKitGTK
+   4.0 hosts (Ubuntu 20.04) with no packaging matrix and no change
+   to the public Java API or JNI signatures. Achieved by resolving
+   WebKitGTK/JavaScriptCore at **runtime** instead of link time. The
+   loader is Linux-only (guarded by `WEBVIEW_GTK` / `__linux__`);
+   the macOS and Windows code paths and builds are not touched.
+
+2. Loader module (`webkit_loader.h` / `webkit_loader.cpp`): one
+   struct of typed function pointers, one member per WebKitGTK/JSC
+   symbol the wrapper calls, each member's type taken via
+   `decltype(&symbol)` against the real headers (unevaluated —
+   creates no link dependency). A global instance `g_wk` plus a
+   `pthread_once`-guarded initializer resolve the pointers once:
+   - `dlopen` the WebKit library preferring
+     `libwebkit2gtk-4.1.so.0`, falling back to
+     `libwebkit2gtk-4.0.so.37`.
+   - `dlopen` the **matching-generation** JavaScriptCore:
+     `libjavascriptcoregtk-4.1.so.0` when 4.1 WebKit opened, else
+     `libjavascriptcoregtk-4.0.so.18` — never mix generations, so
+     only one libsoup is pulled transitively. Do not link libsoup
+     directly.
+   - Both handles opened `RTLD_NOW | RTLD_GLOBAL`.
+   - Resolve every `webkit_*` symbol from the WebKit handle and
+     every `jsc_*` / JavaScriptCore-C-API symbol from the JSC
+     handle via `dlsym`.
+   - The JS-result symbol subset mirrors `webview.h`'s
+     `WEBKIT_MAJOR_VERSION >= 2 && WEBKIT_MINOR_VERSION >= 22`
+     guard exactly, so the loader references only symbols the
+     compiled call sites reference (the pre-2.22
+     `webkit_javascript_result_get_global_context` / `_get_value`
+     path is absent from modern headers and must stay behind the
+     same `#else`).
+   - On any failure — either library not `dlopen`able, or a
+     required symbol missing — fail with a clear message naming
+     **both** candidate SONAMEs of the library that could not be
+     satisfied. Runs from `JNI_OnLoad`; returning `JNI_ERR` makes
+     `System.load` throw with that message (same load-time failure
+     point as before, now diagnosable on both 4.0 and 4.1 hosts).
+
+3. Call-site routing (`webkit_shim.h`): included by `webview.h` and
+   `webview_embed.cpp` immediately after the WebKit/JSC/GTK headers,
+   inside the GTK-only regions. It `#define`s each resolved symbol
+   name to the corresponding `g_wk` member, so existing call sites
+   compile to function-pointer calls with **no textual edits** (the
+   member token is not re-expanded — self-reference is safe). It
+   also redefines the one GObject cast macro in use, `WEBKIT_WEB_VIEW`,
+   to a plain pointer cast, dropping the implicit
+   `webkit_web_view_get_type` symbol reference (no `WEBKIT_IS_*`
+   checks exist, and all other `WEBKIT_*` tokens are compile-time
+   enum/version constants). `webkit_loader.cpp` does **not** include
+   the shim — it assigns the real struct members and `dlsym`s by
+   string name. GTK/GLib cast macros are unchanged (GTK stays
+   linked).
+
+4. Build: compilation still sees the WebKit headers
+   (`pkg-config --cflags gtk+-3.0 $WEBKIT_PKG`), but the link step
+   no longer adds the WebKit/JSC libraries — link only
+   `pkg-config --libs gtk+-3.0` (GTK/GLib), plus `-lX11 -ldl`, and
+   add `src_c/webkit_loader.cpp` to the sources. Applied uniformly
+   to `build-linux.sh`, the Linux `native` job in `build.yml` and
+   `maven-release.yml`, and every `run-linux-*.sh` developer/demo
+   script (so the demos exercise the same runtime-resolution path).
+
+5. Verification gate: after the Linux native build, `build.yml`
+   runs `readelf -d` on the produced `libwebview.so` and fails the
+   job if any `NEEDED` entry matches `webkit2gtk` or
+   `javascriptcoregtk` — the machine-checked proof the artifact
+   carries no hard WebKit dependency.
 
 ## N · Norms
 - The developer `build-*.sh` scripts must quote every shell
@@ -335,6 +427,15 @@ Files: `.github/workflows/build.yml`,
     are present" step of both workflows,
   - one of the `build-*.sh` scripts (or a new one) for local
     builds on the matching OS/arch.
+- The Linux native resolves WebKitGTK/JavaScriptCore at **runtime**
+  (Operation 7), never via a link-time `-l`. Any newly-used
+  `webkit_*` / `jsc_*` symbol must be added to the `webkit_loader`
+  pointer set **and** the `webkit_shim` redirects in the same
+  change, and must belong to the API subset common to WebKitGTK 4.0
+  and 4.1 (if a symbol is 4.1-only, find the 4.0-compatible
+  equivalent or guard it behind the version `#if`). Never add a
+  WebKit/JSC `-l` flag or `--libs` pkg-config module to any Linux
+  build entry point.
 
 ## S · Safeguards
 - `WebViewNative` swallows `IOException` from the loader and
@@ -359,3 +460,12 @@ Files: `.github/workflows/build.yml`,
   (`natives/`, ``, `META-INF/lib/`) so the JAR layout can
   evolve without breaking existing consumers
   (`NativeLibraryUtil.java:334`).
+- The Linux WebKit loader fails **loudly**, not silently: if
+  neither `libwebkit2gtk-4.1.so.0` nor `libwebkit2gtk-4.0.so.37`
+  (respectively the two JavaScriptCore SONAMEs) can be `dlopen`ed,
+  or a required symbol is missing, `JNI_OnLoad` returns `JNI_ERR`
+  and `System.load` throws `UnsatisfiedLinkError` with a message
+  naming both candidate SONAMEs. This replaces the old
+  dynamic-linker error — which named only the 4.1 SONAME and made a
+  4.0 host look broken — with a message that makes the
+  missing-runtime case obvious on either host.

--- a/src/ca/weblite/webview/EmbeddedWebView.java
+++ b/src/ca/weblite/webview/EmbeddedWebView.java
@@ -510,6 +510,29 @@ public class EmbeddedWebView {
     }
 
     /**
+     * Register the popup callback for browser-initiated popups
+     * ({@code window.open}, {@code target="_blank"}).  Anchors {@code cb} in
+     * {@link #heap} so the JVM does not collect the adapter while the native
+     * side holds a global ref.  Delivery is per-platform: macOS installs a
+     * {@code WKUIDelegate createWebViewWithConfiguration:} +
+     * {@code webViewDidClose:} pair; Linux connects the WebKitGTK
+     * {@code create} / {@code ready-to-show} / {@code close} signals; Windows
+     * registers {@code ICoreWebView2::add_NewWindowRequested} and the child's
+     * {@code add_WindowCloseRequested}.  When allowed, the native engine
+     * opens and owns the popup window (linked to the opener).
+     *
+     * @return {@code this} for chaining
+     */
+    public EmbeddedWebView setPopupCallback(WebViewPopupCallback cb) {
+        checkAlive();
+        if (cb != null) {
+            heap.add(cb);
+        }
+        WebViewNative.webview_embed_set_popup_callback(peer, cb);
+        return this;
+    }
+
+    /**
      * Windows-only: force Win32 keyboard focus back to the AWT-owned parent
      * HWND, so subsequent keystrokes route to AWT instead of the WebView2
      * child HWND.  Used by the Java-side global focus-owner listener when
@@ -685,6 +708,14 @@ public class EmbeddedWebView {
             // no-ops instead of invoking JNI on a freed ref.
             try {
                 WebViewNative.webview_embed_set_click_callback(p, null);
+            } catch (Throwable ignored) {
+                // Don't let a clear-callback failure prevent destroy.
+            }
+            // Same reasoning for the popup callback: a late window.open /
+            // webViewDidClose / NewWindowRequested event racing teardown must
+            // land on a null callback field, not a freed global ref.
+            try {
+                WebViewNative.webview_embed_set_popup_callback(p, null);
             } catch (Throwable ignored) {
                 // Don't let a clear-callback failure prevent destroy.
             }

--- a/src/ca/weblite/webview/OffscreenWebView.java
+++ b/src/ca/weblite/webview/OffscreenWebView.java
@@ -371,6 +371,32 @@ public class OffscreenWebView {
         return this;
     }
 
+    /**
+     * Offscreen counterpart to
+     * {@link EmbeddedWebView#setPopupCallback} — bridges
+     * {@code window.open} popup requests in the offscreen engine to the
+     * per-component {@link PopupDispatcher}.
+     *
+     * <p>Anchoring the callback in {@code heap} is required so the JVM does
+     * not garbage-collect the adapter while the native side holds a global
+     * ref.
+     *
+     * <p>On macOS / Windows, where the offscreen engine itself is a stub,
+     * this method has no effect — the native stub is a no-op.  Linux is the
+     * only platform where the offscreen path actually dispatches popup
+     * requests (WebKitGTK {@code create} signal).
+     *
+     * @return {@code this} for chaining
+     */
+    public OffscreenWebView setPopupCallback(WebViewPopupCallback cb) {
+        checkAlive();
+        if (cb != null) {
+            heap.add(cb);
+        }
+        WebViewNative.webview_offscreen_set_popup_callback(peer, cb);
+        return this;
+    }
+
     /** Release native resources. */
     public void dispose() {
         if (peer != 0L) {

--- a/src/ca/weblite/webview/PopupDispatcher.java
+++ b/src/ca/weblite/webview/PopupDispatcher.java
@@ -1,0 +1,183 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import ca.weblite.webview.swing.WebViewComponent;
+
+import java.util.concurrent.ConcurrentHashMap;
+import javax.swing.SwingUtilities;
+
+/**
+ * <p><strong>Internal:</strong> not part of the public API surface.  Use
+ * {@link WebViewComponent#setPopupHandler} /
+ * {@link WebViewComponent#getPopupHandler} instead.  This class is
+ * {@code public} only because the consuming Swing subclasses live in a
+ * different package; matches the pattern used by {@link DialogDispatcher},
+ * {@code ConsoleDispatcher}, {@code WebViewMouseDispatcher},
+ * {@link EmbeddedWebView}, and {@link OffscreenWebView}.
+ *
+ * <p>Per-component fan-out hub for browser-initiated popups.  Holds the
+ * single active {@link WebViewPopupHandler} reference.
+ *
+ * <p><strong>Threading — diverges from {@link DialogDispatcher} in two
+ * documented places:</strong>
+ * <ol>
+ *   <li>{@link #dispatchPopupRequested} runs the handler
+ *       <strong>inline on the calling (native UI) thread</strong>, never on
+ *       the EDT, and returns its {@code boolean} synchronously — the platform
+ *       popup callback needs the allow/deny decision before it can return the
+ *       child web view (or block), and an EDT round-trip from the native UI
+ *       thread risks a deadlock.</li>
+ *   <li>{@link #dispatchPopupOpened} / {@link #dispatchPopupClosed} are
+ *       asynchronous notifications marshalled to the EDT via
+ *       {@link SwingUtilities#invokeLater} (like the focus/click adapters),
+ *       not {@code invokeAndWait}.</li>
+ * </ol>
+ * Handler exceptions are caught and forwarded to
+ * {@link Thread#getDefaultUncaughtExceptionHandler()}; a safe fallback is
+ * returned ({@code false} for the allow/deny gate, so a thrown decision
+ * blocks the popup rather than leaking into the native thread).
+ */
+public final class PopupDispatcher {
+
+    /** Internal drop singleton — installed when caller passes {@code null}
+     *  to {@link #setHandler}.  Blocks all popups without UI.  Stateless;
+     *  package-private (callers reset to the framework default by passing
+     *  {@link WebViewPopupHandler#DEFAULT}). */
+    static final WebViewPopupHandler DROP = new WebViewPopupHandler() {
+        @Override public boolean popupRequested(WebViewPopupEvent e) {
+            return false;
+        }
+        @Override public void popupOpened(WebViewPopupEvent e) { }
+        @Override public void popupClosed(WebViewPopupEvent e) { }
+    };
+
+    private final WebViewComponent source;
+    private volatile WebViewPopupHandler handler = WebViewPopupHandler.DEFAULT;
+    private volatile boolean disposed = false;
+
+    /** Correlates {@link #dispatchPopupOpened} with the later
+     *  {@link #dispatchPopupClosed} so {@code popupClosed} receives the same
+     *  rich event.  Keyed by the engine-assigned popup id. */
+    private final ConcurrentHashMap<Long, WebViewPopupEvent> openPopups =
+        new ConcurrentHashMap<Long, WebViewPopupEvent>();
+
+    public PopupDispatcher(WebViewComponent source) {
+        if (source == null) throw new NullPointerException("source");
+        this.source = source;
+    }
+
+    /** Replace the active handler.  Passing {@code null} installs an internal
+     *  drop handler that blocks all popups.  To reset to the framework
+     *  default, pass {@link WebViewPopupHandler#DEFAULT} explicitly. */
+    public void setHandler(WebViewPopupHandler h) {
+        handler = (h == null) ? DROP : h;
+    }
+
+    /** @return the active handler; never {@code null}. */
+    public WebViewPopupHandler getHandler() {
+        return handler;
+    }
+
+    /** Flip the dispatcher into disposed state.  After this call every
+     *  {@code dispatch*} method returns the safe fallback without invoking
+     *  the handler.  Idempotent. */
+    public void disposeAll() {
+        disposed = true;
+        openPopups.clear();
+    }
+
+    /** @return whether the dispatcher has been disposed. */
+    public boolean isDisposed() {
+        return disposed;
+    }
+
+    // ---------------------------------------------------------------------
+    // Native-facing dispatch entry points (invoked from JNI through the
+    // WebViewPopupCallback adapter installed at peer-attach time).
+    // ---------------------------------------------------------------------
+
+    /** Synchronous allow/deny gate.  Runs the handler inline on the calling
+     *  (native UI) thread; never marshals to the EDT. */
+    public boolean dispatchPopupRequested(String targetUrl, String targetName,
+                                          boolean userGesture, int width,
+                                          int height, String pageUrl) {
+        if (disposed) return false;
+        final WebViewPopupEvent event = new WebViewPopupEvent(
+            source, targetUrl, targetName, userGesture, width, height, pageUrl);
+        try {
+            return handler.popupRequested(event);
+        } catch (Throwable t) {
+            forwardUncaught(t);
+            return false;
+        }
+    }
+
+    /** Async notification that a popup window opened; delivered on the EDT. */
+    public void dispatchPopupOpened(long popupId, String targetUrl,
+                                    String targetName, boolean userGesture,
+                                    int width, int height, String pageUrl) {
+        if (disposed) return;
+        final WebViewPopupEvent event = new WebViewPopupEvent(
+            source, targetUrl, targetName, userGesture, width, height, pageUrl);
+        openPopups.put(Long.valueOf(popupId), event);
+        runOnEdtLater(new Runnable() {
+            @Override public void run() {
+                handler.popupOpened(event);
+            }
+        });
+    }
+
+    /** Async notification that a popup window closed; delivered on the EDT. */
+    public void dispatchPopupClosed(long popupId, String targetUrl,
+                                    String pageUrl) {
+        if (disposed) return;
+        WebViewPopupEvent existing = openPopups.remove(Long.valueOf(popupId));
+        final WebViewPopupEvent event = (existing != null) ? existing
+            : new WebViewPopupEvent(source, targetUrl, "", false, -1, -1,
+                                    pageUrl);
+        runOnEdtLater(new Runnable() {
+            @Override public void run() {
+                handler.popupClosed(event);
+            }
+        });
+    }
+
+    // ---------------------------------------------------------------------
+    // EDT marshal + exception isolation (async notifications only).
+    // ---------------------------------------------------------------------
+
+    private void runOnEdtLater(final Runnable r) {
+        final Runnable wrapped = new Runnable() {
+            @Override public void run() {
+                try {
+                    r.run();
+                } catch (Throwable t) {
+                    forwardUncaught(t);
+                }
+            }
+        };
+        if (SwingUtilities.isEventDispatchThread()) {
+            wrapped.run();
+        } else {
+            SwingUtilities.invokeLater(wrapped);
+        }
+    }
+
+    private static void forwardUncaught(Throwable t) {
+        try {
+            Thread.UncaughtExceptionHandler h =
+                Thread.getDefaultUncaughtExceptionHandler();
+            if (h != null) {
+                h.uncaughtException(Thread.currentThread(), t);
+            } else {
+                t.printStackTrace();
+            }
+        } catch (Throwable ignored) {
+            try { t.printStackTrace(); } catch (Throwable ignored2) { }
+        }
+    }
+}

--- a/src/ca/weblite/webview/WebViewNative.java
+++ b/src/ca/weblite/webview/WebViewNative.java
@@ -283,6 +283,25 @@ native static void webview_embed_set_attach_callback(long w, Object cb);
 // silent no-op.  Never throws via JNI.
 native static void webview_embed_set_dialog_callback(long w, WebViewDialogCallback cb);
 
+// Register (or clear, by passing null) a callback invoked when the
+// embedded page requests a popup (window.open / target=_blank).  The
+// callback's onPopupRequested returns the allow/deny decision
+// synchronously on the native UI thread; onPopupOpened / onPopupClosed
+// are async notifications the library marshals to the EDT via
+// SwingUtilities.invokeLater.  When a popup is allowed the native engine
+// creates the child web view LINKED to the opener and hosts it in a
+// native top-level window it owns.  Per-platform delivery:
+//   - macOS:   WKUIDelegate createWebViewWithConfiguration: +
+//              webViewDidClose: on the WKWebView.
+//   - Linux:   create / ready-to-show / close signals on WebKitWebView
+//              (child created via webkit_web_view_new_with_related_view).
+//   - Windows: ICoreWebView2::add_NewWindowRequested (put_NewWindow with
+//              a controller from the same environment) plus the child's
+//              add_WindowCloseRequested.
+// cb may be null to clear the registration.  Passing 0 for w is a
+// silent no-op.  Never throws via JNI.
+native static void webview_embed_set_popup_callback(long w, WebViewPopupCallback cb);
+
 
 // ---------------------------------------------------------------------------
 // Lightweight / offscreen API (currently Linux-only).
@@ -391,6 +410,13 @@ native static void webview_offscreen_execute_editing_command(long peer, int cmdI
 // macOS / Windows native binaries provide a no-op stub (the offscreen
 // engine on those platforms is itself a stub).  Never throws via JNI.
 native static void webview_offscreen_set_dialog_callback(long peer, WebViewDialogCallback cb);
+
+// Offscreen counterpart to webview_embed_set_popup_callback.  Used by
+// WebViewLightweightComponent on Linux to bridge window.open requests in
+// the offscreen engine to the per-component PopupDispatcher.  macOS /
+// Windows native binaries provide a no-op stub (the offscreen engine on
+// those platforms is itself a stub).  Never throws via JNI.
+native static void webview_offscreen_set_popup_callback(long peer, WebViewPopupCallback cb);
 
 
 }

--- a/src/ca/weblite/webview/WebViewPopupCallback.java
+++ b/src/ca/weblite/webview/WebViewPopupCallback.java
@@ -1,0 +1,58 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+/**
+ * Internal JNI bridge interface invoked by the native engine when the
+ * embedded page requests a popup ({@code window.open}, {@code target="_blank"}).
+ *
+ * <p><strong>Not part of the public application API.</strong>  Application
+ * code customises popup behaviour by installing a
+ * {@link WebViewPopupHandler} via
+ * {@link ca.weblite.webview.swing.WebViewComponent#setPopupHandler}; this
+ * interface is the underlying bridge the library wires from the Swing
+ * component to the native engine via JNI.  It is {@code public} only because
+ * the JNI bridge in {@code src_c/webview_embed.cpp} and
+ * {@code windows/webview_embed.cc} needs to call methods on instances of it,
+ * matching the constraint on {@link WebViewDialogCallback},
+ * {@link WebViewClickCallback}, and {@link WebViewFocusCallback}.
+ *
+ * <p><strong>Threading.</strong> The native engine invokes these methods from
+ * whatever native UI thread the engine runs on (AppKit main on macOS, the GTK
+ * main thread on Linux, the WebView2 worker thread on Windows).
+ * {@link #onPopupRequested} returns the allow/deny decision
+ * <strong>synchronously</strong> — the native side is blocked awaiting the
+ * return value and it MUST NOT be marshalled to the Swing EDT.
+ * {@link #onPopupOpened} and {@link #onPopupClosed} are fire-and-forget
+ * notifications; the library-provided implementation routes them through
+ * {@link PopupDispatcher}, which marshals to the EDT via
+ * {@link javax.swing.SwingUtilities#invokeLater}.
+ */
+public interface WebViewPopupCallback {
+
+    /**
+     * Invoked synchronously when the page requests a popup.  Return
+     * {@code true} to allow it (the engine opens a native window loading
+     * {@code targetUrl}) or {@code false} to block it ({@code window.open}
+     * returns {@code null}).
+     *
+     * @param width  requested width, or {@code -1} when unspecified
+     * @param height requested height, or {@code -1} when unspecified
+     */
+    boolean onPopupRequested(String targetUrl, String targetName,
+                             boolean userGesture, int width, int height,
+                             String pageUrl);
+
+    /** Invoked after the popup's native window has been created and shown.
+     *  {@code popupId} is an engine-assigned opaque handle correlating this
+     *  open with its later {@link #onPopupClosed}. */
+    void onPopupOpened(long popupId, String targetUrl, String targetName,
+                       boolean userGesture, int width, int height,
+                       String pageUrl);
+
+    /** Invoked after the popup's native window has been destroyed. */
+    void onPopupClosed(long popupId, String targetUrl, String pageUrl);
+}

--- a/src/ca/weblite/webview/WebViewPopupEvent.java
+++ b/src/ca/weblite/webview/WebViewPopupEvent.java
@@ -1,0 +1,76 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import ca.weblite.webview.swing.WebViewComponent;
+
+/**
+ * Immutable carrier of one browser-initiated popup request raised by the
+ * embedded page — {@code window.open(url, name, features)} or a click on a
+ * link / form with {@code target="_blank"} — surfaced to
+ * {@link WebViewPopupHandler}.
+ *
+ * <p>String accessors return non-null values; {@code targetUrl},
+ * {@code targetName}, and {@code pageUrl} are the empty string when the
+ * engine reports no value.  {@link #width()} and {@link #height()} are
+ * {@code -1} when the page did not request an explicit size.
+ */
+public final class WebViewPopupEvent {
+
+    private final WebViewComponent source;
+    private final String targetUrl;
+    private final String targetName;
+    private final boolean userGesture;
+    private final int width;
+    private final int height;
+    private final String pageUrl;
+
+    WebViewPopupEvent(WebViewComponent source, String targetUrl,
+                      String targetName, boolean userGesture,
+                      int width, int height, String pageUrl) {
+        if (source == null) throw new NullPointerException("source");
+        this.source = source;
+        this.targetUrl = targetUrl == null ? "" : targetUrl;
+        this.targetName = targetName == null ? "" : targetName;
+        this.userGesture = userGesture;
+        this.width = width;
+        this.height = height;
+        this.pageUrl = pageUrl == null ? "" : pageUrl;
+    }
+
+    /** @return the opener WebView component; never null. */
+    public WebViewComponent source() { return source; }
+
+    /** @return the URL the popup will load; never null, may be empty
+     *  (empty when {@code window.open()} was called with no URL). */
+    public String targetUrl() { return targetUrl; }
+
+    /** @return the requested window name / target; never null, may be
+     *  empty. */
+    public String targetName() { return targetName; }
+
+    /** @return whether a user gesture initiated the popup. */
+    public boolean userGesture() { return userGesture; }
+
+    /** @return the requested popup width, or {@code -1} when the page did
+     *  not request an explicit size. */
+    public int width() { return width; }
+
+    /** @return the requested popup height, or {@code -1} when the page did
+     *  not request an explicit size. */
+    public int height() { return height; }
+
+    /** @return the opener page URL; never null, may be empty. */
+    public String pageUrl() { return pageUrl; }
+
+    @Override
+    public String toString() {
+        String u = targetUrl;
+        if (u.length() > 80) u = u.substring(0, 80) + "...";
+        return "WebViewPopupEvent[url=" + u + ", name=" + targetName
+            + ", size=" + width + "x" + height + "]";
+    }
+}

--- a/src/ca/weblite/webview/WebViewPopupHandler.java
+++ b/src/ca/weblite/webview/WebViewPopupHandler.java
@@ -1,0 +1,72 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+/**
+ * Application hook for browser-initiated popups — {@code window.open(url,
+ * name, features)} and clicks on links / forms with {@code target="_blank"}.
+ * Install one via
+ * {@link ca.weblite.webview.swing.WebViewComponent#setPopupHandler}.
+ *
+ * <h2>Native-owned window model</h2>
+ * When a popup is allowed, the <em>native engine</em> creates the child web
+ * view — linked to the opener so {@code window.opener} is non-null and
+ * {@code window.opener.postMessage(...)} works — and hosts it in a fresh
+ * native top-level window that the engine sizes, shows, and destroys.  The
+ * opener linkage is what makes OAuth "sign-in with popup" flows (which call
+ * {@code window.opener.postMessage} then {@code window.close()}) succeed.
+ * This handler only decides <em>policy</em> ({@link #popupRequested}) and
+ * <em>observes</em> the popup lifecycle ({@link #popupOpened} /
+ * {@link #popupClosed}); it does not open, host, or size the window.
+ *
+ * <h2>Threading</h2>
+ * {@link #popupRequested} runs on the <strong>native UI thread</strong>,
+ * <strong>synchronously</strong> and <strong>off the Swing EDT</strong>: the
+ * platform popup callback must return the allow/deny decision before yielding
+ * back to the browser engine and cannot round-trip to the EDT without risking
+ * a deadlock.  Implementations MUST be fast, thread-safe, and MUST NOT touch
+ * Swing state.  {@link #popupOpened} and {@link #popupClosed} are
+ * asynchronous notifications delivered on the EDT.
+ *
+ * <h2>Blocking popups</h2>
+ * The default handler {@linkplain #DEFAULT allows} every popup.  Passing
+ * {@code null} to {@code setPopupHandler} installs an internal drop handler
+ * whose {@link #popupRequested} returns {@code false}, blocking all popups
+ * ({@code window.open} returns {@code null}) — the pre-feature behaviour,
+ * available as an explicit opt-out.  Reset to the framework default by
+ * passing {@link #DEFAULT} explicitly.
+ */
+public interface WebViewPopupHandler {
+
+    /**
+     * Decide whether to allow a popup.  Runs on the native UI thread,
+     * synchronously, off the EDT — keep it fast and free of Swing access.
+     *
+     * @param event the popup request
+     * @return {@code true} to open the popup in a native window,
+     *         {@code false} to block it ({@code window.open} returns null)
+     */
+    default boolean popupRequested(WebViewPopupEvent event) {
+        return true;
+    }
+
+    /** Notification that a popup window has been created and shown.  Runs
+     *  on the Swing EDT.  Default is a no-op. */
+    default void popupOpened(WebViewPopupEvent event) {
+    }
+
+    /** Notification that a popup window has closed (the popup page called
+     *  {@code window.close()}, or the user closed the window).  Runs on the
+     *  Swing EDT.  Default is a no-op. */
+    default void popupClosed(WebViewPopupEvent event) {
+    }
+
+    /** The framework default: allows every popup, no-op notifications.
+     *  Installed when no caller has set a handler.  Stateless; safe to
+     *  share across components and threads. */
+    WebViewPopupHandler DEFAULT = new WebViewPopupHandler() {
+    };
+}

--- a/src/ca/weblite/webview/swing/WebViewComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewComponent.java
@@ -8,9 +8,11 @@ package ca.weblite.webview.swing;
 import ca.weblite.webview.ConsoleDispatcher;
 import ca.weblite.webview.ConsoleListener;
 import ca.weblite.webview.DialogDispatcher;
+import ca.weblite.webview.PopupDispatcher;
 import ca.weblite.webview.JavaScriptEvalException;
 import ca.weblite.webview.WebView;
 import ca.weblite.webview.WebViewDialogHandler;
+import ca.weblite.webview.WebViewPopupHandler;
 import ca.weblite.webview.WebViewMouseDispatcher;
 import ca.weblite.webview.WebViewMouseListener;
 
@@ -75,6 +77,13 @@ public abstract class WebViewComponent extends JComponent {
      *  on their native peer at peer-attach time that delegates to this
      *  dispatcher's {@code dispatch*} methods. */
     protected final DialogDispatcher dialogDispatcher = new DialogDispatcher(this);
+
+    /** Per-component fan-out hub for browser-initiated popups
+     *  ({@code window.open}).  Subclasses install a
+     *  {@link ca.weblite.webview.WebViewPopupCallback} on their native peer at
+     *  peer-attach time that delegates to this dispatcher's {@code dispatch*}
+     *  methods. */
+    protected final PopupDispatcher popupDispatcher = new PopupDispatcher(this);
 
     /** Implementation mode for {@link #create(Mode)}. */
     public enum Mode {
@@ -505,5 +514,39 @@ public abstract class WebViewComponent extends JComponent {
      */
     public final WebViewDialogHandler getDialogHandler() {
         return dialogDispatcher.getHandler();
+    }
+
+    /**
+     * Install the handler for browser-initiated popups
+     * ({@code window.open}, {@code target="_blank"}).  When a popup is
+     * allowed the native engine opens it in a separate native window linked
+     * to the opener (so OAuth "sign-in with popup" flows work).
+     *
+     * <p>Passing {@code null} installs an internal drop handler that blocks
+     * all popups ({@code window.open} returns {@code null}) — the pre-feature
+     * behaviour, available as an explicit opt-out.  To reset to the framework
+     * default (allow all), pass {@link WebViewPopupHandler#DEFAULT}
+     * explicitly.
+     *
+     * <p>See {@link WebViewPopupHandler} for the full contract, including the
+     * native-owned-window model and the threading rules
+     * ({@code popupRequested} runs on the native UI thread; notifications run
+     * on the EDT).
+     *
+     * @return {@code this} for chaining
+     */
+    public final WebViewComponent setPopupHandler(WebViewPopupHandler handler) {
+        popupDispatcher.setHandler(handler);
+        return this;
+    }
+
+    /**
+     * @return the active {@link WebViewPopupHandler}.  Never returns
+     * {@code null} — returns {@link WebViewPopupHandler#DEFAULT} when no
+     * caller has installed one, and returns the internal drop singleton when
+     * caller passed {@code null} to {@link #setPopupHandler}.
+     */
+    public final WebViewPopupHandler getPopupHandler() {
+        return popupDispatcher.getHandler();
     }
 }

--- a/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
@@ -13,6 +13,7 @@ import ca.weblite.webview.JavascriptFunction;
 import ca.weblite.webview.WebView;
 import ca.weblite.webview.WebViewClickCallback;
 import ca.weblite.webview.WebViewDialogCallback;
+import ca.weblite.webview.WebViewPopupCallback;
 import ca.weblite.webview.WebViewFocusCallback;
 import ca.weblite.webview.WebViewAttachListener;
 import ca.weblite.webview.WebViewMouseDispatcher;
@@ -237,6 +238,7 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
         // false / null / empty) without invoking the handler against
         // a half-disposed component.
         dialogDispatcher.disposeAll();
+        popupDispatcher.disposeAll();
         if (embedded != null) {
             EmbeddedWebView e = embedded;
             embedded = null;
@@ -594,6 +596,33 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
                                          String frameUrl) {
                 return dialogDispatcher.dispatchFilePicker(
                     multiple, mimeTypes, extensions, pageUrl, frameUrl);
+            }
+        });
+        // Install the popup bridge so window.open / target=_blank route to
+        // the per-component WebViewPopupHandler.  onPopupRequested returns
+        // the allow/deny decision synchronously on the native UI thread (no
+        // EDT hop); onPopupOpened / onPopupClosed are async notifications the
+        // dispatcher marshals to the EDT via invokeLater.
+        embedded.setPopupCallback(new WebViewPopupCallback() {
+            @Override
+            public boolean onPopupRequested(String targetUrl, String targetName,
+                                            boolean userGesture, int width,
+                                            int height, String pageUrl) {
+                return popupDispatcher.dispatchPopupRequested(
+                    targetUrl, targetName, userGesture, width, height, pageUrl);
+            }
+            @Override
+            public void onPopupOpened(long popupId, String targetUrl,
+                                      String targetName, boolean userGesture,
+                                      int width, int height, String pageUrl) {
+                popupDispatcher.dispatchPopupOpened(
+                    popupId, targetUrl, targetName, userGesture, width, height,
+                    pageUrl);
+            }
+            @Override
+            public void onPopupClosed(long popupId, String targetUrl,
+                                      String pageUrl) {
+                popupDispatcher.dispatchPopupClosed(popupId, targetUrl, pageUrl);
             }
         });
         // Seed the peer's initial visibility from the component's current

--- a/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
@@ -13,6 +13,7 @@ import ca.weblite.webview.JavascriptFunction;
 import ca.weblite.webview.OffscreenWebView;
 import ca.weblite.webview.WebView;
 import ca.weblite.webview.WebViewDialogCallback;
+import ca.weblite.webview.WebViewPopupCallback;
 import ca.weblite.webview.WebViewMouseDispatcher;
 
 import java.awt.Color;
@@ -278,6 +279,32 @@ public class WebViewLightweightComponent extends WebViewComponent {
                     multiple, mimeTypes, extensions, pageUrl, frameUrl);
             }
         });
+        // Install the popup bridge (window.open) on the offscreen engine.
+        // Linux dispatches via the WebKitGTK create signal; on macOS /
+        // Windows the offscreen engine is a stub and this call is a
+        // native-side no-op.
+        engine.setPopupCallback(new WebViewPopupCallback() {
+            @Override
+            public boolean onPopupRequested(String targetUrl, String targetName,
+                                            boolean userGesture, int width,
+                                            int height, String pageUrl) {
+                return popupDispatcher.dispatchPopupRequested(
+                    targetUrl, targetName, userGesture, width, height, pageUrl);
+            }
+            @Override
+            public void onPopupOpened(long popupId, String targetUrl,
+                                      String targetName, boolean userGesture,
+                                      int width, int height, String pageUrl) {
+                popupDispatcher.dispatchPopupOpened(
+                    popupId, targetUrl, targetName, userGesture, width, height,
+                    pageUrl);
+            }
+            @Override
+            public void onPopupClosed(long popupId, String targetUrl,
+                                      String pageUrl) {
+                popupDispatcher.dispatchPopupClosed(popupId, targetUrl, pageUrl);
+            }
+        });
         for (String js : pendingInit) {
             engine.addOnBeforeLoad(js);
         }
@@ -315,6 +342,7 @@ public class WebViewLightweightComponent extends WebViewComponent {
         // native side mid-teardown returns the safe fallback without
         // invoking the handler against a half-disposed component.
         dialogDispatcher.disposeAll();
+        popupDispatcher.disposeAll();
         if (engine != null) {
             OffscreenWebView ow = engine;
             engine = null;

--- a/src_c/webkit_loader.cpp
+++ b/src_c/webkit_loader.cpp
@@ -1,0 +1,119 @@
+// webkit_loader.cpp
+//
+// Linux-only. Resolves WebKitGTK / JavaScriptCore at runtime (dlopen + dlsym),
+// preferring the 4.1 SONAMEs and falling back to 4.0, so a single libwebview.so
+// runs on both. See webkit_loader.h for the design and the symbol inventory.
+//
+// This file deliberately does NOT include webkit_shim.h: it assigns the real
+// g_wk members and resolves symbols by string name.
+#include "webkit_loader.h"
+
+#if defined(WEBVIEW_GTK) || defined(__linux__)
+
+#include <dlfcn.h>
+#include <jni.h>
+#include <cstdio>
+#include <cstring>
+
+// The single runtime-resolved pointer table.
+WkFns g_wk;
+
+namespace {
+
+// Candidate SONAMEs. 4.1 is preferred; 4.0 is the fallback.
+const char *const kWebKit41 = "libwebkit2gtk-4.1.so.0";
+const char *const kWebKit40 = "libwebkit2gtk-4.0.so.37";
+const char *const kJsc41 = "libjavascriptcoregtk-4.1.so.0";
+const char *const kJsc40 = "libjavascriptcoregtk-4.0.so.18";
+
+void *g_webkit_handle = nullptr;
+void *g_jsc_handle = nullptr;
+char g_err[512] = {0};
+
+// Resolve everything exactly once. Returns true on success; on failure writes
+// a diagnostic to g_err and returns false. Called only through the C++11
+// thread-safe function-local static in webkit_loader_ensure().
+bool do_init() {
+  // 1. WebKit: prefer 4.1, fall back to 4.0.
+  bool is_41 = true;
+  g_webkit_handle = dlopen(kWebKit41, RTLD_NOW | RTLD_GLOBAL);
+  if (!g_webkit_handle) {
+    g_webkit_handle = dlopen(kWebKit40, RTLD_NOW | RTLD_GLOBAL);
+    is_41 = false;
+  }
+  if (!g_webkit_handle) {
+    std::snprintf(g_err, sizeof(g_err),
+                  "swingwebview: unable to load the WebKitGTK runtime — tried "
+                  "'%s' then '%s' (%s). Install libwebkit2gtk-4.1-0 (Ubuntu "
+                  "22.04+) or libwebkit2gtk-4.0-37 (Ubuntu 20.04).",
+                  kWebKit41, kWebKit40, dlerror());
+    return false;
+  }
+
+  // 2. JavaScriptCore: match the WebKit generation so only one libsoup loads.
+  const char *jsc_primary = is_41 ? kJsc41 : kJsc40;
+  const char *jsc_secondary = is_41 ? kJsc40 : kJsc41;
+  g_jsc_handle = dlopen(jsc_primary, RTLD_NOW | RTLD_GLOBAL);
+  if (!g_jsc_handle) {
+    g_jsc_handle = dlopen(jsc_secondary, RTLD_NOW | RTLD_GLOBAL);
+  }
+  if (!g_jsc_handle) {
+    std::snprintf(g_err, sizeof(g_err),
+                  "swingwebview: unable to load the JavaScriptCore runtime — "
+                  "tried '%s' then '%s' (%s).",
+                  kJsc41, kJsc40, dlerror());
+    return false;
+  }
+
+  // 3. Resolve the symbol tables. First missing symbol wins the error.
+  const char *missing = nullptr;
+#define WK_RESOLVE(handle, sym)                                                \
+  do {                                                                         \
+    g_wk.fn_##sym =                                                            \
+        reinterpret_cast<decltype(g_wk.fn_##sym)>(dlsym((handle), #sym));      \
+    if (!g_wk.fn_##sym && !missing) missing = #sym;                            \
+  } while (0);
+#define WK_RESOLVE_WEBKIT(sym) WK_RESOLVE(g_webkit_handle, sym)
+#define WK_RESOLVE_JSC(sym) WK_RESOLVE(g_jsc_handle, sym)
+  WK_WEBKIT_SYMS(WK_RESOLVE_WEBKIT)
+  WK_WEBKIT_JS_SYMS(WK_RESOLVE_WEBKIT)
+  WK_JSC_JS_SYMS(WK_RESOLVE_JSC)
+#undef WK_RESOLVE_JSC
+#undef WK_RESOLVE_WEBKIT
+#undef WK_RESOLVE
+
+  if (missing) {
+    std::snprintf(g_err, sizeof(g_err),
+                  "swingwebview: the installed WebKitGTK runtime (%s) is "
+                  "missing required symbol '%s' — it is too old or incomplete.",
+                  is_41 ? kWebKit41 : kWebKit40, missing);
+    return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+bool webkit_loader_ensure(char *errbuf, size_t errlen) {
+  // C++11 guarantees thread-safe, once-only initialization of this static.
+  static const bool ok = do_init();
+  if (!ok && errbuf && errlen) {
+    std::snprintf(errbuf, errlen, "%s", g_err);
+  }
+  return ok;
+}
+
+// Resolve at library load time. Returning JNI_ERR makes System.load throw an
+// UnsatisfiedLinkError carrying our diagnostic — the same load-time failure
+// point as the old hard DT_NEEDED, but now naming both candidate SONAMEs.
+extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void * /*reserved*/) {
+  (void)vm;
+  char err[512];
+  if (!webkit_loader_ensure(err, sizeof(err))) {
+    std::fprintf(stderr, "%s\n", err);
+    return JNI_ERR;
+  }
+  return JNI_VERSION_1_6;
+}
+
+#endif  // WEBVIEW_GTK || __linux__

--- a/src_c/webkit_loader.h
+++ b/src_c/webkit_loader.h
@@ -1,0 +1,109 @@
+// webkit_loader.h
+//
+// Linux-only runtime resolver for WebKitGTK / JavaScriptCore.
+//
+// libwebview.so is built WITHOUT linking libwebkit2gtk / libjavascriptcoregtk
+// (see build-linux.sh and the Linux CI jobs). Instead every WebKit/JSC symbol
+// the wrapper calls is resolved at runtime into a typed function pointer here,
+// and the call sites are redirected to those pointers by webkit_shim.h. This
+// yields a single portable .so that runs on both WebKitGTK 4.1 (Ubuntu 22.04+)
+// and 4.0 (Ubuntu 20.04) hosts.
+//
+// This header is included by webkit_loader.cpp (the resolver) and, together
+// with webkit_shim.h, by the GTK call-site translation units (webview.h,
+// webview_embed.cpp). It is inert on non-Linux/non-GTK builds.
+#ifndef WEBLITE_WEBKIT_LOADER_H
+#define WEBLITE_WEBKIT_LOADER_H
+
+#if defined(WEBVIEW_GTK) || defined(__linux__)
+
+#include <cstddef>
+#include <JavaScriptCore/JavaScript.h>
+#include <webkit2/webkit2.h>
+
+// ---------------------------------------------------------------------------
+// Symbol inventory (X-macro lists). Keep in sync with the redirects in
+// webkit_shim.h. WK_WEBKIT_* symbols resolve from the libwebkit2gtk handle;
+// WK_JSC_* symbols resolve from the libjavascriptcoregtk handle.
+// ---------------------------------------------------------------------------
+#define WK_WEBKIT_SYMS(X)                                                      \
+  X(webkit_file_chooser_request_cancel)                                        \
+  X(webkit_file_chooser_request_get_mime_types)                                \
+  X(webkit_file_chooser_request_get_select_multiple)                           \
+  X(webkit_file_chooser_request_select_files)                                  \
+  X(webkit_navigation_action_get_request)                                      \
+  X(webkit_navigation_action_is_user_gesture)                                  \
+  X(webkit_script_dialog_confirm_set_confirmed)                                \
+  X(webkit_script_dialog_get_dialog_type)                                      \
+  X(webkit_script_dialog_get_message)                                          \
+  X(webkit_script_dialog_prompt_get_default_text)                              \
+  X(webkit_script_dialog_prompt_set_text)                                      \
+  X(webkit_settings_get_enable_developer_extras)                               \
+  X(webkit_settings_set_enable_developer_extras)                               \
+  X(webkit_settings_set_enable_write_console_messages_to_stdout)               \
+  X(webkit_settings_set_hardware_acceleration_policy)                          \
+  X(webkit_uri_request_get_uri)                                                \
+  X(webkit_user_content_manager_add_script)                                    \
+  X(webkit_user_content_manager_register_script_message_handler)               \
+  X(webkit_user_script_new)                                                    \
+  X(webkit_web_inspector_show)                                                 \
+  X(webkit_web_view_execute_editing_command)                                   \
+  X(webkit_web_view_get_inspector)                                             \
+  X(webkit_web_view_get_settings)                                              \
+  X(webkit_web_view_get_uri)                                                   \
+  X(webkit_web_view_get_user_content_manager)                                  \
+  X(webkit_web_view_get_window_properties)                                     \
+  X(webkit_web_view_load_uri)                                                  \
+  X(webkit_web_view_new)                                                       \
+  X(webkit_web_view_new_with_related_view)                                     \
+  X(webkit_web_view_run_javascript)                                            \
+  X(webkit_web_view_set_background_color)                                      \
+  X(webkit_web_view_set_input_method_context)                                  \
+  X(webkit_window_properties_get_geometry)
+
+// JS-result readers. Mirror webview.h's version gate EXACTLY: the pre-2.22
+// JSValueRef path (webkit_javascript_result_get_global_context / _get_value)
+// was removed from modern headers, so referencing it unconditionally would
+// fail to compile there. All target distros (Ubuntu 20.04+) ship >= 2.22.
+#if WEBKIT_MAJOR_VERSION >= 2 && WEBKIT_MINOR_VERSION >= 22
+#define WK_WEBKIT_JS_SYMS(X)                                                   \
+  X(webkit_javascript_result_get_js_value)
+#define WK_JSC_JS_SYMS(X)                                                      \
+  X(jsc_value_to_string)
+#else
+#define WK_WEBKIT_JS_SYMS(X)                                                   \
+  X(webkit_javascript_result_get_global_context)                              \
+  X(webkit_javascript_result_get_value)
+#define WK_JSC_JS_SYMS(X)                                                      \
+  X(JSValueToStringCopy)                                                       \
+  X(JSStringRelease)                                                           \
+  X(JSStringGetMaximumUTF8CStringSize)                                         \
+  X(JSStringGetUTF8CString)
+#endif
+
+// The pointer table. Member types are taken from the real declarations via
+// decltype — unevaluated, so this creates no link-time dependency on the
+// WebKit/JSC symbols.
+struct WkFns {
+// Members are prefixed `fn_` so the member name never collides with the real
+// symbol name used inside decltype(&sym) — an identical name would be
+// ill-formed ([class.mem] "changes meaning"). The shim maps `sym` -> `fn_sym`.
+#define WK_DECL_MEMBER(sym) decltype(&sym) fn_##sym;
+  WK_WEBKIT_SYMS(WK_DECL_MEMBER)
+  WK_WEBKIT_JS_SYMS(WK_DECL_MEMBER)
+  WK_JSC_JS_SYMS(WK_DECL_MEMBER)
+#undef WK_DECL_MEMBER
+};
+
+// The single resolved table (defined in webkit_loader.cpp). Call sites reach
+// it through the redirects in webkit_shim.h.
+extern WkFns g_wk;
+
+// Resolve the WebKit/JSC runtime once (idempotent, thread-safe). Returns true
+// on success. On failure, if errbuf/errlen are non-null, copies a diagnostic
+// message naming the candidate SONAMEs. Invoked from JNI_OnLoad; callers do
+// not normally need it directly.
+bool webkit_loader_ensure(char *errbuf, size_t errlen);
+
+#endif  // WEBVIEW_GTK || __linux__
+#endif  // WEBLITE_WEBKIT_LOADER_H

--- a/src_c/webkit_shim.h
+++ b/src_c/webkit_shim.h
@@ -1,0 +1,81 @@
+// webkit_shim.h
+//
+// Redirects every WebKitGTK / JavaScriptCore call site to the runtime-resolved
+// function pointers in g_wk (see webkit_loader.h). Include this AFTER the real
+// <webkit2/webkit2.h> / <JavaScriptCore/JavaScript.h> / <gtk/gtk.h> headers and
+// after webkit_loader.h, inside the GTK-only regions of webview.h and
+// webview_embed.cpp.
+//
+// Each redirect expands `foo(args)` to `(::g_wk.fn_foo)(args)`. The member token
+// `foo` is not re-expanded (the macro being expanded is not applied to its own
+// name), so this is self-reference-safe. Because no call site references the
+// real symbol any more, libwebview.so ends up with no undefined WebKit/JSC
+// symbols and therefore no DT_NEEDED on them — it loads under any binding mode.
+//
+// webkit_loader.cpp must NOT include this header: it assigns the real g_wk
+// members and dlsym()s symbols by string name.
+#ifndef WEBLITE_WEBKIT_SHIM_H
+#define WEBLITE_WEBKIT_SHIM_H
+
+#if defined(WEBVIEW_GTK) || defined(__linux__)
+
+#define webkit_file_chooser_request_cancel (::g_wk.fn_webkit_file_chooser_request_cancel)
+#define webkit_file_chooser_request_get_mime_types (::g_wk.fn_webkit_file_chooser_request_get_mime_types)
+#define webkit_file_chooser_request_get_select_multiple (::g_wk.fn_webkit_file_chooser_request_get_select_multiple)
+#define webkit_file_chooser_request_select_files (::g_wk.fn_webkit_file_chooser_request_select_files)
+#define webkit_navigation_action_get_request (::g_wk.fn_webkit_navigation_action_get_request)
+#define webkit_navigation_action_is_user_gesture (::g_wk.fn_webkit_navigation_action_is_user_gesture)
+#define webkit_script_dialog_confirm_set_confirmed (::g_wk.fn_webkit_script_dialog_confirm_set_confirmed)
+#define webkit_script_dialog_get_dialog_type (::g_wk.fn_webkit_script_dialog_get_dialog_type)
+#define webkit_script_dialog_get_message (::g_wk.fn_webkit_script_dialog_get_message)
+#define webkit_script_dialog_prompt_get_default_text (::g_wk.fn_webkit_script_dialog_prompt_get_default_text)
+#define webkit_script_dialog_prompt_set_text (::g_wk.fn_webkit_script_dialog_prompt_set_text)
+#define webkit_settings_get_enable_developer_extras (::g_wk.fn_webkit_settings_get_enable_developer_extras)
+#define webkit_settings_set_enable_developer_extras (::g_wk.fn_webkit_settings_set_enable_developer_extras)
+#define webkit_settings_set_enable_write_console_messages_to_stdout (::g_wk.fn_webkit_settings_set_enable_write_console_messages_to_stdout)
+#define webkit_settings_set_hardware_acceleration_policy (::g_wk.fn_webkit_settings_set_hardware_acceleration_policy)
+#define webkit_uri_request_get_uri (::g_wk.fn_webkit_uri_request_get_uri)
+#define webkit_user_content_manager_add_script (::g_wk.fn_webkit_user_content_manager_add_script)
+#define webkit_user_content_manager_register_script_message_handler (::g_wk.fn_webkit_user_content_manager_register_script_message_handler)
+#define webkit_user_script_new (::g_wk.fn_webkit_user_script_new)
+#define webkit_web_inspector_show (::g_wk.fn_webkit_web_inspector_show)
+#define webkit_web_view_execute_editing_command (::g_wk.fn_webkit_web_view_execute_editing_command)
+#define webkit_web_view_get_inspector (::g_wk.fn_webkit_web_view_get_inspector)
+#define webkit_web_view_get_settings (::g_wk.fn_webkit_web_view_get_settings)
+#define webkit_web_view_get_uri (::g_wk.fn_webkit_web_view_get_uri)
+#define webkit_web_view_get_user_content_manager (::g_wk.fn_webkit_web_view_get_user_content_manager)
+#define webkit_web_view_get_window_properties (::g_wk.fn_webkit_web_view_get_window_properties)
+#define webkit_web_view_load_uri (::g_wk.fn_webkit_web_view_load_uri)
+#define webkit_web_view_new (::g_wk.fn_webkit_web_view_new)
+#define webkit_web_view_new_with_related_view (::g_wk.fn_webkit_web_view_new_with_related_view)
+#define webkit_web_view_run_javascript (::g_wk.fn_webkit_web_view_run_javascript)
+#define webkit_web_view_set_background_color (::g_wk.fn_webkit_web_view_set_background_color)
+#define webkit_web_view_set_input_method_context (::g_wk.fn_webkit_web_view_set_input_method_context)
+#define webkit_window_properties_get_geometry (::g_wk.fn_webkit_window_properties_get_geometry)
+
+// JS-result readers — gate identically to webkit_loader.h / webview.h.
+#if WEBKIT_MAJOR_VERSION >= 2 && WEBKIT_MINOR_VERSION >= 22
+#define webkit_javascript_result_get_js_value (::g_wk.fn_webkit_javascript_result_get_js_value)
+#define jsc_value_to_string (::g_wk.fn_jsc_value_to_string)
+#else
+#define webkit_javascript_result_get_global_context (::g_wk.fn_webkit_javascript_result_get_global_context)
+#define webkit_javascript_result_get_value (::g_wk.fn_webkit_javascript_result_get_value)
+#define JSValueToStringCopy (::g_wk.fn_JSValueToStringCopy)
+#define JSStringRelease (::g_wk.fn_JSStringRelease)
+#define JSStringGetMaximumUTF8CStringSize (::g_wk.fn_JSStringGetMaximumUTF8CStringSize)
+#define JSStringGetUTF8CString (::g_wk.fn_JSStringGetUTF8CString)
+#endif
+
+// The only GObject cast macro used in the code is WEBKIT_WEB_VIEW, which
+// expands to a G_TYPE_CHECK_INSTANCE_CAST that references webkit_web_view_get_type
+// — an undefined-symbol reference we do NOT want. Replace it with a plain
+// pointer cast (the code always passes WebKitWebView-compatible pointers).
+// No WEBKIT_IS_* checks exist, and all other WEBKIT_* tokens are compile-time
+// enum/version constants, so nothing else needs neutralizing.
+#ifdef WEBKIT_WEB_VIEW
+#undef WEBKIT_WEB_VIEW
+#endif
+#define WEBKIT_WEB_VIEW(obj) ((WebKitWebView *)(void *)(obj))
+
+#endif  // WEBVIEW_GTK || __linux__
+#endif  // WEBLITE_WEBKIT_SHIM_H

--- a/src_c/webview.h
+++ b/src_c/webview.h
@@ -410,6 +410,11 @@ inline std::string json_parse(std::string s, std::string key, int index) {
 #include <gtk/gtk.h>
 #include <webkit2/webkit2.h>
 
+// Route WebKitGTK/JSC through the runtime-resolved loader so libwebview.so
+// carries no hard dependency on a specific webkit2gtk SONAME (4.0 vs 4.1).
+#include "webkit_loader.h"
+#include "webkit_shim.h"
+
 namespace webview {
 
 class browser_engine {

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -43,6 +43,9 @@
 #include <gdk/gdk.h>
 #include <gdk/gdkx.h>
 #include <webkit2/webkit2.h>
+// Route WebKitGTK/JSC through the runtime-resolved loader (no hard SONAME dep).
+#include "webkit_loader.h"
+#include "webkit_shim.h"
 #endif
 
 #ifdef WEBVIEW_COCOA

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -2997,6 +2997,10 @@ static void impl_run_open_panel(id self, SEL, id webView, id parameters,
 // the window and tears the child engine down.
 // ---------------------------------------------------------------------------
 
+// Forward declaration: impl_create_web_view (below) builds each child engine's
+// UI delegate from the shared class, whose definition follows this block.
+static Class get_webview_embed_ui_delegate_cls();
+
 // Fire an async notification (onPopupOpened / onPopupClosed) into Java on a
 // detached worker thread so AppKit main is not blocked.  Void return.
 static void fire_popup_notify_opened(JavaVM *jvm, jobject cb, jlong popup_id,
@@ -3134,8 +3138,12 @@ static id impl_create_web_view(id self, SEL, id webView, id configuration,
         if (jn) env->DeleteLocalRef(jn);
         if (jp) env->DeleteLocalRef(jp);
     }
-    if (attached) jvm->DetachCurrentThread();
-    if (!allow) return nullptr;
+    // NOTE: keep the thread attached until AFTER the child engine's global
+    // refs are created below — detaching here would invalidate `env`.
+    if (!allow) {
+        if (attached) jvm->DetachCurrentThread();
+        return nullptr;
+    }
 
     // Size the popup: use the requested size, else a typical auth-popup size.
     int W = req_w > 0 ? req_w : 500;
@@ -3145,7 +3153,10 @@ static id impl_create_web_view(id self, SEL, id webView, id configuration,
     id child = msg(objc_cls("WKWebView"), sel("alloc"));
     child = msg<id, CGRect, id>(child, sel("initWithFrame:configuration:"),
                                 CGRectMake(0, 0, W, H), configuration);
-    if (!child) return nullptr;
+    if (!child) {
+        if (attached) jvm->DetachCurrentThread();
+        return nullptr;
+    }
 
     // Host it in an engine-owned NSWindow (titled|closable|miniaturizable|
     // resizable = 1|2|4|8; NSBackingStoreBuffered = 2).
@@ -3166,7 +3177,7 @@ static id impl_create_web_view(id self, SEL, id webView, id configuration,
     child_e->config = configuration;
     child_e->manager = msg(configuration, sel("userContentController"));
     child_e->popup_window = win;
-    child_e->popup_id = (jlong)(intptr_t)child_e;
+    child_e->popup_id = (jlong)child_e;
     if (env) {
         child_e->popup_callback = env->NewGlobalRef(cb);
         if (e->dialog_callback)
@@ -3182,7 +3193,12 @@ static id impl_create_web_view(id self, SEL, id webView, id configuration,
         g_webview_map[child] = child_e;
     }
 
+    // Global refs are created; safe to detach now if we attached above.
+    if (attached) jvm->DetachCurrentThread();
+
     // Notify the opener's PopupDispatcher (async) that the popup is open.
+    // fire_popup_notify_opened attaches its own worker thread; it does not
+    // use `env`.
     fire_popup_notify_opened(jvm, cb, child_e->popup_id, target, "",
                              gesture, W, H, page);
     return child;

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -2212,6 +2212,20 @@ struct Engine {
     // released in cocoa_destroy_engine after we clear the WKWebView's
     // uiDelegate property.
     id ui_delegate = nullptr;
+
+    // JNI global ref to the registered WebViewPopupCallback, or nullptr.
+    // Read by the createWebViewWithConfiguration: / webViewDidClose:
+    // selectors to decide/notify popups.  For a child (popup) engine this
+    // is inherited from the opener at creation so onPopupClosed can reach
+    // the opener's PopupDispatcher.  Cleared before ui_delegate is
+    // released.
+    jobject popup_callback = nullptr;
+
+    // For a child (popup) engine only: the NSWindow the engine created to
+    // host the popup web view, and the opaque id correlating the
+    // onPopupOpened / onPopupClosed pair.  nullptr / 0 on a normal engine.
+    id popup_window = nullptr;
+    jlong popup_id = 0;
 };
 
 // Process-global map from WKWebView (id) to its owning Engine*.  Populated
@@ -2966,6 +2980,272 @@ static void impl_run_open_panel(id self, SEL, id webView, id parameters,
     }).detach();
 }
 
+// ---------------------------------------------------------------------------
+// Popup (window.open) support — Canvas 15.
+//
+// window.open / target=_blank is delivered to WKWebView through the
+// WKUIDelegate selector
+//   webView:createWebViewWithConfiguration:forNavigationAction:windowFeatures:
+// which must RETURN the child WKWebView (or nil to block) synchronously.
+// Unlike the dialog selectors (which defer to a worker thread and fire a
+// completion handler), the popup channel needs the decision inline, so the
+// allow/deny hop into Java (onPopupRequested) is synchronous on AppKit main.
+// The child web view is created from the SAME WKWebViewConfiguration WebKit
+// hands us so it is LINKED to the opener (window.opener / postMessage work —
+// required for OAuth signInWithPopup).  We host it in an NSWindow the engine
+// owns.  window.close() from the popup fires webViewDidClose:, which closes
+// the window and tears the child engine down.
+// ---------------------------------------------------------------------------
+
+// Fire an async notification (onPopupOpened / onPopupClosed) into Java on a
+// detached worker thread so AppKit main is not blocked.  Void return.
+static void fire_popup_notify_opened(JavaVM *jvm, jobject cb, jlong popup_id,
+                                     std::string url, std::string name,
+                                     bool gesture, int w, int h,
+                                     std::string page) {
+    if (!jvm || !cb) return;
+    std::thread([jvm, cb, popup_id, url, name, gesture, w, h, page]() {
+        JNIEnv *env = nullptr;
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return;
+        jstring ju = env->NewStringUTF(url.c_str());
+        jstring jn = env->NewStringUTF(name.c_str());
+        jstring jp = env->NewStringUTF(page.c_str());
+        jclass cls = env->GetObjectClass(cb);
+        if (cls) {
+            jmethodID mid = env->GetMethodID(cls, "onPopupOpened",
+                "(JLjava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)V");
+            if (mid) {
+                env->CallVoidMethod(cb, mid, popup_id, ju, jn,
+                                    gesture ? JNI_TRUE : JNI_FALSE,
+                                    (jint)w, (jint)h, jp);
+                if (env->ExceptionCheck()) {
+                    env->ExceptionDescribe();
+                    env->ExceptionClear();
+                }
+            }
+            env->DeleteLocalRef(cls);
+        }
+        if (ju) env->DeleteLocalRef(ju);
+        if (jn) env->DeleteLocalRef(jn);
+        if (jp) env->DeleteLocalRef(jp);
+        jvm->DetachCurrentThread();
+    }).detach();
+}
+
+// Fires onPopupClosed and then takes ownership of the child engine's two
+// inherited global refs (popup_cb, dialog_cb), deleting them after the JNI
+// call.  Ownership transfer avoids a use-after-free: the caller must NOT
+// delete these refs itself (the async worker outlives the caller's teardown).
+// dialog_cb may be nullptr.
+static void fire_popup_notify_closed(JavaVM *jvm, jobject popup_cb,
+                                     jobject dialog_cb, jlong popup_id,
+                                     std::string url, std::string page) {
+    if (!jvm) return;
+    std::thread([jvm, popup_cb, dialog_cb, popup_id, url, page]() {
+        JNIEnv *env = nullptr;
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return;
+        if (popup_cb) {
+            jstring ju = env->NewStringUTF(url.c_str());
+            jstring jp = env->NewStringUTF(page.c_str());
+            jclass cls = env->GetObjectClass(popup_cb);
+            if (cls) {
+                jmethodID mid = env->GetMethodID(cls, "onPopupClosed",
+                    "(JLjava/lang/String;Ljava/lang/String;)V");
+                if (mid) {
+                    env->CallVoidMethod(popup_cb, mid, popup_id, ju, jp);
+                    if (env->ExceptionCheck()) {
+                        env->ExceptionDescribe();
+                        env->ExceptionClear();
+                    }
+                }
+                env->DeleteLocalRef(cls);
+            }
+            if (ju) env->DeleteLocalRef(ju);
+            if (jp) env->DeleteLocalRef(jp);
+        }
+        // Now free the inherited global refs (ownership transferred to us).
+        if (popup_cb) env->DeleteGlobalRef(popup_cb);
+        if (dialog_cb) env->DeleteGlobalRef(dialog_cb);
+        jvm->DetachCurrentThread();
+    }).detach();
+}
+
+// Read an NSNumber* (or nil) window-feature dimension into an int, or -1.
+static int popup_feature_int(id nsNumber) {
+    if (!nsNumber) return -1;
+    return (int)msg<int>(nsNumber, sel("intValue"));
+}
+
+// WKUIDelegate createWebViewWithConfiguration:forNavigationAction:windowFeatures:
+// Returns the child WKWebView, or nil to block.
+static id impl_create_web_view(id self, SEL, id webView, id configuration,
+                               id navigationAction, id windowFeatures) {
+    Engine *e = (Engine *)objc_getAssociatedObject(self, "eng");
+    if (!e || !e->popup_callback) return nullptr;
+
+    // Extract the request URL, gesture, and requested size.
+    std::string target;
+    {
+        id req = msg(navigationAction, sel("request"));
+        id url = req ? msg(req, sel("URL")) : nullptr;
+        id abs = url ? msg(url, sel("absoluteString")) : nullptr;
+        if (abs) target = ns_string_to_utf8(abs);
+    }
+    std::string page = page_url_utf8(webView);
+    int req_w = popup_feature_int(msg(windowFeatures, sel("width")));
+    int req_h = popup_feature_int(msg(windowFeatures, sel("height")));
+    // window.open in practice requires a user gesture; report true.
+    bool gesture = true;
+
+    // Synchronous allow/deny hop into Java (AppKit main -> JNI).
+    JavaVM *jvm = e->jvm;
+    jobject cb = e->popup_callback;
+    JNIEnv *env = nullptr;
+    bool attached = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return nullptr;
+        attached = true;
+    }
+    bool allow = false;
+    {
+        jstring ju = env->NewStringUTF(target.c_str());
+        jstring jn = env->NewStringUTF("");
+        jstring jp = env->NewStringUTF(page.c_str());
+        jclass cls = env->GetObjectClass(cb);
+        if (cls) {
+            jmethodID mid = env->GetMethodID(cls, "onPopupRequested",
+                "(Ljava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)Z");
+            if (mid) {
+                jboolean r = env->CallBooleanMethod(cb, mid, ju, jn,
+                    gesture ? JNI_TRUE : JNI_FALSE, (jint)req_w, (jint)req_h, jp);
+                if (env->ExceptionCheck()) {
+                    env->ExceptionDescribe();
+                    env->ExceptionClear();
+                    r = JNI_FALSE;
+                }
+                allow = (r == JNI_TRUE);
+            }
+            env->DeleteLocalRef(cls);
+        }
+        if (ju) env->DeleteLocalRef(ju);
+        if (jn) env->DeleteLocalRef(jn);
+        if (jp) env->DeleteLocalRef(jp);
+    }
+    if (attached) jvm->DetachCurrentThread();
+    if (!allow) return nullptr;
+
+    // Size the popup: use the requested size, else a typical auth-popup size.
+    int W = req_w > 0 ? req_w : 500;
+    int H = req_h > 0 ? req_h : 650;
+
+    // Create the child WKWebView LINKED to the opener via the passed config.
+    id child = msg(objc_cls("WKWebView"), sel("alloc"));
+    child = msg<id, CGRect, id>(child, sel("initWithFrame:configuration:"),
+                                CGRectMake(0, 0, W, H), configuration);
+    if (!child) return nullptr;
+
+    // Host it in an engine-owned NSWindow (titled|closable|miniaturizable|
+    // resizable = 1|2|4|8; NSBackingStoreBuffered = 2).
+    id win = msg(objc_cls("NSWindow"), sel("alloc"));
+    win = msg<id, CGRect, unsigned long, unsigned long, BOOL>(
+        win, sel("initWithContentRect:styleMask:backing:defer:"),
+        CGRectMake(0, 0, W, H), (unsigned long)15, (unsigned long)2, NO);
+    msg<void, id>(win, sel("setTitle:"), ns_str("Popup"));
+    msg<void, id>(win, sel("setContentView:"), child);
+    msg<void>(win, sel("center"));
+    msg<void, id>(win, sel("makeKeyAndOrderFront:"), nullptr);
+
+    // Build the child Engine, inheriting the opener's callbacks so the popup
+    // supports dialogs / nested popups and can notify onPopupClosed.
+    Engine *child_e = new Engine();
+    child_e->webview = child;
+    child_e->jvm = jvm;
+    child_e->config = configuration;
+    child_e->manager = msg(configuration, sel("userContentController"));
+    child_e->popup_window = win;
+    child_e->popup_id = (jlong)(intptr_t)child_e;
+    if (env) {
+        child_e->popup_callback = env->NewGlobalRef(cb);
+        if (e->dialog_callback)
+            child_e->dialog_callback = env->NewGlobalRef(e->dialog_callback);
+    }
+    Class uicls = get_webview_embed_ui_delegate_cls();
+    id ui = msg((id)uicls, sel("new"));
+    objc_setAssociatedObject(ui, "eng", (id)child_e, OBJC_ASSOCIATION_ASSIGN);
+    msg<void, id>(child, sel("setUIDelegate:"), ui);
+    child_e->ui_delegate = ui;
+    {
+        std::lock_guard<std::mutex> lk(g_webview_map_mutex);
+        g_webview_map[child] = child_e;
+    }
+
+    // Notify the opener's PopupDispatcher (async) that the popup is open.
+    fire_popup_notify_opened(jvm, cb, child_e->popup_id, target, "",
+                             gesture, W, H, page);
+    return child;
+}
+
+// WKUIDelegate webViewDidClose: — the popup called window.close().  Runs on
+// AppKit main.  We tear down the child engine's native objects synchronously
+// here and hand the inherited Java global refs to the async close-notify
+// worker, which fires onPopupClosed and then frees them (ownership transfer —
+// see fire_popup_notify_closed).  The worker only reads captured-by-value
+// state, never `e`, so deleting `e` here is safe.
+static void impl_web_view_did_close(id self, SEL, id webView) {
+    Engine *e = (Engine *)objc_getAssociatedObject(self, "eng");
+    if (!e) return;
+    std::string url = page_url_utf8(webView);
+    JavaVM *jvm = e->jvm;
+    jobject popup_cb = e->popup_callback;
+    jobject dialog_cb = e->dialog_callback;
+    jlong pid = e->popup_id;
+
+    // Detach the delegate and drop from the map BEFORE releasing so no
+    // in-flight selector dereferences a freed engine.
+    msg<void, id>(webView, sel("setUIDelegate:"), nullptr);
+    {
+        std::lock_guard<std::mutex> lk(g_webview_map_mutex);
+        g_webview_map.erase(webView);
+    }
+    if (e->popup_window) {
+        msg<void>(e->popup_window, sel("close"));
+    }
+
+    // Notify Java and transfer ownership of the two inherited global refs.
+    fire_popup_notify_closed(jvm, popup_cb, dialog_cb, pid, url, "");
+
+    // Release native objects and free the engine.  The refs are now owned by
+    // the worker, so we must not touch them here.
+    e->popup_callback = nullptr;
+    e->dialog_callback = nullptr;
+    if (e->ui_delegate) { msg(e->ui_delegate, sel("release")); e->ui_delegate = nullptr; }
+    if (e->popup_window) { msg(e->popup_window, sel("release")); e->popup_window = nullptr; }
+    // Balance the +1 from the [[WKWebView alloc] init...] in
+    // impl_create_web_view.  WebKit and (until now) the NSWindow contentView
+    // held their own refs; releasing our alloc ref lets the child web view
+    // deallocate once WebKit drops its reference.  (Retain/release balance
+    // here is a prime candidate for on-device zombie/Instruments validation.)
+    if (e->webview) { msg(e->webview, sel("release")); }
+    e->webview = nullptr;
+    delete e;
+}
+
+// Register (or clear, when cb is null) the Java WebViewPopupCallback for this
+// engine.  Mirrors cocoa_set_dialog_callback.
+static void cocoa_set_popup_callback(Engine *e, JNIEnv *env, jobject cb) {
+    if (!e) return;
+    if (e->popup_callback) {
+        env->DeleteGlobalRef(e->popup_callback);
+        e->popup_callback = nullptr;
+    }
+    if (cb) {
+        e->popup_callback = env->NewGlobalRef(cb);
+    }
+}
+
 static Class get_webview_embed_ui_delegate_cls() {
     std::call_once(g_webview_embed_ui_delegate_once, [] {
         Class c = objc_allocateClassPair((Class)objc_cls("NSObject"),
@@ -2991,6 +3271,16 @@ static Class get_webview_embed_ui_delegate_cls() {
             sel("webView:runOpenPanelWithParameters:"
                 "initiatedByFrame:completionHandler:"),
             (IMP)impl_run_open_panel, "v@:@@@@");
+        // Popup (window.open) support — Canvas 15.
+        class_addMethod(
+            c,
+            sel("webView:createWebViewWithConfiguration:"
+                "forNavigationAction:windowFeatures:"),
+            (IMP)impl_create_web_view, "@@:@@@@");
+        class_addMethod(
+            c,
+            sel("webViewDidClose:"),
+            (IMP)impl_web_view_did_close, "v@:@");
         objc_registerClassPair(c);
         g_webview_embed_ui_delegate_cls = c;
     });
@@ -4566,6 +4856,28 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
     // OffscreenWebView.create returns null on those platforms.
     (void)env; (void)cb;
 #endif
+}
+
+// Popup (window.open) callback registration — Canvas 15.  macOS is wired in
+// this iteration; the Linux (GTK) and Windows native popup sites land in the
+// follow-up coverage canvases, so those branches are a no-op for now and
+// window.open stays blocked there (the Java handler reference is held but no
+// native callback is invoked).
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1popup_1callback
+  (JNIEnv *env, jclass, jlong wv, jobject cb) {
+    if (wv == 0) return;
+#if defined(WEBVIEW_COCOA)
+    embed::cocoa_set_popup_callback((embed::Engine *)wv, env, cb);
+#else
+    (void)env; (void)cb;
+#endif
+}
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1set_1popup_1callback
+  (JNIEnv *env, jclass, jlong peer, jobject cb) {
+    if (peer == 0) return;
+    // Offscreen popup support lands with Linux coverage (Canvas 16).
+    (void)env; (void)cb;
 }
 
 } // extern "C"

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -409,6 +409,15 @@ struct Engine {
     // the global ref without dropping the canvas-004-002 changes.
     jobject dialog_callback = nullptr;
 
+    // JNI global ref to the registered WebViewPopupCallback, or nullptr.
+    // Populated by gtk_set_popup_callback; cleared in gtk_destroy_engine.
+    // The `create` signal handler wired in gtk_create_engine invokes it
+    // (onPopupRequested / onPopupOpened / onPopupClosed) so window.open /
+    // target=_blank open a native GTK popup window linked to the opener --
+    // Canvas 16.  A child (popup) web view inherits this ref via its own
+    // PopupEngine so nested popups work.
+    jobject popup_callback = nullptr;
+
     Engine() {}
     ~Engine() {}
 };
@@ -837,6 +846,324 @@ static gboolean on_run_file_chooser_engine(WebKitWebView *web,
     return handle_run_file_chooser(e->jvm, e->dialog_callback, uri, request);
 }
 
+// ---------------------------------------------------------------------------
+// Popup (window.open) support — Canvas 16 (Linux / WebKitGTK).
+//
+// window.open / target=_blank is delivered to a WebKitWebView through the
+// `create` signal, whose handler must RETURN a new (linked) WebKitWebView for
+// WebKit to drive, or NULL to block.  The child is created with
+// webkit_web_view_new_with_related_view(opener) so it is LINKED to the opener
+// (window.opener / postMessage work — required for OAuth signInWithPopup) and
+// hosted in an engine-owned GTK_WINDOW_TOPLEVEL.  ready-to-show sizes/shows the
+// window and fires onPopupOpened; close destroys it and fires onPopupClosed.
+//
+// The allow/deny hop (onPopupRequested) is SYNCHRONOUS on the GTK main thread
+// (the create handler must return the child before yielding to WebKit), exactly
+// like the script-dialog confirm path.  onPopupOpened / onPopupClosed are
+// fire-and-forget; the Java PopupDispatcher marshals them to the EDT via
+// invokeLater (non-blocking), so the GTK main thread is never blocked — no
+// detached worker thread is needed (unlike the macOS AppKit-main path).
+// ---------------------------------------------------------------------------
+
+// A child popup's native state: a standalone on-screen GTK toplevel hosting a
+// WebKit-related child web view.  Distinct from Engine / OffEngine — no AWT
+// reparenting, no offscreen blitting.  The inherited popup_callback /
+// dialog_callback global refs are freed in on_close_popup.
+struct PopupEngine {
+    GtkWidget *window = nullptr;        // GTK_WINDOW_TOPLEVEL
+    WebKitWebView *web = nullptr;       // the related child web view
+    JavaVM *jvm = nullptr;
+    jobject popup_callback = nullptr;   // inherited global ref
+    jobject dialog_callback = nullptr;  // inherited global ref, may be null
+    jlong popup_id = 0;
+};
+
+// Synchronous allow/deny hop into Java on the GTK main thread.  Returns false
+// on null callback, attach failure, or any exception (block-on-error default).
+static bool fire_popup_requested(JavaVM *jvm, jobject cb,
+                                 const char *url, const char *name,
+                                 bool gesture, int w, int h,
+                                 const char *page) {
+    if (!jvm || !cb) return false;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return false;
+        detach = true;
+    }
+    bool allow = false;
+    jstring ju = env->NewStringUTF(url ? url : "");
+    jstring jn = env->NewStringUTF(name ? name : "");
+    jstring jp = env->NewStringUTF(page ? page : "");
+    jclass cls = env->GetObjectClass(cb);
+    if (cls) {
+        jmethodID mid = env->GetMethodID(cls, "onPopupRequested",
+            "(Ljava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)Z");
+        if (mid) {
+            jboolean r = env->CallBooleanMethod(cb, mid, ju, jn,
+                gesture ? JNI_TRUE : JNI_FALSE, (jint)w, (jint)h, jp);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+                r = JNI_FALSE;
+            }
+            allow = (r == JNI_TRUE);
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (ju) env->DeleteLocalRef(ju);
+    if (jn) env->DeleteLocalRef(jn);
+    if (jp) env->DeleteLocalRef(jp);
+    if (detach) jvm->DetachCurrentThread();
+    return allow;
+}
+
+// Fire onPopupOpened.  CallVoidMethod (fire-and-forget); the Java dispatcher
+// marshals to the EDT via invokeLater so this does not block the GTK main
+// thread.
+static void fire_gtk_popup_opened(JavaVM *jvm, jobject cb, jlong popup_id,
+                                  const char *url, const char *name,
+                                  bool gesture, int w, int h,
+                                  const char *page) {
+    if (!jvm || !cb) return;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return;
+        detach = true;
+    }
+    jstring ju = env->NewStringUTF(url ? url : "");
+    jstring jn = env->NewStringUTF(name ? name : "");
+    jstring jp = env->NewStringUTF(page ? page : "");
+    jclass cls = env->GetObjectClass(cb);
+    if (cls) {
+        jmethodID mid = env->GetMethodID(cls, "onPopupOpened",
+            "(JLjava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)V");
+        if (mid) {
+            env->CallVoidMethod(cb, mid, popup_id, ju, jn,
+                gesture ? JNI_TRUE : JNI_FALSE, (jint)w, (jint)h, jp);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (ju) env->DeleteLocalRef(ju);
+    if (jn) env->DeleteLocalRef(jn);
+    if (jp) env->DeleteLocalRef(jp);
+    if (detach) jvm->DetachCurrentThread();
+}
+
+// Fire onPopupClosed.  Does NOT delete the inherited global refs — the caller
+// (on_close_popup) frees them after this synchronous call returns.  dialog_cb
+// is unused here; it is freed by the caller alongside popup_cb.
+static void fire_gtk_popup_closed(JavaVM *jvm, jobject popup_cb,
+                                  jobject dialog_cb, jlong popup_id,
+                                  const char *url, const char *page) {
+    (void)dialog_cb;
+    if (!jvm || !popup_cb) return;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return;
+        detach = true;
+    }
+    jstring ju = env->NewStringUTF(url ? url : "");
+    jstring jp = env->NewStringUTF(page ? page : "");
+    jclass cls = env->GetObjectClass(popup_cb);
+    if (cls) {
+        jmethodID mid = env->GetMethodID(cls, "onPopupClosed",
+            "(JLjava/lang/String;Ljava/lang/String;)V");
+        if (mid) {
+            env->CallVoidMethod(popup_cb, mid, popup_id, ju, jp);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (ju) env->DeleteLocalRef(ju);
+    if (jp) env->DeleteLocalRef(jp);
+    if (detach) jvm->DetachCurrentThread();
+}
+
+// Forward declarations for the child-popup signal handlers (defined below;
+// referenced by handle_create_web_view when connecting the child's signals).
+static GtkWidget *on_create_web_view_popup(WebKitWebView *web,
+        WebKitNavigationAction *nav, gpointer user_data);
+static gboolean on_script_dialog_popup(WebKitWebView *web,
+        WebKitScriptDialog *dialog, gpointer user_data);
+static gboolean on_run_file_chooser_popup(WebKitWebView *web,
+        WebKitFileChooserRequest *request, gpointer user_data);
+static void on_ready_to_show_popup(WebKitWebView *web, gpointer user_data);
+static void on_close_popup(WebKitWebView *web, gpointer user_data);
+
+// Shared inner handler for the `create` signal.  Engine-agnostic: the three
+// wrappers (engine / off_engine / popup) pull jvm + popup_callback +
+// dialog_callback from their struct and call here.  Returns a new linked child
+// WebKitWebView for WebKit to adopt, or NULL to block the popup.
+static GtkWidget *handle_create_web_view(JavaVM *jvm, jobject popup_cb,
+                                         jobject dialog_cb,
+                                         WebKitWebView *opener,
+                                         WebKitNavigationAction *nav) {
+    if (!popup_cb) return NULL;
+
+    const char *uri = "";
+    if (nav) {
+        WebKitURIRequest *req = webkit_navigation_action_get_request(nav);
+        if (req) {
+            const char *u = webkit_uri_request_get_uri(req);
+            if (u) uri = u;
+        }
+    }
+    bool gesture =
+        nav ? (webkit_navigation_action_is_user_gesture(nav) != FALSE) : true;
+    const char *page = opener ? webkit_web_view_get_uri(opener) : nullptr;
+    if (!page) page = "";
+
+    // Synchronous allow/deny.  Size is not known until ready-to-show, so pass
+    // -1/-1 here (matching the event contract's "unspecified" sentinel).
+    if (!fire_popup_requested(jvm, popup_cb, uri, "", gesture, -1, -1, page))
+        return NULL;
+
+    // Create the child LINKED to the opener (window.opener / postMessage).
+    GtkWidget *childw = webkit_web_view_new_with_related_view(opener);
+    if (!childw) return NULL;
+    WebKitWebView *child = WEBKIT_WEB_VIEW(childw);
+
+    // Host it in an engine-owned native top-level window.
+    GtkWidget *win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+    gtk_window_set_title(GTK_WINDOW(win), "Popup");
+    gtk_container_add(GTK_CONTAINER(win), childw);
+
+    PopupEngine *pe = new PopupEngine();
+    pe->window = win;
+    pe->web = child;
+    pe->jvm = jvm;
+    pe->popup_id = (jlong)(intptr_t)pe;
+
+    // Inherit fresh global refs so the popup can raise dialogs / nested popups
+    // and notify onPopupClosed even after the opener is gone.
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) == JNI_OK)
+            detach = true;
+    }
+    if (env) {
+        pe->popup_callback = env->NewGlobalRef(popup_cb);
+        if (dialog_cb) pe->dialog_callback = env->NewGlobalRef(dialog_cb);
+        if (detach) jvm->DetachCurrentThread();
+    }
+
+    // Nested popups + dialogs from inside the popup, and the show/close hooks.
+    g_signal_connect(child, "create",
+                     (GCallback)on_create_web_view_popup, pe);
+    g_signal_connect(child, "script-dialog",
+                     (GCallback)on_script_dialog_popup, pe);
+    g_signal_connect(child, "run-file-chooser",
+                     (GCallback)on_run_file_chooser_popup, pe);
+    g_signal_connect(child, "ready-to-show",
+                     (GCallback)on_ready_to_show_popup, pe);
+    g_signal_connect(child, "close",
+                     (GCallback)on_close_popup, pe);
+
+    // WebKit adopts the floating reference on the returned view.
+    return childw;
+}
+
+// child `ready-to-show`: size from window properties (fallback 500x650), show,
+// then notify onPopupOpened.
+static void on_ready_to_show_popup(WebKitWebView *web, gpointer user_data) {
+    PopupEngine *pe = static_cast<PopupEngine *>(user_data);
+    if (!pe) return;
+    int W = 500, H = 650;
+    WebKitWindowProperties *props = webkit_web_view_get_window_properties(web);
+    if (props) {
+        GdkRectangle geo = {0, 0, 0, 0};
+        webkit_window_properties_get_geometry(props, &geo);
+        if (geo.width > 0) W = geo.width;
+        if (geo.height > 0) H = geo.height;
+    }
+    if (pe->window) {
+        gtk_window_set_default_size(GTK_WINDOW(pe->window), W, H);
+        gtk_widget_show_all(pe->window);
+        gtk_window_present(GTK_WINDOW(pe->window));
+    }
+    const char *url = webkit_web_view_get_uri(web);
+    fire_gtk_popup_opened(pe->jvm, pe->popup_callback, pe->popup_id,
+                          url ? url : "", "", true, W, H, "");
+}
+
+// child `close`: window.close() (or the user closed the window).  Notify
+// onPopupClosed, destroy the window, free the inherited refs, delete the
+// PopupEngine.  Because the notify is synchronous and the Java side only reads
+// the event it correlated at open time, freeing the refs here is safe.
+static void on_close_popup(WebKitWebView *web, gpointer user_data) {
+    PopupEngine *pe = static_cast<PopupEngine *>(user_data);
+    if (!pe) return;
+    const char *url = webkit_web_view_get_uri(web);
+    fire_gtk_popup_closed(pe->jvm, pe->popup_callback, pe->dialog_callback,
+                          pe->popup_id, url ? url : "", "");
+    if (pe->window) {
+        gtk_widget_destroy(pe->window);
+        pe->window = nullptr;
+        pe->web = nullptr;
+    }
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (pe->jvm && pe->jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (pe->jvm->AttachCurrentThread((void **)&env, nullptr) == JNI_OK)
+            detach = true;
+    }
+    if (env) {
+        if (pe->popup_callback) env->DeleteGlobalRef(pe->popup_callback);
+        if (pe->dialog_callback) env->DeleteGlobalRef(pe->dialog_callback);
+        if (detach) pe->jvm->DetachCurrentThread();
+    }
+    pe->popup_callback = nullptr;
+    pe->dialog_callback = nullptr;
+    delete pe;
+}
+
+// Per-PopupEngine wrappers (nested popup + dialogs from inside a popup).
+static GtkWidget *on_create_web_view_popup(WebKitWebView *web,
+        WebKitNavigationAction *nav, gpointer user_data) {
+    PopupEngine *pe = static_cast<PopupEngine *>(user_data);
+    if (!pe) return NULL;
+    return handle_create_web_view(pe->jvm, pe->popup_callback,
+                                  pe->dialog_callback, web, nav);
+}
+static gboolean on_script_dialog_popup(WebKitWebView *web,
+        WebKitScriptDialog *dialog, gpointer user_data) {
+    PopupEngine *pe = static_cast<PopupEngine *>(user_data);
+    if (!pe) return TRUE;
+    const gchar *uri = webkit_web_view_get_uri(web);
+    return handle_script_dialog(pe->jvm, pe->dialog_callback, uri, dialog);
+}
+static gboolean on_run_file_chooser_popup(WebKitWebView *web,
+        WebKitFileChooserRequest *request, gpointer user_data) {
+    PopupEngine *pe = static_cast<PopupEngine *>(user_data);
+    if (!pe) return TRUE;
+    const gchar *uri = webkit_web_view_get_uri(web);
+    return handle_run_file_chooser(pe->jvm, pe->dialog_callback, uri, request);
+}
+
+// Per-Engine wrapper for the `create` signal (heavyweight).  Mirrors
+// on_script_dialog_engine — the divergence is the shared inner it delegates to.
+static GtkWidget *on_create_web_view_engine(WebKitWebView *web,
+        WebKitNavigationAction *nav, gpointer user_data) {
+    Engine *e = static_cast<Engine *>(user_data);
+    if (!e) return NULL;
+    return handle_create_web_view(e->jvm, e->popup_callback,
+                                  e->dialog_callback, web, nav);
+}
+
 static void engine_on_message(Engine *e, const char *msg) {
     if (msg == nullptr) return;
     // The message is JSON: {name, seq, args}.  We mirror the bind format used
@@ -1022,6 +1349,9 @@ static Engine *gtk_create_engine(JNIEnv *env, jobject component, jint debug) {
                          (GCallback)on_script_dialog_engine, e);
         g_signal_connect(WEBKIT_WEB_VIEW(e->web), "run-file-chooser",
                          (GCallback)on_run_file_chooser_engine, e);
+        // window.open / target=_blank -> native popup window (Canvas 16).
+        g_signal_connect(WEBKIT_WEB_VIEW(e->web), "create",
+                         (GCallback)on_create_web_view_engine, e);
 
         // Wire up the "external" message handler.
         g_signal_connect(
@@ -1267,6 +1597,18 @@ static void gtk_destroy_engine(Engine *e) {
         e->dialog_callback = nullptr;
         if (detach) e->jvm->DetachCurrentThread();
     }
+    // Same treatment for the popup-callback global ref (Canvas 16).
+    if (e->popup_callback) {
+        JNIEnv *env = nullptr;
+        bool detach = false;
+        if (e->jvm && e->jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+            e->jvm->AttachCurrentThread((void **)&env, nullptr);
+            detach = true;
+        }
+        if (env) env->DeleteGlobalRef(e->popup_callback);
+        e->popup_callback = nullptr;
+        if (detach) e->jvm->DetachCurrentThread();
+    }
     GtkPump::instance().run_sync([&] {
         if (e->redraw_timer_id) {
             g_source_remove(e->redraw_timer_id);
@@ -1426,6 +1768,19 @@ static void gtk_set_dialog_callback(Engine *e, JNIEnv *env, jobject cb) {
     }
 }
 
+// Register (or clear, when cb is null) the Java WebViewPopupCallback for this
+// heavyweight engine (Canvas 16).  Mirrors gtk_set_dialog_callback.
+static void gtk_set_popup_callback(Engine *e, JNIEnv *env, jobject cb) {
+    if (!e) return;
+    if (e->popup_callback) {
+        env->DeleteGlobalRef(e->popup_callback);
+        e->popup_callback = nullptr;
+    }
+    if (cb) {
+        e->popup_callback = env->NewGlobalRef(cb);
+    }
+}
+
 // ===========================================================================
 // Linux / GTK lightweight (offscreen) engine
 //
@@ -1453,6 +1808,13 @@ struct OffEngine {
     // handle_script_dialog / handle_run_file_chooser inner functions
     // declared in the heavyweight engine block above.
     jobject dialog_callback = nullptr;
+
+    // JNI global ref to the registered WebViewPopupCallback, or nullptr.
+    // Set by gtk_off_set_popup_callback; cleared in gtk_off_destroy_engine.
+    // Invoked by the `create` signal handler installed in
+    // gtk_off_create_engine, which routes through the shared
+    // handle_create_web_view inner function (Canvas 16).
+    jobject popup_callback = nullptr;
 };
 
 // Per-OffEngine wrapper for the `script-dialog` signal.  Reads page URL,
@@ -1477,6 +1839,16 @@ static gboolean on_run_file_chooser_off_engine(
     if (!e) return TRUE;
     const gchar *uri = webkit_web_view_get_uri(web);
     return handle_run_file_chooser(e->jvm, e->dialog_callback, uri, request);
+}
+
+// Per-OffEngine wrapper for the `create` signal (lightweight).  Delegates to
+// the shared handle_create_web_view with the OffEngine's callbacks (Canvas 16).
+static GtkWidget *on_create_web_view_off_engine(WebKitWebView *web,
+        WebKitNavigationAction *nav, gpointer user_data) {
+    OffEngine *e = static_cast<OffEngine *>(user_data);
+    if (!e) return NULL;
+    return handle_create_web_view(e->jvm, e->popup_callback,
+                                  e->dialog_callback, web, nav);
 }
 
 // Parallel of engine_on_message for OffEngine: parse the {name, seq, args}
@@ -1568,6 +1940,9 @@ static OffEngine *gtk_off_create_engine(JNIEnv *env,
                          (GCallback)on_script_dialog_off_engine, e);
         g_signal_connect(WEBKIT_WEB_VIEW(e->web), "run-file-chooser",
                          (GCallback)on_run_file_chooser_off_engine, e);
+        // window.open / target=_blank -> native popup window (Canvas 16).
+        g_signal_connect(WEBKIT_WEB_VIEW(e->web), "create",
+                         (GCallback)on_create_web_view_off_engine, e);
 
         webkit_user_content_manager_add_script(
             e->manager,
@@ -1679,6 +2054,18 @@ static void gtk_off_destroy_engine(OffEngine *e) {
         e->dialog_callback = nullptr;
         if (detach) e->jvm->DetachCurrentThread();
     }
+    // Same treatment for the popup-callback global ref (Canvas 16).
+    if (e->popup_callback) {
+        JNIEnv *env = nullptr;
+        bool detach = false;
+        if (e->jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+            e->jvm->AttachCurrentThread((void **)&env, nullptr);
+            detach = true;
+        }
+        if (env) env->DeleteGlobalRef(e->popup_callback);
+        e->popup_callback = nullptr;
+        if (detach) e->jvm->DetachCurrentThread();
+    }
     for (auto &kv : e->bindings) {
         Binding *b = kv.second;
         JNIEnv *env = nullptr;
@@ -1712,6 +2099,20 @@ static void gtk_off_set_dialog_callback(OffEngine *e, JNIEnv *env,
     }
     if (cb) {
         e->dialog_callback = env->NewGlobalRef(cb);
+    }
+}
+
+// Register (or clear, when cb is null) the Java WebViewPopupCallback for this
+// offscreen engine (Canvas 16).  Mirrors gtk_off_set_dialog_callback.
+static void gtk_off_set_popup_callback(OffEngine *e, JNIEnv *env,
+                                       jobject cb) {
+    if (!e) return;
+    if (e->popup_callback) {
+        env->DeleteGlobalRef(e->popup_callback);
+        e->popup_callback = nullptr;
+    }
+    if (cb) {
+        e->popup_callback = env->NewGlobalRef(cb);
     }
 }
 
@@ -4874,15 +5275,16 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
 #endif
 }
 
-// Popup (window.open) callback registration — Canvas 15.  macOS is wired in
-// this iteration; the Linux (GTK) and Windows native popup sites land in the
-// follow-up coverage canvases, so those branches are a no-op for now and
-// window.open stays blocked there (the Java handler reference is held but no
-// native callback is invoked).
+// Popup (window.open) callback registration — Canvas 15 (Java + macOS),
+// Canvas 16 (Linux / GTK).  Windows native popup site lands in Canvas 17, so
+// that branch stays a no-op for now and window.open stays blocked there (the
+// Java handler reference is held but no native callback is invoked).
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1popup_1callback
   (JNIEnv *env, jclass, jlong wv, jobject cb) {
     if (wv == 0) return;
-#if defined(WEBVIEW_COCOA)
+#ifdef WEBVIEW_GTK
+    embed::gtk_set_popup_callback((embed::Engine *)wv, env, cb);
+#elif defined(WEBVIEW_COCOA)
     embed::cocoa_set_popup_callback((embed::Engine *)wv, env, cb);
 #else
     (void)env; (void)cb;
@@ -4892,8 +5294,13 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1set_1popup_1callback
   (JNIEnv *env, jclass, jlong peer, jobject cb) {
     if (peer == 0) return;
-    // Offscreen popup support lands with Linux coverage (Canvas 16).
+#ifdef WEBVIEW_GTK
+    embed::gtk_off_set_popup_callback((embed::OffEngine *)peer, env, cb);
+#else
+    // macOS / Windows have no offscreen engine; OffscreenWebView.create
+    // returns null there so this is never reached.
     (void)env; (void)cb;
+#endif
 }
 
 } // extern "C"

--- a/test/ca/weblite/webview/PopupDispatcherTest.java
+++ b/test/ca/weblite/webview/PopupDispatcherTest.java
@@ -1,0 +1,356 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import ca.weblite.webview.swing.WebViewComponent;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.swing.SwingUtilities;
+
+/**
+ * Unit tests for {@link PopupDispatcher} — exercise the Java contract
+ * (handler registration, drop semantics, the synchronous off-EDT
+ * allow/deny gate, EDT-marshalled open/close notifications, open→close
+ * correlation, exception isolation, dispose semantics) without a live
+ * native engine.  GUI integration is verified by {@code WebViewPopupDemo}.
+ */
+public class PopupDispatcherTest {
+
+    /** Minimal {@link WebViewComponent} subclass usable as a dispatcher
+     *  source; never attaches to a native peer. */
+    private static final class StubComponent extends WebViewComponent {
+        @Override public WebViewComponent setUrl(String url) { return this; }
+        @Override public String getUrl() { return ""; }
+        @Override public WebViewComponent setDebug(boolean debug) { return this; }
+        @Override public WebViewComponent addOnBeforeLoad(String js) { return this; }
+        @Override public WebViewComponent eval(String js) { return this; }
+        @Override public CompletableFuture<String> evalAsync(String js) {
+            CompletableFuture<String> f = new CompletableFuture<String>();
+            f.completeExceptionally(new IllegalStateException("stub"));
+            return f;
+        }
+        @Override public WebViewComponent addJavascriptCallback(
+                String name, WebView.JavascriptCallback cb) { return this; }
+        @Override public WebViewComponent addJavascriptFunction(
+                String name, JavascriptFunction fn) { return this; }
+        @Override public WebViewComponent addJavascriptFunction(
+                String name, AsyncJavascriptFunction fn) { return this; }
+        @Override public WebViewComponent dispatch(Runnable r) { return this; }
+        @Override public void dispose() { }
+    }
+
+    private StubComponent source;
+    private PopupDispatcher dispatcher;
+    private Thread.UncaughtExceptionHandler priorHandler;
+    private AtomicReference<Throwable> uncaught;
+
+    @Before
+    public void setUp() {
+        source = new StubComponent();
+        dispatcher = new PopupDispatcher(source);
+        priorHandler = Thread.getDefaultUncaughtExceptionHandler();
+        uncaught = new AtomicReference<Throwable>();
+        Thread.setDefaultUncaughtExceptionHandler(
+            new Thread.UncaughtExceptionHandler() {
+                @Override
+                public void uncaughtException(Thread t, Throwable e) {
+                    uncaught.compareAndSet(null, e);
+                }
+            });
+    }
+
+    @After
+    public void tearDown() {
+        Thread.setDefaultUncaughtExceptionHandler(priorHandler);
+    }
+
+    // -----------------------------------------------------------------
+    // Handler-reference lifecycle.
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testDefaultHandlerIsDEFAULT() {
+        assertSame(WebViewPopupHandler.DEFAULT, dispatcher.getHandler());
+    }
+
+    @Test
+    public void testGetHandlerNeverReturnsNull() {
+        assertNotNull(dispatcher.getHandler());
+        dispatcher.setHandler(null);
+        assertNotNull(dispatcher.getHandler());
+        dispatcher.setHandler(WebViewPopupHandler.DEFAULT);
+        assertNotNull(dispatcher.getHandler());
+    }
+
+    @Test
+    public void testSetHandlerNullInstallsDrop() {
+        dispatcher.setHandler(null);
+        WebViewPopupHandler h = dispatcher.getHandler();
+        assertNotNull(h);
+        assertNotSame("DROP must not be identity-equal to DEFAULT",
+            WebViewPopupHandler.DEFAULT, h);
+    }
+
+    @Test
+    public void testSetHandlerCustomIsReturnedByGetter() {
+        WebViewPopupHandler custom = new WebViewPopupHandler() {};
+        dispatcher.setHandler(custom);
+        assertSame(custom, dispatcher.getHandler());
+    }
+
+    @Test
+    public void testSetHandlerDefaultAfterNullResets() {
+        dispatcher.setHandler(null);
+        assertNotSame(WebViewPopupHandler.DEFAULT, dispatcher.getHandler());
+        dispatcher.setHandler(WebViewPopupHandler.DEFAULT);
+        assertSame(WebViewPopupHandler.DEFAULT, dispatcher.getHandler());
+    }
+
+    // -----------------------------------------------------------------
+    // Allow/deny gate.
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testDefaultHandlerAllows() {
+        assertTrue(dispatcher.dispatchPopupRequested(
+            "https://e.com", "_blank", true, 500, 650, "https://o.com"));
+    }
+
+    @Test
+    public void testDropHandlerBlocks() {
+        dispatcher.setHandler(null);
+        assertFalse(dispatcher.dispatchPopupRequested(
+            "https://e.com", "_blank", true, -1, -1, "https://o.com"));
+    }
+
+    @Test
+    public void testPopupRequestedRunsOffEdtAndReturnsHandlerValue() {
+        // The test thread is NOT the EDT; the gate must run the handler
+        // inline here (off the EDT) and return its value synchronously.
+        final AtomicReference<Boolean> onEdt = new AtomicReference<Boolean>();
+        final AtomicReference<WebViewPopupEvent> received =
+            new AtomicReference<WebViewPopupEvent>();
+        dispatcher.setHandler(new WebViewPopupHandler() {
+            @Override public boolean popupRequested(WebViewPopupEvent e) {
+                onEdt.set(SwingUtilities.isEventDispatchThread());
+                received.set(e);
+                return false;
+            }
+        });
+        boolean allowed = dispatcher.dispatchPopupRequested(
+            "https://e.com/auth", "authwin", true, 520, 640, "https://o.com");
+        assertFalse(allowed);
+        assertEquals("gate must run off the EDT", Boolean.FALSE, onEdt.get());
+        WebViewPopupEvent ev = received.get();
+        assertNotNull(ev);
+        assertSame(source, ev.source());
+        assertEquals("https://e.com/auth", ev.targetUrl());
+        assertEquals("authwin", ev.targetName());
+        assertTrue(ev.userGesture());
+        assertEquals(520, ev.width());
+        assertEquals(640, ev.height());
+        assertEquals("https://o.com", ev.pageUrl());
+    }
+
+    @Test
+    public void testPopupRequestedUnspecifiedSizeIsMinusOne() {
+        final AtomicReference<WebViewPopupEvent> received =
+            new AtomicReference<WebViewPopupEvent>();
+        dispatcher.setHandler(new WebViewPopupHandler() {
+            @Override public boolean popupRequested(WebViewPopupEvent e) {
+                received.set(e);
+                return true;
+            }
+        });
+        dispatcher.dispatchPopupRequested("u", "", false, -1, -1, "p");
+        assertEquals(-1, received.get().width());
+        assertEquals(-1, received.get().height());
+        assertFalse(received.get().userGesture());
+    }
+
+    // -----------------------------------------------------------------
+    // Open / close notifications (EDT-marshalled) + correlation.
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testPopupOpenedNotifiedOnEdt() throws Exception {
+        final AtomicReference<Boolean> onEdt = new AtomicReference<Boolean>();
+        final AtomicReference<WebViewPopupEvent> received =
+            new AtomicReference<WebViewPopupEvent>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        dispatcher.setHandler(new WebViewPopupHandler() {
+            @Override public void popupOpened(WebViewPopupEvent e) {
+                onEdt.set(SwingUtilities.isEventDispatchThread());
+                received.set(e);
+                latch.countDown();
+            }
+        });
+        dispatcher.dispatchPopupOpened(
+            42L, "https://e.com", "_blank", true, 500, 650, "https://o.com");
+        assertTrue("popupOpened not delivered",
+            latch.await(2, TimeUnit.SECONDS));
+        assertEquals(Boolean.TRUE, onEdt.get());
+        assertEquals("https://e.com", received.get().targetUrl());
+        assertEquals(500, received.get().width());
+    }
+
+    @Test
+    public void testPopupClosedReceivesSameEventInstanceAsOpen()
+            throws Exception {
+        final AtomicReference<WebViewPopupEvent> opened =
+            new AtomicReference<WebViewPopupEvent>();
+        final AtomicReference<WebViewPopupEvent> closed =
+            new AtomicReference<WebViewPopupEvent>();
+        final CountDownLatch openLatch = new CountDownLatch(1);
+        final CountDownLatch closeLatch = new CountDownLatch(1);
+        dispatcher.setHandler(new WebViewPopupHandler() {
+            @Override public void popupOpened(WebViewPopupEvent e) {
+                opened.set(e);
+                openLatch.countDown();
+            }
+            @Override public void popupClosed(WebViewPopupEvent e) {
+                closed.set(e);
+                closeLatch.countDown();
+            }
+        });
+        dispatcher.dispatchPopupOpened(
+            7L, "https://e.com", "n", true, 500, 650, "https://o.com");
+        assertTrue(openLatch.await(2, TimeUnit.SECONDS));
+        dispatcher.dispatchPopupClosed(7L, "ignored-url", "ignored-page");
+        assertTrue(closeLatch.await(2, TimeUnit.SECONDS));
+        // Correlation: close reuses the rich event stored at open.
+        assertSame(opened.get(), closed.get());
+        assertEquals("https://e.com", closed.get().targetUrl());
+    }
+
+    @Test
+    public void testPopupClosedWithoutOpenBuildsMinimalEvent()
+            throws Exception {
+        final AtomicReference<WebViewPopupEvent> closed =
+            new AtomicReference<WebViewPopupEvent>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        dispatcher.setHandler(new WebViewPopupHandler() {
+            @Override public void popupClosed(WebViewPopupEvent e) {
+                closed.set(e);
+                latch.countDown();
+            }
+        });
+        dispatcher.dispatchPopupClosed(999L, "https://late.com", "https://o.com");
+        assertTrue(latch.await(2, TimeUnit.SECONDS));
+        assertNotNull(closed.get());
+        assertEquals("https://late.com", closed.get().targetUrl());
+        assertEquals("https://o.com", closed.get().pageUrl());
+        assertEquals(-1, closed.get().width());
+    }
+
+    // -----------------------------------------------------------------
+    // Exception isolation.
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testPopupRequestedExceptionBlocksAndIsolated() {
+        dispatcher.setHandler(new WebViewPopupHandler() {
+            @Override public boolean popupRequested(WebViewPopupEvent e) {
+                throw new RuntimeException("boom-req");
+            }
+        });
+        // A thrown decision blocks the popup (returns false) and does not
+        // propagate to the native caller.
+        assertFalse(dispatcher.dispatchPopupRequested(
+            "u", "n", true, -1, -1, "p"));
+        waitForUncaught();
+        assertNotNull(uncaught.get());
+        assertEquals("boom-req", uncaught.get().getMessage());
+    }
+
+    @Test
+    public void testPopupOpenedExceptionIsolated() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        dispatcher.setHandler(new WebViewPopupHandler() {
+            @Override public void popupOpened(WebViewPopupEvent e) {
+                try {
+                    throw new RuntimeException("boom-open");
+                } finally {
+                    latch.countDown();
+                }
+            }
+        });
+        dispatcher.dispatchPopupOpened(1L, "u", "n", true, -1, -1, "p");
+        assertTrue(latch.await(2, TimeUnit.SECONDS));
+        waitForUncaught();
+        assertNotNull(uncaught.get());
+    }
+
+    // -----------------------------------------------------------------
+    // Disposal semantics.
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testDisposedDispatcherReturnsFallbacks() {
+        dispatcher.setHandler(new WebViewPopupHandler() {
+            @Override public boolean popupRequested(WebViewPopupEvent e) {
+                throw new AssertionError("handler invoked after dispose");
+            }
+            @Override public void popupOpened(WebViewPopupEvent e) {
+                throw new AssertionError("handler invoked after dispose");
+            }
+            @Override public void popupClosed(WebViewPopupEvent e) {
+                throw new AssertionError("handler invoked after dispose");
+            }
+        });
+        dispatcher.disposeAll();
+        assertTrue(dispatcher.isDisposed());
+        assertFalse(dispatcher.dispatchPopupRequested(
+            "u", "n", true, -1, -1, "p"));
+        dispatcher.dispatchPopupOpened(1L, "u", "n", true, -1, -1, "p");
+        dispatcher.dispatchPopupClosed(1L, "u", "p");
+    }
+
+    @Test
+    public void testDisposeAllIsIdempotent() {
+        dispatcher.disposeAll();
+        dispatcher.disposeAll();
+        assertTrue(dispatcher.isDisposed());
+    }
+
+    // -----------------------------------------------------------------
+    // Constructor null-checks.
+    // -----------------------------------------------------------------
+
+    @Test(expected = NullPointerException.class)
+    public void testConstructorRejectsNullSource() {
+        new PopupDispatcher(null);
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers.
+    // -----------------------------------------------------------------
+
+    private void waitForUncaught() {
+        long deadline = System.currentTimeMillis() + 500;
+        while (uncaught.get() == null
+            && System.currentTimeMillis() < deadline) {
+            try { Thread.sleep(5); } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+}

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -138,6 +138,14 @@ struct Engine {
     // public hook for <input type=file>), so this callback is never
     // invoked for the file-picker event kind on Windows.
     jobject dialog_callback = nullptr;
+
+    // JNI global ref to the registered WebViewPopupCallback, or nullptr —
+    // Canvas 15.  Stored here on Windows; the follow-up Windows coverage
+    // canvas wires ICoreWebView2::add_NewWindowRequested off this field
+    // (put_NewWindow with a controller from the same environment) plus the
+    // child's add_WindowCloseRequested so window.open opens a native window
+    // linked to the opener.  Until then window.open stays blocked on Windows.
+    jobject popup_callback = nullptr;
 };
 
 static void fire_focus_callback(Engine *e, bool became) {
@@ -1333,6 +1341,29 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
     // Windows has no offscreen engine; OffscreenWebView.create returns
     // null on Windows so this JNI bridge should never be reached.
     // Stub it for link-symmetry across all three native binaries.
+}
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1popup_1callback
+  (JNIEnv *env, jclass, jlong wv, jobject cb) {
+    // Canvas 15 ships the callback storage on Windows; the follow-up
+    // Windows coverage canvas wires ICoreWebView2::add_NewWindowRequested
+    // off this field.  Until then storing the ref is a harmless no-op and
+    // window.open stays blocked on Windows.
+    auto *e = (Engine *)wv;
+    if (!e) return;
+    if (e->popup_callback) {
+        env->DeleteGlobalRef(e->popup_callback);
+        e->popup_callback = nullptr;
+    }
+    if (cb) {
+        e->popup_callback = env->NewGlobalRef(cb);
+    }
+}
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1set_1popup_1callback
+  (JNIEnv *, jclass, jlong, jobject) {
+    // Windows has no offscreen engine; stub for link-symmetry across all
+    // three native binaries.
 }
 
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1release_1native_1focus

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -146,6 +146,19 @@ struct Engine {
     // child's add_WindowCloseRequested so window.open opens a native window
     // linked to the opener.  Until then window.open stays blocked on Windows.
     jobject popup_callback = nullptr;
+
+    // EventRegistrationToken for the NewWindowRequested handler registered in
+    // the controller-ready callback (Canvas 17).  Not explicitly removed in
+    // destroy_engine -- the controller / webview Release detaches it
+    // transitively, like the other tokens.
+    EventRegistrationToken new_window_token{};
+
+    // The ICoreWebView2Environment this engine was created from, AddRef'd at
+    // environment-ready and Release'd in destroy_engine (Canvas 17).  The
+    // NewWindowRequested handler creates the child popup controller from THIS
+    // environment so the popup is a linked view (window.opener / postMessage
+    // work) -- a controller from a different environment is not linked.
+    ICoreWebView2Environment *environment = nullptr;
 };
 
 static void fire_focus_callback(Engine *e, bool became) {
@@ -593,6 +606,372 @@ private:
     Engine *m_engine;
 };
 
+// ---------------------------------------------------------------------------
+// Popup (window.open) support — Canvas 17 (Windows / WebView2).
+//
+// window.open / target=_blank raises ICoreWebView2::NewWindowRequested.  Invoke
+// runs on the WebView2 worker thread and must NOT block it, so we use the
+// deferral pattern (like ScriptDialogHandler): GetDeferral, hop to Java on a
+// short-lived worker for the allow/deny decision, then dispatch_to_thread back
+// onto the WebView2 worker to create the child (via put_NewWindow with a
+// controller built from the SAME environment, so window.opener / postMessage
+// work) and Complete the deferral.  The engine owns the popup HWND; the child's
+// WindowCloseRequested destroys it.
+// ---------------------------------------------------------------------------
+
+// A child popup's native state: an engine-owned top-level window hosting a
+// linked child WebView2.  Freed in PopupWndProc's WM_DESTROY.
+struct PopupWindow {
+    HWND hwnd = nullptr;
+    ICoreWebView2Controller *controller = nullptr;
+    ICoreWebView2 *webview = nullptr;
+    Engine *opener = nullptr;   // for jvm + popup_callback (notifications)
+    jlong popup_id = 0;
+    std::string url;
+    EventRegistrationToken close_token{};
+};
+
+static LRESULT CALLBACK PopupWndProc(HWND hwnd, UINT msg, WPARAM wp,
+                                     LPARAM lp) {
+    PopupWindow *pw = (PopupWindow *)GetWindowLongPtr(hwnd, GWLP_USERDATA);
+    switch (msg) {
+    case WM_SIZE:
+        if (pw && pw->controller) {
+            RECT r;
+            GetClientRect(hwnd, &r);
+            pw->controller->put_Bounds(r);
+        }
+        return 0;
+    case WM_DESTROY:
+        if (pw) {
+            if (pw->webview) { pw->webview->Release(); pw->webview = nullptr; }
+            if (pw->controller) {
+                pw->controller->Close();
+                pw->controller->Release();
+                pw->controller = nullptr;
+            }
+            SetWindowLongPtr(hwnd, GWLP_USERDATA, 0);
+            delete pw;
+        }
+        return 0;
+    default:
+        return DefWindowProc(hwnd, msg, wp, lp);
+    }
+}
+
+static ATOM ensure_popup_class_registered() {
+    static ATOM atom = 0;
+    if (atom != 0) return atom;
+    WNDCLASSEX wc{};
+    wc.cbSize = sizeof(wc);
+    wc.hInstance = GetModuleHandle(nullptr);
+    wc.lpszClassName = "WebViewEmbedPopup";
+    wc.lpfnWndProc = PopupWndProc;
+    wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
+    atom = RegisterClassEx(&wc);
+    return atom;
+}
+
+// Synchronous allow/deny hop into Java (runs on the JNI worker thread the
+// NewWindowRequested handler spins up).  Returns false on null callback,
+// attach failure, or any exception (block-on-error default).
+static bool fire_popup_requested_win(Engine *e, const char *url, bool gesture,
+                                     int w, int h, const char *page) {
+    if (!e || !e->popup_callback || !e->jvm) return false;
+    JavaVM *jvm = e->jvm;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return false;
+        detach = true;
+    }
+    bool allow = false;
+    jstring ju = env->NewStringUTF(url ? url : "");
+    jstring jn = env->NewStringUTF("");
+    jstring jp = env->NewStringUTF(page ? page : "");
+    jclass cls = env->GetObjectClass(e->popup_callback);
+    if (cls) {
+        jmethodID mid = env->GetMethodID(cls, "onPopupRequested",
+            "(Ljava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)Z");
+        if (mid) {
+            jboolean r = env->CallBooleanMethod(e->popup_callback, mid, ju, jn,
+                gesture ? JNI_TRUE : JNI_FALSE, (jint)w, (jint)h, jp);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+                r = JNI_FALSE;
+            }
+            allow = (r == JNI_TRUE);
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (ju) env->DeleteLocalRef(ju);
+    if (jn) env->DeleteLocalRef(jn);
+    if (jp) env->DeleteLocalRef(jp);
+    if (detach) jvm->DetachCurrentThread();
+    return allow;
+}
+
+// Fire onPopupOpened (fire-and-forget; the Java dispatcher marshals to the
+// EDT via invokeLater).  Runs on the WebView2 worker thread.
+static void fire_popup_opened_win(Engine *e, jlong popup_id, const char *url,
+                                  bool gesture, int w, int h,
+                                  const char *page) {
+    if (!e || !e->popup_callback || !e->jvm) return;
+    JavaVM *jvm = e->jvm;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return;
+        detach = true;
+    }
+    jstring ju = env->NewStringUTF(url ? url : "");
+    jstring jn = env->NewStringUTF("");
+    jstring jp = env->NewStringUTF(page ? page : "");
+    jclass cls = env->GetObjectClass(e->popup_callback);
+    if (cls) {
+        jmethodID mid = env->GetMethodID(cls, "onPopupOpened",
+            "(JLjava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)V");
+        if (mid) {
+            env->CallVoidMethod(e->popup_callback, mid, popup_id, ju, jn,
+                gesture ? JNI_TRUE : JNI_FALSE, (jint)w, (jint)h, jp);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (ju) env->DeleteLocalRef(ju);
+    if (jn) env->DeleteLocalRef(jn);
+    if (jp) env->DeleteLocalRef(jp);
+    if (detach) jvm->DetachCurrentThread();
+}
+
+// Fire onPopupClosed.  Runs on the WebView2 worker thread.
+static void fire_popup_closed_win(Engine *e, jlong popup_id, const char *url,
+                                  const char *page) {
+    if (!e || !e->popup_callback || !e->jvm) return;
+    JavaVM *jvm = e->jvm;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return;
+        detach = true;
+    }
+    jstring ju = env->NewStringUTF(url ? url : "");
+    jstring jp = env->NewStringUTF(page ? page : "");
+    jclass cls = env->GetObjectClass(e->popup_callback);
+    if (cls) {
+        jmethodID mid = env->GetMethodID(cls, "onPopupClosed",
+            "(JLjava/lang/String;Ljava/lang/String;)V");
+        if (mid) {
+            env->CallVoidMethod(e->popup_callback, mid, popup_id, ju, jp);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (ju) env->DeleteLocalRef(ju);
+    if (jp) env->DeleteLocalRef(jp);
+    if (detach) jvm->DetachCurrentThread();
+}
+
+// window.close() from the popup (or the user closing the native window).
+// Notify onPopupClosed, then DestroyWindow -> PopupWndProc WM_DESTROY frees
+// the controller/webview and deletes the PopupWindow.
+class PopupCloseHandler : public CallbackBase<
+    ICoreWebView2WindowCloseRequestedEventHandler> {
+public:
+    explicit PopupCloseHandler(PopupWindow *pw) : m_pw(pw) {}
+    HRESULT STDMETHODCALLTYPE Invoke(ICoreWebView2 *, IUnknown *) override {
+        if (!m_pw) return S_OK;
+        fire_popup_closed_win(m_pw->opener, m_pw->popup_id,
+                              m_pw->url.c_str(), "");
+        if (m_pw->hwnd) DestroyWindow(m_pw->hwnd);
+        return S_OK;
+    }
+private:
+    PopupWindow *m_pw;
+};
+
+// NewWindowRequested -> allow/deny via Java, then create the linked child in an
+// engine-owned top-level window.  Deferral pattern; see the block comment.
+class NewWindowRequestedHandler : public CallbackBase<
+    ICoreWebView2NewWindowRequestedEventHandler> {
+public:
+    explicit NewWindowRequestedHandler(Engine *e) : m_engine(e) {}
+    HRESULT STDMETHODCALLTYPE Invoke(
+        ICoreWebView2 *,
+        ICoreWebView2NewWindowRequestedEventArgs *args) override {
+        if (!args || !m_engine) return S_OK;
+
+        LPWSTR uri_w = nullptr;
+        args->get_Uri(&uri_w);
+        std::string uri = wide_to_utf8(uri_w);
+        if (uri_w) CoTaskMemFree(uri_w);
+
+        BOOL user_initiated = FALSE;
+        args->get_IsUserInitiated(&user_initiated);
+
+        int req_w = -1, req_h = -1;
+        ICoreWebView2WindowFeatures *feat = nullptr;
+        if (SUCCEEDED(args->get_WindowFeatures(&feat)) && feat) {
+            BOOL has_size = FALSE;
+            feat->get_HasSize(&has_size);
+            if (has_size) {
+                UINT32 fw = 0, fh = 0;
+                feat->get_Width(&fw);
+                feat->get_Height(&fh);
+                if (fw > 0) req_w = (int)fw;
+                if (fh > 0) req_h = (int)fh;
+            }
+            feat->Release();
+        }
+
+        // Opener document URL (best effort).
+        std::string page;
+        {
+            LPWSTR src = nullptr;
+            if (m_engine->webview &&
+                SUCCEEDED(m_engine->webview->get_Source(&src)) && src) {
+                page = wide_to_utf8(src);
+            }
+            if (src) CoTaskMemFree(src);
+        }
+
+        ICoreWebView2Deferral *deferral = nullptr;
+        HRESULT hr = args->GetDeferral(&deferral);
+        if (FAILED(hr) || !deferral) {
+            WV_LOG("NewWindowRequested GetDeferral failed: HRESULT=0x%08lx",
+                   (unsigned long)hr);
+            return S_OK;  // WebView2 opens its own default window (fallback)
+        }
+        args->AddRef();
+
+        Engine *e = m_engine;
+        bool gesture = (user_initiated != FALSE);
+        std::thread([e, args, deferral, uri, page, gesture, req_w, req_h] {
+            bool allow = fire_popup_requested_win(e, uri.c_str(), gesture,
+                                                  req_w, req_h, page.c_str());
+            dispatch_to_thread(e, [e, args, deferral, uri, page, gesture,
+                                   req_w, req_h, allow] {
+                if (!allow) {
+                    args->put_Handled(TRUE);   // block; window.open -> null
+                    deferral->Complete();
+                    deferral->Release();
+                    args->Release();
+                    return;
+                }
+                int W = req_w > 0 ? req_w : 500;
+                int H = req_h > 0 ? req_h : 650;
+                ensure_popup_class_registered();
+                HWND popup = CreateWindowEx(
+                    0, "WebViewEmbedPopup", "Popup", WS_OVERLAPPEDWINDOW,
+                    CW_USEDEFAULT, CW_USEDEFAULT, W, H,
+                    nullptr, nullptr, GetModuleHandle(nullptr), nullptr);
+                if (!popup || !e->environment) {
+                    if (popup) DestroyWindow(popup);
+                    args->put_Handled(TRUE);   // blocked
+                    deferral->Complete();
+                    deferral->Release();
+                    args->Release();
+                    return;
+                }
+                PopupWindow *pw = new PopupWindow();
+                pw->hwnd = popup;
+                pw->opener = e;
+                pw->popup_id = (jlong)(LONG_PTR)pw;
+                pw->url = uri;
+                SetWindowLongPtr(popup, GWLP_USERDATA, (LONG_PTR)pw);
+
+                auto *ctrl_handler = new ControllerHandler(
+                    [e, args, deferral, pw, uri, page, gesture, W, H]
+                    (HRESULT r2, ICoreWebView2Controller *ctrl) {
+                        if (FAILED(r2) || !ctrl) {
+                            WV_LOG("popup CreateController completion failed: "
+                                   "0x%08lx", (unsigned long)r2);
+                            args->put_Handled(TRUE);   // blocked
+                            deferral->Complete();
+                            deferral->Release();
+                            args->Release();
+                            DestroyWindow(pw->hwnd);   // WM_DESTROY frees pw
+                            return;
+                        }
+                        ctrl->AddRef();
+                        pw->controller = ctrl;
+                        ICoreWebView2 *child = nullptr;
+                        ctrl->get_CoreWebView2(&child);
+                        if (child) { child->AddRef(); pw->webview = child; }
+
+                        args->put_NewWindow(child);   // LINKED to opener
+                        args->put_Handled(TRUE);
+                        deferral->Complete();
+
+                        RECT rc;
+                        GetClientRect(pw->hwnd, &rc);
+                        ctrl->put_Bounds(rc);
+                        ctrl->put_IsVisible(TRUE);
+                        ShowWindow(pw->hwnd, SW_SHOW);
+
+                        if (child) {
+                            // Nested popups + dialogs from inside the popup,
+                            // reusing the opener's callbacks.
+                            EventRegistrationToken nw_t{};
+                            auto *nwh = new NewWindowRequestedHandler(e);
+                            child->add_NewWindowRequested(nwh, &nw_t);
+                            nwh->Release();
+
+                            ICoreWebView2Settings *settings = nullptr;
+                            if (SUCCEEDED(child->get_Settings(&settings)) &&
+                                settings) {
+                                settings->put_AreDefaultScriptDialogsEnabled(
+                                    FALSE);
+                                settings->Release();
+                            }
+                            EventRegistrationToken sd_t{};
+                            auto *sdh = new ScriptDialogHandler(e);
+                            child->add_ScriptDialogOpening(sdh, &sd_t);
+                            sdh->Release();
+
+                            auto *pch = new PopupCloseHandler(pw);
+                            child->add_WindowCloseRequested(pch,
+                                                            &pw->close_token);
+                            pch->Release();
+                        }
+
+                        fire_popup_opened_win(e, pw->popup_id, uri.c_str(),
+                                              gesture, W, H, page.c_str());
+
+                        deferral->Release();
+                        args->Release();
+                    });
+                HRESULT rc2 = e->environment->CreateCoreWebView2Controller(
+                    pw->hwnd, ctrl_handler);
+                ctrl_handler->Release();
+                if (FAILED(rc2)) {
+                    WV_LOG("popup CreateCoreWebView2Controller call failed: "
+                           "0x%08lx", (unsigned long)rc2);
+                    args->put_Handled(TRUE);
+                    deferral->Complete();
+                    deferral->Release();
+                    args->Release();
+                    DestroyWindow(pw->hwnd);   // WM_DESTROY frees pw
+                }
+            });
+        }).detach();
+
+        return S_OK;
+    }
+private:
+    Engine *m_engine;
+};
+
 static void engine_on_message(Engine *e, LPCWSTR msg) {
     if (!msg) return;
     int n = WideCharToMultiByte(CP_UTF8, 0, msg, -1, nullptr, 0, nullptr, nullptr);
@@ -713,6 +1092,10 @@ static void engine_thread(Engine *e, HWND /*parent*/, int width, int height,
                 init_done.clear();
                 return;
             }
+            // Keep the environment alive so NewWindowRequested can build the
+            // child popup controller from it (linked view) -- Canvas 17.
+            e->environment = env;
+            env->AddRef();
             auto *ctrl_handler = new ControllerHandler(
                 [&](HRESULT r2, ICoreWebView2Controller *ctrl) {
                     if (FAILED(r2) || !ctrl) {
@@ -792,6 +1175,13 @@ static void engine_thread(Engine *e, HWND /*parent*/, int width, int height,
                     auto *lh = new FocusHandler(e, false);
                     ctrl->add_LostFocus(lh, &e->lost_focus_token);
                     lh->Release();
+
+                    // window.open / target=_blank -> native popup window
+                    // linked to the opener (Canvas 17).
+                    auto *nwh = new NewWindowRequestedHandler(e);
+                    e->webview->add_NewWindowRequested(
+                        nwh, &e->new_window_token);
+                    nwh->Release();
 
                     init_done.clear();
                 });
@@ -960,6 +1350,25 @@ static void destroy_engine(Engine *e) {
         if (env) env->DeleteGlobalRef(e->dialog_callback);
         e->dialog_callback = nullptr;
         if (detach) e->jvm->DetachCurrentThread();
+    }
+    // Symmetric cleanup for the popup callback global ref (Canvas 17).  The
+    // NewWindowRequested handler fires off this field, so clear it before the
+    // worker thread tears down.
+    if (e->popup_callback) {
+        JNIEnv *env = nullptr;
+        bool detach = false;
+        if (e->jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+            e->jvm->AttachCurrentThread((void **)&env, nullptr);
+            detach = true;
+        }
+        if (env) env->DeleteGlobalRef(e->popup_callback);
+        e->popup_callback = nullptr;
+        if (detach) e->jvm->DetachCurrentThread();
+    }
+    // Release the environment ref taken at environment-ready (Canvas 17).
+    if (e->environment) {
+        e->environment->Release();
+        e->environment = nullptr;
     }
     {
         std::lock_guard<std::mutex> lk(e->bindings_mutex);


### PR DESCRIPTION
## What this delivers

**1. Browser-initiated popups (`window.open` / `target="_blank"`) — all three platforms.**
Pages that call `window.open(url, name, features)` or click `target="_blank"` links were silently dropped (native layer installed no new-window hook), breaking OAuth "sign-in with popup" flows (Firebase `auth/popup-blocked`). This adds a clean Java policy+notification contract and native implementations on every platform:

- **Java API** (Canvas 15): `WebViewPopupHandler` — `popupRequested` (allow/deny gate), `popupOpened`/`popupClosed` (notifications); `WebViewComponent.setPopupHandler`/`getPopupHandler`; `WebViewPopupEvent`, `WebViewPopupCallback` (JNI bridge), `PopupDispatcher`. `DEFAULT` allows; `setPopupHandler(null)` blocks all popups (`window.open` → `null`), the pre-feature behaviour as an explicit opt-out.
- **Native — the engine owns the popup window.** When allowed, the native engine creates the child web view **linked to the opener** (so `window.opener`/`postMessage` work — the mechanism `signInWithPopup` uses) and hosts it in a native top-level window it sizes, shows, and destroys; `window.close()` tears it down.
  - **macOS** — WKWebView `createWebViewWithConfiguration:` + `webViewDidClose:` (Canvas 15).
  - **Linux** — WebKitGTK `create` / `ready-to-show` / `close`, heavyweight **and** lightweight (Canvas 16).
  - **Windows** — WebView2 `NewWindowRequested` + child `WindowCloseRequested` (Canvas 17).
- **Threading:** `popupRequested` runs inline on the native UI thread (synchronous allow/deny); `popupOpened`/`popupClosed` marshal to the EDT.

**2. Portable Linux native — one `libwebview.so` for WebKitGTK 4.0 *and* 4.1** (Canvas 8, Operation 7).
The Linux native previously hard-linked `libwebkit2gtk-4.1.so.0` (baked in by the 4.1 CI runner), so it failed on WebKitGTK-4.0-only hosts (Ubuntu 20.04, older WSL) with `UnsatisfiedLinkError`. It now resolves WebKitGTK/JavaScriptCore at runtime: a Linux-only loader `dlopen`s WebKit (4.1 preferred, 4.0 fallback) + the matching JavaScriptCore and `dlsym`s every symbol into a typed pointer table; a shim routes all call sites through it with no textual edits. Result: **no `webkit2gtk`/`javascriptcoregtk` `NEEDED` entry**, so one binary serves both. macOS/Windows are untouched; no public Java/JNI change.

**3. One-shot demo runners** for `WebViewPopupDemo` on all three OSes: `run-mac-popup-demo.sh`, `run-linux-popup-demo.sh`, `run-windows-popup-demo.bat` (build native → jar → compile → launch, no Ant).

## Verification

- **Java layer:** built + unit-tested on Linux (84 tests, incl. 17 `PopupDispatcherTest`).
- **CI:** green on all six native platforms + jar assembly. A new `readelf -d` gate on the Linux native asserts zero `webkit2gtk`/`javascriptcoregtk` `NEEDED` — gate output: `OK: no webkit2gtk/javascriptcoregtk NEEDED entries.`
- **On-device native validation** (repo has no automated GUI tests):
  - macOS — ✅ validated (popup opens, opener-linked).
  - Linux — ✅ popup opens example.com in lightweight mode on a real WebKitGTK-4.1 host (also exercises the runtime loader); heavyweight pass recommended.
  - Windows — ⏳ pending.
  - A real WebKitGTK-**4.0** host (Ubuntu 20.04) — ⏳ pending, to fully confirm the 4.0 runtime path (CI already proves no hard dependency).

## SPDD
Source of truth: Canvas 15 (popup contract + macOS), Canvas 16 (Linux), Canvas 17 (Windows), Canvas 8 Operation 7 (runtime WebKitGTK loader + `readelf` gate). Code generated from the canvases; canvas and code land together.

## Release
Versioning is tag-driven (`pom.xml` is `1.0-SNAPSHOT`; `maven-release.yml` publishes on `v*` tags), so this ships on the next release tag (**v1.0.12**) — nothing to bump in-repo.

Draft pending the remaining on-device checks above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUc1QZKwpPgYLDkjZoHJ9A)_