### PR TITLE
Release version 1.1.0 (browser-initiated popup support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add the dependency to your `pom.xml`:
 <dependency>
     <groupId>ca.weblite</groupId>
     <artifactId>webview</artifactId>
-    <version>1.0.10</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 
@@ -457,7 +457,7 @@ cd swingwebview
 mvn -DskipTests package
 ```
 
-This produces `target/webview-1.0-SNAPSHOT.jar`.  The build targets
+This produces `target/webview-1.1.0.jar`.  The build targets
 Java 8 bytecode (`maven.compiler.source` / `maven.compiler.target` =
 `1.8` in `pom.xml`); it works on JDK 8 and any newer LTS.  Pass
 `-Dmaven.compiler.release=8` if you want strict Java 8 API checking

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>ca.weblite</groupId>
     <artifactId>webview</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>WebView</name>


### PR DESCRIPTION
## Summary

Bumps the library version to **1.1.0** for the release that carries the browser-initiated popup API (`window.open` / `target="_blank"`) added in the recent popup canvases. This is the version the swingwebbrowser demo depends on to route popups into new tabs.

## Changes

- **`pom.xml`**: version `1.0-SNAPSHOT` → `1.1.0`.
- **`README.md`**: update the install-snippet dependency version and the build-output jar name to `1.1.0`.

This is a release/versioning change only — no source or behavior changes; the popup API itself already landed on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQ5ZdfKb9qG6o6EsrszxcQ