### PR TITLE
Embedded web-app compatibility: popup adoption (Canvas 18) + custom User-Agent (Canvas 21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,33 @@ wv.setPopupHandler(new WebViewPopupHandler() {
   the existing popup handlers but **must be validated on-device** (no
   native toolchain runs in the code-generation sandbox).
 
+## Custom user agent
+
+Some web apps gate on the `User-Agent`. WKWebView's default UA omits the
+`Version/… Safari/…` tokens, so UA-sniffing sites can reject the embedded
+WebView. Override it with `setUserAgent` — this changes the **actual HTTP
+`User-Agent` request header** (not just the JS-visible
+`navigator.userAgent`):
+
+```java
+WebViewComponent wv = WebViewComponent.create();
+wv.setUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    + "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3 Safari/605.1.15");
+wv.setUrl("https://example.com/");   // first request carries the custom UA
+```
+
+* **Reset.** `setUserAgent(null)` or `setUserAgent("")` restores the engine
+  default. `getUserAgent()` returns the override, or `null` when the default
+  is in force.
+* **Timing.** Called before display, it applies to the first request. Called
+  after display, it applies to the **next** navigation (engines don't rewrite
+  the in-flight request for the current page).
+* **Platform coverage.** macOS `WKWebView.customUserAgent`, Linux WebKitGTK
+  `webkit_settings_set_user_agent`, Windows WebView2
+  `ICoreWebView2Settings2::UserAgent`. The native setters ship
+  pattern-faithful but must be validated on-device (confirm the header via an
+  echo endpoint).
+
 ## Demo
 
 See [`demos/WebViewHeavyweightDemo/`](demos/WebViewHeavyweightDemo/README.md)

--- a/README.md
+++ b/README.md
@@ -420,6 +420,61 @@ wv.setPopupHandler(new WebViewPopupHandler() {
 See [`demos/WebViewPopupDemo/`](demos/WebViewPopupDemo/README.md) for a
 runnable example that exercises the allow / custom / block modes.
 
+### Adopting popups into a component (a tab)
+
+By default an allowed popup opens in a **native window** the engine owns
+(above).  A tabbed browser usually wants the popup to appear as a **new
+tab** instead.  Blocking the native window and re-opening
+`e.targetUrl()` with `setUrl(url)` does *not* work for that: `setUrl`
+issues a **GET**, so a `<form method="post" target="…">` popup loses its
+POST body and the re-opened page is no longer opener-linked.  The POST
+body is not exposed to the popup channel on any engine, so the request
+cannot be replayed from Java.
+
+Instead, **adopt** the engine's own opener-linked child — the view
+WebKit already drove the original request (POST verb + body) into — into
+a `WebViewComponent` you supply:
+
+```java
+wv.setPopupHandler(new WebViewPopupHandler() {
+    // 1. Decide ADOPT on the native UI thread (synchronous, off the EDT).
+    @Override public PopupDisposition popupDisposition(WebViewPopupEvent e) {
+        return PopupDisposition.ADOPT;   // not a native window
+    }
+    // 2. On the EDT, host the retained child in a new tab.
+    @Override public void popupAdoptable(WebViewPopupEvent e, long popupId) {
+        WebViewComponent tab = WebViewComponent.adoptPopup(popupId);
+        myTabbedPane.addTab("Popup", tab);   // realizing it adopts the child
+    }
+});
+```
+
+* **POST + opener preserved.**  The adopted component reuses the engine's
+  child, so `<form method="post">` popups keep their body and
+  `window.opener` / `postMessage` keep working — the same guarantee the
+  native-window path has, now in a tab.
+* **Two-phase, no flash.**  `popupDisposition` returns `ADOPT`
+  synchronously on the native UI thread (same rules as `popupRequested`:
+  fast, thread-safe, no Swing).  The engine creates the child but shows
+  **no window**; it fires `popupAdoptable` on the EDT, where you build the
+  tab and call `WebViewComponent.adoptPopup(popupId)`.  Adoption happens
+  when that component is realized.
+* **Backward compatible.**  `popupDisposition` defaults to deriving from
+  `popupRequested` (`true → NATIVE_WINDOW`, `false → BLOCK`), so existing
+  handlers and `setPopupHandler(null)` are unchanged.
+* **Adopt-once / reclaim.**  A `popupId` may be adopted once; an unknown
+  or already-adopted id throws (`IllegalArgumentException` /
+  `IllegalStateException`).  A child decided `ADOPT` but never adopted is
+  reclaimed when the opener is disposed or after a bounded grace period.
+* **Platform coverage.**  The reference backend is **macOS heavyweight**
+  (WKWebView; the retained child is reparented into the tab's `NSView`).
+  Linux (WebKitGTK) and Windows (WebView2) adoption, and lightweight /
+  offscreen adoption, are follow-up work; on those the native adopt is
+  not yet wired, so `adoptPopup` there fails fast rather than silently
+  losing the popup.  The native adoption code ships pattern-faithful to
+  the existing popup handlers but **must be validated on-device** (no
+  native toolchain runs in the code-generation sandbox).
+
 ## Demo
 
 See [`demos/WebViewHeavyweightDemo/`](demos/WebViewHeavyweightDemo/README.md)

--- a/demos/WebViewAdoptPopupDemo/README.md
+++ b/demos/WebViewAdoptPopupDemo/README.md
@@ -48,6 +48,21 @@ and launches the demo.
 
 - The demo sets `JPopupMenu.setDefaultLightWeightPopupEnabled(false)` and the
   tooltip equivalent, required for heavyweight popups.
-- Adoption's reference backend is macOS (WKWebView). Linux (Canvas 19) and
-  Windows (Canvas 20) native adoption are follow-ups; on those the disposition
-  falls back and popups are not yet adopted into tabs.
+## Platform matrix
+
+| Feature | macOS | Linux | Windows |
+|---|---|---|---|
+| **Adopt into tab** | ✅ | ❌ Canvas 19 (`adoptPopup` throws `IllegalStateException`) | ❌ Canvas 20 (same) |
+| **Native window** popup | ✅ | ✅ | ✅ |
+| **Block** popup | ✅ | ✅ | ✅ |
+| **User-Agent** (Set/Reset) | ✅ | ✅ | ✅ |
+
+So on **Linux / Windows**, test with **Native window** or **Block** mode plus
+the **User-Agent** field. **Adopt into tab** is the macOS reference backend
+until the Linux (Canvas 19) and Windows (Canvas 20) native reparenting lands —
+selecting it there raises `IllegalStateException` from `adoptPopup` by design
+(the native adopt bridge returns 0).
+
+Run scripts per platform (each rebuilds the native lib from `src_c/`):
+`./run-mac-adopt-popup-demo.sh`, `./run-linux-adopt-popup-demo.sh`
+(`WEBVIEW_MODE=heavyweight` to force heavyweight), `run-windows-adopt-popup-demo.bat`.

--- a/demos/WebViewAdoptPopupDemo/README.md
+++ b/demos/WebViewAdoptPopupDemo/README.md
@@ -1,0 +1,53 @@
+# WebViewAdoptPopupDemo
+
+On-device demo for **popup adoption** (Canvas 18) and **custom User-Agent**
+(Canvas 21). Lets you validate the native code for both features on a real
+desktop without swingwebbrowser.
+
+## Run
+
+From the repo root:
+
+```bash
+./run-mac-adopt-popup-demo.sh
+```
+
+It rebuilds `libwebview.dylib` from `src_c/` (so your changes to the native
+adoption / UA code are picked up), builds `dist/WebView.jar`, then compiles
+and launches the demo.
+
+> The POST/echo checks hit `https://httpbin.org`, so they need network. The
+> adoption and opener mechanics work offline too.
+
+## What to exercise
+
+**Popup mode** (top-left combo):
+
+- **Adopt into tab** — `popupDisposition` returns `ADOPT`. The engine keeps
+  the opener-linked child and `popupAdoptable` hosts it in a **new tab** via
+  `WebViewComponent.adoptPopup(popupId)`.
+  - Click **POST → popup**: the new tab shows httpbin's JSON echo containing
+    `"form": { "q": "hello" }` — proof the **POST body survived** into the
+    adopted tab (not a GET). The echoed `"User-Agent"` header reflects any
+    custom UA you set.
+  - **window.open → popup** and the **target=_blank** link also open as tabs.
+  - No native popup window appears at any point.
+- **Native window** — the Canvas 15 behaviour: the popup opens in a separate
+  native window (POST preserved, opener-linked).
+- **Block** — `window.open` returns `null`; the POST form submit is blocked.
+
+**User-Agent** (field + Set / Reset):
+
+- Edit the field (prefilled with a Safari UA) and click **Set UA** — the
+  opener reloads. The page's `navigator.userAgent` readout updates, and
+  submitting the POST form shows the changed `User-Agent` header in the
+  httpbin echo (proving the **HTTP header**, not just the JS value, changed).
+- **Reset UA** restores the engine default.
+
+## Notes
+
+- The demo sets `JPopupMenu.setDefaultLightWeightPopupEnabled(false)` and the
+  tooltip equivalent, required for heavyweight popups.
+- Adoption's reference backend is macOS (WKWebView). Linux (Canvas 19) and
+  Windows (Canvas 20) native adoption are follow-ups; on those the disposition
+  falls back and popups are not yet adopted into tabs.

--- a/demos/WebViewAdoptPopupDemo/build.xml
+++ b/demos/WebViewAdoptPopupDemo/build.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="WebViewAdoptPopupDemo" default="run" basedir=".">
+    <description>Build and run the popup-adoption + custom-User-Agent demo.</description>
+
+    <property name="src.dir" value="src"/>
+    <property name="build.dir" value="build"/>
+    <property name="classes.dir" value="${build.dir}/classes"/>
+    <property name="webview.jar" value="../../dist/WebView.jar"/>
+    <property name="main.class" value="ca.weblite.webview.demos.WebViewAdoptPopupDemo"/>
+
+    <target name="check-webview-jar">
+        <available file="${webview.jar}" property="webview.jar.exists"/>
+        <fail unless="webview.jar.exists">
+WebView.jar not found at ${webview.jar}.
+Build it first from the project root, e.g. run ./run-mac-adopt-popup-demo.sh
+(or another platform run-*-demo.sh / .bat) once to produce dist/WebView.jar.
+        </fail>
+    </target>
+
+    <target name="compile" depends="check-webview-jar">
+        <mkdir dir="${classes.dir}"/>
+        <javac srcdir="${src.dir}" destdir="${classes.dir}"
+               includeantruntime="false" source="1.8" target="1.8">
+            <classpath>
+                <pathelement location="${webview.jar}"/>
+            </classpath>
+        </javac>
+    </target>
+
+    <target name="run" depends="compile">
+        <java classname="${main.class}" fork="true">
+            <classpath>
+                <pathelement location="${classes.dir}"/>
+                <pathelement location="${webview.jar}"/>
+            </classpath>
+        </java>
+    </target>
+
+    <target name="clean">
+        <delete dir="${build.dir}"/>
+    </target>
+</project>

--- a/demos/WebViewAdoptPopupDemo/src/ca/weblite/webview/demos/WebViewAdoptPopupDemo.java
+++ b/demos/WebViewAdoptPopupDemo/src/ca/weblite/webview/demos/WebViewAdoptPopupDemo.java
@@ -1,0 +1,176 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview.demos;
+
+import ca.weblite.webview.PopupDisposition;
+import ca.weblite.webview.WebViewPopupEvent;
+import ca.weblite.webview.WebViewPopupHandler;
+import ca.weblite.webview.swing.WebViewComponent;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JTabbedPane;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.ToolTipManager;
+
+/**
+ * On-device demo for Canvas 18 (popup adoption) and Canvas 21 (custom
+ * User-Agent).  Exercises everything the two features add, so the native
+ * code can be validated on a real desktop without swingwebbrowser:
+ *
+ * <ul>
+ *   <li><b>Popup mode</b> combo — Adopt into tab / Native window / Block —
+ *       drives {@code popupDisposition}.  On {@code ADOPT}, {@code
+ *       popupAdoptable} opens the engine's opener-linked child as a new tab
+ *       via {@link WebViewComponent#adoptPopup(long)}.</li>
+ *   <li>The opener page has a <b>POST form</b> ({@code target="win"}), a
+ *       {@code window.open} button, and a {@code target="_blank"} link, plus
+ *       a live {@code navigator.userAgent} readout.  Submitting the POST form
+ *       in Adopt mode proves the POST body survives into the adopted tab
+ *       (httpbin echoes {@code q=hello} and the {@code User-Agent} header).</li>
+ *   <li><b>User-Agent</b> field + Set / Reset — calls {@link
+ *       WebViewComponent#setUserAgent(String)} on the opener and reloads, so
+ *       both the JS-visible UA and the HTTP header (visible in the httpbin
+ *       echo) change.</li>
+ * </ul>
+ *
+ * <p>The POST/echo checks hit {@code https://httpbin.org/post}, so they need
+ * network; the adoption / opener mechanics work offline too.
+ */
+public final class WebViewAdoptPopupDemo {
+
+    /** A current desktop Safari UA (prefilled into the UA field). */
+    private static final String SAFARI_UA =
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+      + "AppleWebKit/605.1.15 (KHTML, like Gecko) "
+      + "Version/18.3 Safari/605.1.15";
+
+    /** Read off the EDT by {@code popupDisposition} (native UI thread); set
+     *  on the EDT when the combo changes. */
+    private static volatile PopupDisposition mode = PopupDisposition.ADOPT;
+
+    public static void main(String[] args) {
+        // Heavyweight popups need Swing popups to be heavyweight too.
+        JPopupMenu.setDefaultLightWeightPopupEnabled(false);
+        ToolTipManager.sharedInstance().setLightWeightPopupEnabled(false);
+        SwingUtilities.invokeLater(WebViewAdoptPopupDemo::buildUi);
+    }
+
+    private static void buildUi() {
+        JFrame frame = new JFrame("WebView Adopt-Popup + User-Agent Demo");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setSize(1000, 760);
+
+        JTabbedPane tabs = new JTabbedPane();
+
+        WebViewComponent opener = WebViewComponent.create();
+        opener.setPopupHandler(new WebViewPopupHandler() {
+            // Native UI thread, synchronous, off the EDT.
+            @Override public PopupDisposition popupDisposition(
+                    WebViewPopupEvent e) {
+                return mode;
+            }
+            // EDT: host the retained child in a new tab.
+            @Override public void popupAdoptable(WebViewPopupEvent e,
+                                                 long popupId) {
+                WebViewComponent tab = WebViewComponent.adoptPopup(popupId);
+                addTab(tabs, "popup", tab);
+            }
+            @Override public void popupOpened(WebViewPopupEvent e) {
+                System.out.println("[demo] popupOpened  " + e.targetUrl());
+            }
+            @Override public void popupClosed(WebViewPopupEvent e) {
+                System.out.println("[demo] popupClosed  " + e.targetUrl());
+            }
+        });
+        opener.setUrl(openerPage());
+
+        frame.add(buildControls(opener), java.awt.BorderLayout.NORTH);
+        addTab(tabs, "opener", opener);
+        frame.add(tabs, java.awt.BorderLayout.CENTER);
+        frame.setVisible(true);
+    }
+
+    private static JPanel buildControls(WebViewComponent opener) {
+        JPanel bar = new JPanel(new java.awt.FlowLayout(
+            java.awt.FlowLayout.LEFT, 8, 6));
+        bar.setBorder(BorderFactory.createEmptyBorder(2, 4, 2, 4));
+
+        bar.add(new JLabel("Popup mode:"));
+        JComboBox<String> modeBox = new JComboBox<>(new String[] {
+            "Adopt into tab", "Native window", "Block" });
+        modeBox.addActionListener(e -> {
+            switch (modeBox.getSelectedIndex()) {
+                case 1:  mode = PopupDisposition.NATIVE_WINDOW; break;
+                case 2:  mode = PopupDisposition.BLOCK;         break;
+                default: mode = PopupDisposition.ADOPT;         break;
+            }
+        });
+        bar.add(modeBox);
+
+        bar.add(new JLabel("   User-Agent:"));
+        JTextField uaField = new JTextField(SAFARI_UA, 34);
+        bar.add(uaField);
+        JButton setUa = new JButton("Set UA");
+        setUa.addActionListener(e -> {
+            opener.setUserAgent(uaField.getText());
+            opener.setUrl(openerPage());  // reload so the UA applies
+        });
+        bar.add(setUa);
+        JButton resetUa = new JButton("Reset UA");
+        resetUa.addActionListener(e -> {
+            opener.setUserAgent(null);
+            opener.setUrl(openerPage());
+        });
+        bar.add(resetUa);
+        return bar;
+    }
+
+    private static void addTab(JTabbedPane tabs, String title,
+                               WebViewComponent c) {
+        tabs.addTab(title, c);
+        tabs.setSelectedComponent(c);
+    }
+
+    /** Opener page as a base64 {@code data:} URL (the cross-engine-reliable
+     *  path the dialog/popup demos use). */
+    private static String openerPage() {
+        String html =
+            "<!doctype html><html><head><meta charset=utf-8>"
+          + "<style>body{font:14px system-ui;margin:24px;line-height:1.5}"
+          + "button,a{font-size:14px}code{background:#eee;padding:2px 4px}"
+          + "</style></head><body>"
+          + "<h2>Adopt-popup + User-Agent demo</h2>"
+          + "<p><b>navigator.userAgent:</b><br><code id=ua></code></p>"
+          + "<h3>1. POST form (proves POST survives into the popup)</h3>"
+          + "<form method='post' action='https://httpbin.org/post' "
+          + "target='win'>"
+          + "<input name='q' value='hello'> "
+          + "<button type='submit'>POST &rarr; popup</button></form>"
+          + "<h3>2. window.open</h3>"
+          + "<button onclick=\"window.open("
+          + "'https://httpbin.org/user-agent','win','width=520,height=640')\">"
+          + "window.open &rarr; popup</button>"
+          + "<h3>3. target=_blank link</h3>"
+          + "<a href='https://example.com' target='_blank'>open example.com</a>"
+          + "<script>document.getElementById('ua').textContent="
+          + "navigator.userAgent;</script>"
+          + "</body></html>";
+        String b64 = Base64.getEncoder().encodeToString(
+            html.getBytes(StandardCharsets.UTF_8));
+        return "data:text/html;charset=utf-8;base64," + b64;
+    }
+
+    private WebViewAdoptPopupDemo() { }
+}

--- a/requirements/[User-story-5]adopt-popups-into-webviewcomponent-tab.md
+++ b/requirements/[User-story-5]adopt-popups-into-webviewcomponent-tab.md
@@ -1,0 +1,510 @@
+# Story Decomposition: Adopt Browser-Initiated Popups Into a Caller-Provided WebViewComponent (Swing Tab)
+
+## INVEST Analysis
+
+### Abstract Task: "Popup Adoption Into a Swing Tab"
+
+**Analysis Dimensions**:
+- **Core Responsibility**: Let an application host a browser-initiated
+  popup (the engine-created, opener-linked child web view raised by
+  `window.open`, `<a target="_blank">`, or `<form method="post"
+  target="…">`) inside a `WebViewComponent` it supplies — i.e. a new
+  tab — instead of the native top-level window the engine currently
+  owns (Canvas 15). The adopted child must keep the exact navigation
+  WebKit started: the POST verb and body, and opener linkage
+  (`window.opener`, `postMessage`).
+- **Primary Operations**: (1) decide popup disposition on the native
+  UI thread — block / native-window / adopt; (2) on adopt, create the
+  linked child but host it in a hidden native holder (no visible
+  window); (3) notify the application asynchronously on the EDT; (4)
+  construct a `WebViewComponent` that wraps the pre-existing child
+  engine and reparent the native child into that component's realized
+  surface; (5) observe close and dispose.
+- **Key Constraints**: `popupRequested` is synchronous on the native
+  UI thread and MUST NOT round-trip to the EDT (deadlock) — so the
+  target component cannot be created inside it; adoption is therefore
+  two-phase and asynchronous. POST body is NOT reliably exposed to the
+  delegate on any engine, so replaying the request from Java is not an
+  option — the engine's own child must be reused. Backward compatible
+  with Canvas 15 (existing boolean handlers keep working;
+  `setPopupHandler(null)` still blocks all).
+- **Technical Complexity**: High — a new `WebViewComponent`
+  construction mode that adopts a pre-existing native engine, native
+  reparenting of an already-created child view across three engines,
+  and a strict off-EDT/on-EDT threading split.
+- **Business Complexity**: Medium — one primary scenario (popup →
+  tab) with disposition and lifecycle variants.
+
+### INVEST Evaluation
+
+- ✅ **Independent**: Builds only on Canvas 15's shipped popup
+  plumbing (`WebViewPopupHandler`, `PopupDispatcher`, the native
+  `create`/`NewWindowRequested` sites). Each per-platform sub-story is
+  independently shippable; the Java contract is designed once in
+  STORY-005-001 and the other stories conform to it. The consumer
+  story (STORY-005-004) is separately valuable.
+- ✅ **Negotiable**: The disposition surface (enum vs. richer handler
+  return), the adoption entry point, and the native reparenting
+  strategy are all open to team design in `/spdd-analysis` and
+  `/spdd-reasons-canvas`.
+- ✅ **Valuable**: Fixes a concrete, currently-broken user outcome —
+  POST-form and OAuth popups opened as tabs in a tabbed browser.
+- ✅ **Estimable**: Each sub-story mirrors the dialog (Canvas 11–13)
+  and popup (Canvas 15–17) staging the team has already executed
+  twice.
+- ✅ **Small**: Each sub-story is 2-5 days.
+- ✅ **Testable**: The Java contract has unit-testable behavior
+  (disposition routing, adopt-construction validation, dispatcher
+  correlation); native paths are validated on-device via the demo,
+  consistent with the repo's no-automated-GUI-tests policy.
+
+**Conclusion**: Needs splitting along the same platform-backend
+boundaries the dialog and popup features used, plus a consumer story.
+The Java contract is established in STORY-005-001 (co-delivered with
+macOS, the reference engine). STORY-005-002 (Linux) and STORY-005-003
+(Windows) extend native coverage. STORY-005-004 wires swingwebbrowser
+to open popups as real tabs through the adopt path.
+
+### Split Strategy
+
+```
+STORY-005-001 (Java adopt contract + macOS WKWebView)
+        │
+        ├──► STORY-005-002 (Linux WebKitGTK: heavyweight + offscreen) — conforms to the 005-001 contract
+        │
+        ├──► STORY-005-003 (Windows WebView2) — conforms to the 005-001 contract
+        │
+        └──► STORY-005-004 (swingwebbrowser consumer: popups → tabs, POST preserved) — depends on the 005-001 contract; on-device needs the matching platform story
+```
+
+STORY-005-002 and STORY-005-003 can proceed in parallel once
+STORY-005-001 has landed. STORY-005-004 can be developed against the
+Java contract from STORY-005-001 and lights up per platform as
+002/003 land.
+
+---
+
+## [STORY-005-001] Popup-Adoption Java Contract and macOS WKWebView Coverage
+
+### Background
+
+Canvas 15 ("Browser-Initiated Popups") gave the embedded page a way
+to raise popups — `window.open`, `<a target="_blank">`, `<form
+target="…">` — and the native engine hosts each popup's opener-linked
+child web view in a **native top-level window it owns** (NSWindow /
+GtkWindow / HWND). The Java `WebViewPopupHandler` only decides
+allow/deny and observes open/close; it never gets to host the popup in
+a Swing surface. Canvas 15 named this exact follow-up as anticipated
+future work: *"A future canvas may add an 'adopt into a provided
+`WebViewComponent`' path if a caller needs Swing integration."*
+
+A tabbed browser (swingwebbrowser) built on the library wants popups
+to appear as **new tabs**. With only the Canvas 15 API it must block
+the native window (`popupRequested` → `false`) and re-open the popup's
+URL in a fresh tab with `WebViewComponent.setUrl(url)`. That is a
+plain GET, so a `<form method="post" target="…">` popup loses its POST
+body entirely, and the re-opened page is no longer opener-linked
+(`window.opener` is null, `postMessage` to the opener fails, OAuth
+"sign-in with popup" breaks). The POST body is not reliably exposed to
+the popup-create delegate on any engine, so the request cannot be
+reconstructed and replayed from Java. The only faithful path is to
+reuse the engine's own child — the view WebKit already drove the
+original request into.
+
+This story designs the cross-platform Java contract for **adopting**
+that child into a caller-supplied `WebViewComponent`, and ships the
+macOS (WKWebView) implementation as the reference backend.
+
+### Business Value
+
+- Provide application developers a way to host a browser-initiated
+  popup inside their own Swing surface (a tab), not only in a native
+  window.
+- Preserve the popup's real navigation — POST method and body — and
+  its opener linkage, so form-POST popups and OAuth popup flows work
+  when surfaced as tabs.
+- Establish the single Java contract that the Linux and Windows
+  stories conform to, avoiding per-platform API drift.
+
+### Dependencies and Assumptions
+
+- **Prerequisites**: Canvas 15 (popup `window.open` support:
+  `WebViewPopupHandler`, `WebViewPopupEvent`, `PopupDispatcher`,
+  `WebViewPopupCallback`, and the native popup-create sites) is in
+  place on macOS. Canvases 5/6/7 (mode selection, heavyweight,
+  lightweight embedding) provide the `WebViewComponent` peer model.
+- **Data assumptions**: A popup request already reaches the native
+  popup-create delegate (macOS
+  `createWebViewWithConfiguration:forNavigationAction:windowFeatures:`),
+  which today constructs the linked child and its own NSWindow.
+- **Integration points**: The consuming application
+  (swingwebbrowser, STORY-005-004) installs the handler and creates
+  the target tab component.
+- **Business constraints**: Backward compatibility with Canvas 15 is
+  mandatory — existing `boolean popupRequested` handlers and
+  `setPopupHandler(null)` semantics must be unchanged for callers who
+  do not opt into adoption.
+
+### Scope In
+
+- A popup **disposition** decision surfaced on the native UI thread:
+  block, host in a native window (today's behavior), or adopt into a
+  Swing component. Adoption is requested here but performed later.
+- A hidden-holder path: on an adopt decision the macOS engine creates
+  the opener-linked child WKWebView but does NOT create or show its
+  own NSWindow (no visible flash), retaining the child under an
+  offscreen holder keyed by the popup id.
+- An asynchronous EDT notification that carries enough to build the
+  tab and request adoption (the popup id + event fields).
+- A `WebViewComponent` construction/attach mode that wraps the
+  pre-existing macOS child engine identified by the popup id and
+  reparents the child WKWebView into the component's realized surface,
+  instead of creating a new engine.
+- Backward-compatible handler API: existing boolean handlers keep
+  working (mapped to the native-window disposition);
+  `setPopupHandler(null)` still blocks all popups.
+- macOS (WKWebView) native implementation of the above.
+- `PopupDispatcher` / handler unit tests for the new disposition
+  routing, adopt-request plumbing, correlation, and dispose behavior.
+- README + demo coverage of the adopt path on macOS.
+
+### Scope Out
+
+- Linux (STORY-005-002) and Windows (STORY-005-003) native adoption.
+- swingwebbrowser consumer wiring (STORY-005-004).
+- Reparenting an *arbitrary* running `WebViewComponent` between
+  windows — this story only adopts a **freshly engine-created popup
+  child**, once, at popup time.
+- Exposing the raw HTTP method/body to Java — adoption reuses the
+  engine's child precisely because the request cannot be surfaced;
+  no `postUrl`/request-object API is added.
+- Per-popup window chrome, feature strings beyond width/height, HTTP
+  auth / download / permission channels (unchanged from Canvas 15).
+
+### Acceptance Criteria
+
+#### AC1: A POST-form popup adopted into a tab keeps its POST body
+**Given** an embedded page with `<form method="post" action="/echo"
+target="win"><input name="q" value="hello"></form>` and an installed
+handler that requests **adopt** disposition
+**When** the form is submitted and the application adopts the popup
+into a new tab's `WebViewComponent`
+**Then** the adopted tab shows the server's response to the **POST**
+(the echoed body contains `q=hello`), not a GET of `/echo`.
+
+#### AC2: An adopted popup remains opener-linked
+**Given** a page that opens a popup via
+`window.open('child.html','win')` and the popup calls
+`window.opener.postMessage('ready','*')` then `window.close()`
+**When** the popup is adopted into a tab
+**Then** `window.opener` in the popup is non-null, the opener page
+receives the `'ready'` message, and `window.close()` closes the
+adopted tab's popup.
+
+#### AC3: Adopt disposition shows no native popup window
+**Given** a handler that requests adopt disposition
+**When** a popup is raised
+**Then** no separate native top-level popup window appears at any
+point; the popup content becomes visible only once it is adopted into
+the caller's component.
+
+#### AC4: Backward compatibility — existing allow handler still opens a native window
+**Given** a handler that uses only the Canvas 15 API and allows the
+popup (the default, or `popupRequested` returning `true`)
+**When** a popup is raised
+**Then** the popup opens in a native top-level window exactly as
+before this story — no adoption occurs and no behavior changes.
+
+#### AC5: Backward compatibility — blocking still blocks
+**Given** `setPopupHandler(null)` (or a handler that denies the popup)
+**When** a popup is raised
+**Then** the popup is blocked (`window.open` returns `null`) and no
+child is created or retained — identical to Canvas 15.
+
+#### AC6: A requested adoption that is never claimed does not leak
+**Given** a handler that requests adopt disposition but the
+application never constructs a component to adopt the popup
+**When** a bounded grace period elapses (or the opener is disposed)
+**Then** the retained child engine and its hidden holder are torn down
+and the popup is treated as closed — no orphaned native view or engine
+remains.
+
+#### AC7: Adopting an unknown or already-adopted popup id fails cleanly
+**Given** an application that attempts to adopt a popup id that was
+never issued, or one it has already adopted
+**When** it constructs the adopting `WebViewComponent`
+**Then** the attempt is rejected with a clear, documented error and no
+partially-constructed component or native view is left behind.
+
+#### AC8: Closing an adopted popup notifies the application
+**Given** a popup adopted into a tab
+**When** the popup page calls `window.close()` or the user closes the
+tab
+**Then** the application receives the close notification correlated to
+the same popup, and the adopted component and child engine are
+disposed without dereferencing freed native state.
+
+#### Non-Functional Expectations
+- The disposition decision on the native UI thread must remain fast
+  and must not access Swing or block on the EDT (the deadlock
+  constraint from Canvas 15 is preserved).
+- Constructing the adopting `WebViewComponent`, and all handler
+  notifications, must be safe on the EDT and must not throw
+  `HeadlessException` in headless construction paths that do not
+  realize a peer.
+
+---
+
+## [STORY-005-002] Linux WebKitGTK Coverage for Popup Adoption (Heavyweight + Offscreen)
+
+### Background
+
+STORY-005-001 establishes the Java adoption contract and ships the
+macOS backend. Canvas 16 already wired the Linux WebKitGTK `create`
+signal so `window.open` opens a native, opener-linked popup on Linux
+for both the heavyweight (X11-reparented) and offscreen/lightweight
+engines. This story extends those same sites so an adopt disposition
+retains the `webkit_web_view_new_with_related_view` child under a
+hidden holder and lets the application reparent it into a
+`WebViewComponent`'s realized GTK/X11 surface, instead of hosting it
+in the engine-owned `GtkWindow`.
+
+### Business Value
+
+- Bring the popup-adoption capability to Linux users of the library
+  and of swingwebbrowser, at parity with macOS.
+- Cover both embedding modes (heavyweight and offscreen) with the
+  shared WebKitGTK engine, as the popup and dialog features did.
+
+### Dependencies and Assumptions
+
+- **Prerequisites**: STORY-005-001 (Java contract) merged; Canvas 16
+  (Linux popup `create`-signal support) in place.
+- **Data assumptions**: The Linux `create` signal already produces an
+  opener-linked child that today is placed in a `GtkWindow`.
+- **Integration points**: Same handler/component API as STORY-005-001;
+  no Java API changes.
+- **Business constraints**: No regression to the Canvas 16
+  native-window popup path for callers who do not adopt.
+
+### Scope In
+
+- On adopt disposition, retain the WebKitGTK child under a hidden
+  holder (unrealized/unshown top-level or offscreen container) keyed
+  by popup id, without showing the engine-owned window.
+- Reparent the retained child widget into the adopting
+  `WebViewComponent`'s realized surface for both heavyweight and
+  offscreen engines.
+- Close/teardown wiring for the adopted child on both modes.
+
+### Scope Out
+
+- Java contract changes (owned by STORY-005-001).
+- macOS / Windows backends.
+- swingwebbrowser wiring (STORY-005-004).
+
+### Acceptance Criteria
+
+#### AC1: POST-form popup adopted into a tab keeps its POST body (Linux, heavyweight)
+**Given** a heavyweight `WebViewComponent` on Linux and a handler
+requesting adopt disposition
+**When** a `<form method="post" target="win">` popup is submitted and
+adopted into a new tab
+**Then** the adopted tab shows the POST response with the submitted
+body intact.
+
+#### AC2: POST-form popup adopted into a tab keeps its POST body (Linux, offscreen)
+**Given** an offscreen/lightweight `WebViewComponent` on Linux and a
+handler requesting adopt disposition
+**When** a `<form method="post" target="win">` popup is submitted and
+adopted into a new tab
+**Then** the adopted tab shows the POST response with the submitted
+body intact.
+
+#### AC3: Opener linkage preserved on Linux
+**Given** an adopted popup on Linux
+**When** the popup calls `window.opener.postMessage(...)`
+**Then** the opener page receives the message and `window.close()`
+closes the adopted tab's popup.
+
+#### AC4: No engine-owned popup window on adopt
+**Given** an adopt disposition on Linux
+**When** a popup is raised
+**Then** no `GtkWindow` popup appears; content is visible only after
+adoption.
+
+#### AC5: Backward compatibility on Linux
+**Given** a Canvas 16 allow handler (native window) or
+`setPopupHandler(null)`
+**When** a popup is raised
+**Then** the native-window popup opens (allow) or is blocked (null),
+exactly as before this story.
+
+---
+
+## [STORY-005-003] Windows WebView2 Coverage for Popup Adoption
+
+### Background
+
+STORY-005-001 establishes the Java adoption contract and ships macOS.
+Canvas 17 wired the Windows WebView2 `NewWindowRequested` event so
+`window.open` opens a native, opener-linked popup on Windows via a
+child controller from the same environment (`put_NewWindow`). This
+story extends that handler so an adopt disposition creates the child
+controller against a hidden holder window and lets the application
+reparent/attach the child WebView2 into a `WebViewComponent`'s
+realized `HWND`, instead of showing the engine-owned popup window.
+
+### Business Value
+
+- Bring popup adoption to Windows users at parity with macOS and
+  Linux.
+- Complete the three-platform matrix so swingwebbrowser's tabbed
+  popups work everywhere.
+
+### Dependencies and Assumptions
+
+- **Prerequisites**: STORY-005-001 (Java contract) merged; Canvas 17
+  (Windows popup `NewWindowRequested` support) in place.
+- **Data assumptions**: The WebView2 `NewWindowRequested` deferral
+  path already creates a child controller from the same environment.
+- **Integration points**: Same handler/component API; no Java API
+  changes.
+- **Business constraints**: No regression to the Canvas 17
+  native-window popup path for non-adopting callers.
+
+### Scope In
+
+- On adopt disposition, create the WebView2 child controller against a
+  hidden holder `HWND` (not shown), retained by popup id, completing
+  the `NewWindowRequested` deferral with the child assigned.
+- Reparent/attach the child controller into the adopting
+  `WebViewComponent`'s realized `HWND` and track bounds.
+- Close/teardown wiring (`WindowCloseRequested`) for the adopted
+  child.
+
+### Scope Out
+
+- Java contract changes (owned by STORY-005-001).
+- macOS / Linux backends.
+- swingwebbrowser wiring (STORY-005-004).
+
+### Acceptance Criteria
+
+#### AC1: POST-form popup adopted into a tab keeps its POST body (Windows)
+**Given** a `WebViewComponent` on Windows and a handler requesting
+adopt disposition
+**When** a `<form method="post" target="win">` popup is submitted and
+adopted into a new tab
+**Then** the adopted tab shows the POST response with the submitted
+body intact.
+
+#### AC2: Opener linkage preserved on Windows
+**Given** an adopted popup on Windows
+**When** the popup calls `window.opener.postMessage(...)` then
+`window.close()`
+**Then** the opener receives the message and the adopted tab's popup
+closes.
+
+#### AC3: No engine-owned popup window on adopt
+**Given** an adopt disposition on Windows
+**When** a popup is raised
+**Then** no separate WebView2 popup window appears; content is visible
+only after adoption.
+
+#### AC4: Backward compatibility on Windows
+**Given** a Canvas 17 allow handler (native window) or
+`setPopupHandler(null)`
+**When** a popup is raised
+**Then** the native-window popup opens (allow) or is blocked (null),
+exactly as before this story.
+
+---
+
+## [STORY-005-004] swingwebbrowser: Open Browser Popups as Real Tabs via Adoption
+
+### Background
+
+swingwebbrowser currently opens browser-initiated popups as new tabs
+by blocking the native popup window and calling `newTab(targetUrl)`,
+which issues a GET (`BrowserTab.java` popup handler →
+`BrowserFrame.onPopupRequested` → `newTab` → `setUrl`). This drops the
+POST body of `<form method="post" target="…">` popups and breaks
+opener linkage. This story rewires swingwebbrowser onto the popup
+adoption contract from STORY-005-001 so popups become tabs that host
+the engine's real opener-linked child, preserving POST and
+`window.opener`.
+
+### Business Value
+
+- Deliver the actual user-visible outcome: form-POST popups and OAuth
+  "sign-in with popup" flows open correctly as tabs in the browser.
+- Remove the lossy GET-reopen workaround.
+
+### Dependencies and Assumptions
+
+- **Prerequisites**: STORY-005-001 (Java adopt contract) available in
+  the swingwebview dependency; on-device correctness on a given OS
+  additionally requires the matching platform story (005-002 /
+  005-003).
+- **Data assumptions**: swingwebbrowser already manages tabs and
+  `WebViewComponent`s per tab.
+- **Integration points**: The swingwebview popup-adoption API.
+- **Business constraints**: The tab UX (title, history, close) must
+  work for adopted popup tabs as for normal tabs.
+
+### Scope In
+
+- Replace the block-and-GET-reopen popup handler with an
+  adopt-disposition handler: request adoption on the native thread,
+  and on the EDT notification create a new tab whose
+  `WebViewComponent` adopts the popup child.
+- Ensure adopted popup tabs participate in normal tab behavior
+  (selection, title updates, close, dev console retargeting).
+- Handle the not-adopted / failed-adopt cases gracefully (no orphan
+  tabs; the popup is dropped cleanly).
+
+### Scope Out
+
+- Any change to the swingwebview library contract (owned by
+  STORY-005-001).
+- Native engine changes.
+
+### Acceptance Criteria
+
+#### AC1: POST-form popup opens as a tab with POST preserved
+**Given** the browser is on a page with `<form method="post"
+action="/echo" target="popup"><input name="q" value="hi"></form>`
+**When** the user submits the form
+**Then** a new tab opens showing the server's POST response echoing
+`q=hi` — not a GET of `/echo`.
+
+#### AC2: window.open popup opens as an opener-linked tab
+**Given** a page that calls
+`window.open('child.html','popup','width=520,height=640')`
+**When** the popup is created
+**Then** a new tab opens loading `child.html`, `window.opener` is
+non-null in that tab, and `window.opener.postMessage(...)` reaches the
+originating tab.
+
+#### AC3: target="_blank" link opens as a tab
+**Given** a page with `<a href="page2.html" target="_blank">open</a>`
+**When** the user clicks the link
+**Then** a new tab opens loading `page2.html`.
+
+#### AC4: Popup that calls window.close() closes its tab
+**Given** a popup tab whose page calls `window.close()`
+**When** that happens
+**Then** the corresponding tab closes and browser state stays
+consistent (active tab, tab list).
+
+#### AC5: No lost popups or orphan tabs
+**Given** any allowed popup
+**When** it is created and adopted
+**Then** exactly one tab is created for it; a popup that fails to
+adopt produces no tab and no error dialog surfaced to the user beyond
+a logged diagnostic.
+
+#### Non-Functional Expectations
+- Popup-to-tab creation must feel immediate to the user (no visible
+  intermediate native window, no perceptible flash).

--- a/run-linux-adopt-popup-demo.sh
+++ b/run-linux-adopt-popup-demo.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# One-shot script: build the Linux native lib, build WebView.jar, compile
+# and run the browser-initiated popup demo (WebViewAdoptPopupDemo).
+#
+# Exercises window.open(url, name, features) and <a target="_blank"> across
+# three handler modes (Default = allow, Custom = allow + log
+# popupOpened/popupClosed, Block = setPopupHandler(null) => window.open
+# returns null).  See demos/WebViewAdoptPopupDemo/README.md for the AC-mapped
+# manual test checklist (allow, opener linkage, notifications, requested
+# size, block, window.close()).
+#
+# On Linux the allowed popup is created from WebKitGTK's "create" signal and
+# hosted in a native GTK top-level window linked to the opener; window.close()
+# fires the child's "close" signal, which tears the popup window down.
+#
+# NOTE: this builds libwebview.so WITHOUT linking WebKitGTK/JavaScriptCore
+# (they are dlopen'd at runtime, 4.1 preferred / 4.0 fallback, by
+# src_c/webkit_loader.cpp), so it also exercises that runtime-resolution path.
+#
+# Usage:    ./run-linux-popup-demo.sh             # lightweight (default)
+#           ./run-linux-popup-demo.sh heavyweight # force heavyweight mode
+#           ./run-linux-popup-demo.sh lightweight # force lightweight mode
+#           WEBVIEW_MODE=heavyweight ./run-linux-popup-demo.sh
+#
+# Popups work in BOTH embedding modes on Linux; run the script twice (once
+# per mode) to cover the full matrix.
+#
+# Override JDK:  JAVA_HOME=/path/to/jdk ./run-linux-popup-demo.sh
+#
+# Required packages:
+#   - g++, pkg-config
+#   - libgtk-3-dev
+#   - libwebkit2gtk-4.1-dev (Ubuntu 24.04+) or libwebkit2gtk-4.0-dev (older)
+#   - libx11-dev
+#   - libxt-dev   <-- pulled in because JDK 8's jawt_md.h includes X11/Intrinsic.h
+set -e
+set -o pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR"
+
+# ---------------------------------------------------------------------------
+# 0. Mode selection
+# ---------------------------------------------------------------------------
+MODE="${1:-${WEBVIEW_MODE:-lightweight}}"
+case "$MODE" in
+    heavyweight|lightweight) ;;
+    *)
+        echo "Unknown mode: $MODE" >&2
+        echo "Usage: $0 [heavyweight|lightweight]" >&2
+        exit 1
+        ;;
+esac
+echo "Mode: $MODE"
+
+# ---------------------------------------------------------------------------
+# 1. Resolve JAVA_HOME
+# ---------------------------------------------------------------------------
+if [ -z "$JAVA_HOME" ]; then
+    if command -v javac >/dev/null 2>&1; then
+        JAVAC_PATH="$(readlink -f "$(command -v javac)" 2>/dev/null || command -v javac)"
+        JAVA_HOME="$(dirname "$(dirname "$JAVAC_PATH")")"
+    fi
+fi
+if [ -z "$JAVA_HOME" ] || [ ! -d "$JAVA_HOME" ]; then
+    echo "JAVA_HOME is not set and could not be resolved automatically." >&2
+    echo "Install a JDK and export JAVA_HOME, e.g. via mise / asdf:" >&2
+    echo "  mise install   # picks up .tool-versions" >&2
+    exit 1
+fi
+export JAVA_HOME
+echo "Using JAVA_HOME=$JAVA_HOME"
+JAVAC="$JAVA_HOME/bin/javac"
+JAVA="$JAVA_HOME/bin/java"
+JAR="$JAVA_HOME/bin/jar"
+for tool in "$JAVAC" "$JAVA" "$JAR"; do
+    if [ ! -x "$tool" ]; then
+        echo "Missing tool: $tool" >&2; exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 2. Pick a WebKit pkg-config name (for HEADERS only; not linked)
+# ---------------------------------------------------------------------------
+if pkg-config --exists webkit2gtk-4.1; then
+    WEBKIT_PKG=webkit2gtk-4.1
+elif pkg-config --exists webkit2gtk-4.0; then
+    WEBKIT_PKG=webkit2gtk-4.0
+else
+    echo "Neither webkit2gtk-4.1 nor webkit2gtk-4.0 was found via pkg-config." >&2
+    echo "Install one of the following with your package manager:" >&2
+    echo "  Debian/Ubuntu 24.04+:  sudo apt install libgtk-3-dev libwebkit2gtk-4.1-dev libx11-dev libxt-dev" >&2
+    echo "  Debian/Ubuntu older:   sudo apt install libgtk-3-dev libwebkit2gtk-4.0-dev libx11-dev libxt-dev" >&2
+    echo "  Fedora:                sudo dnf install gtk3-devel webkit2gtk4.1-devel libX11-devel libXt-devel" >&2
+    exit 1
+fi
+if ! pkg-config --exists gtk+-3.0; then
+    echo "gtk+-3.0 (libgtk-3-dev) is required." >&2
+    exit 1
+fi
+echo "Using WebKit package (headers only): $WEBKIT_PKG"
+
+if ! printf '#include <X11/Intrinsic.h>\nint main(){return 0;}\n' | \
+        g++ -E -x c++ - >/dev/null 2>&1; then
+    echo "" >&2
+    echo "ERROR: <X11/Intrinsic.h> not found." >&2
+    echo "" >&2
+    echo "JDK 8 on Linux pulls X11 Intrinsics in via jawt_md.h.  Install:" >&2
+    echo "  Debian/Ubuntu:  sudo apt install libxt-dev" >&2
+    echo "  Fedora:         sudo dnf install libXt-devel" >&2
+    echo "  Arch:           sudo pacman -S libxt" >&2
+    echo "" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Build libwebview.so for the current arch
+# ---------------------------------------------------------------------------
+case "$(uname -m)" in
+    x86_64|amd64)   NATIVE_DIR=linux_64 ;;
+    aarch64|arm64)  NATIVE_DIR=linux_arm64 ;;
+    armv7l|armv7)   NATIVE_DIR=linux_arm ;;
+    i?86)           NATIVE_DIR=linux_32 ;;
+    *)              NATIVE_DIR=linux_64 ;;
+esac
+echo "Native dir: $NATIVE_DIR (arch: $(uname -m))"
+mkdir -p "$REPO_DIR/src/$NATIVE_DIR"
+SO="$REPO_DIR/src/$NATIVE_DIR/libwebview.so"
+
+NEED_SO=0
+if [ ! -f "$SO" ]; then
+    NEED_SO=1
+else
+    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp src_c/webkit_loader.cpp src_c/webkit_loader.h src_c/webkit_shim.h; do
+        if [ "$src" -nt "$SO" ]; then NEED_SO=1; break; fi
+    done
+fi
+
+if [ "$NEED_SO" = "1" ]; then
+    echo "Building libwebview.so ..."
+    g++ -fPIC -std=c++11 -Wall \
+        -DWEBVIEW_GTK=1 \
+        -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/linux" \
+        -I./src_c \
+        $(pkg-config --cflags gtk+-3.0 "$WEBKIT_PKG") \
+        src_c/webview.c src_c/webview_embed.cpp src_c/webkit_loader.cpp \
+        $(pkg-config --libs gtk+-3.0) \
+        -lX11 -ldl \
+        -shared -o "$SO"
+    echo "Built $SO"
+else
+    echo "libwebview.so up to date."
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Compile WebView Java sources
+# ---------------------------------------------------------------------------
+BUILD_DIR="$REPO_DIR/build"
+WV_CLASSES="$BUILD_DIR/classes-webview"
+WV_JAR="$REPO_DIR/dist/WebView.jar"
+mkdir -p "$WV_CLASSES" "$REPO_DIR/dist"
+echo "Compiling WebView Java sources ..."
+find src -name '*.java' > "$BUILD_DIR/wv-sources.txt"
+"$JAVAC" -d "$WV_CLASSES" -classpath "lib/*" @"$BUILD_DIR/wv-sources.txt"
+
+# ---------------------------------------------------------------------------
+# 5. Build WebView.jar -- classes + linux_*/libwebview.so at jar root
+# ---------------------------------------------------------------------------
+echo "Building WebView.jar ..."
+STAGE="$BUILD_DIR/stage-webview"
+rm -rf "$STAGE"
+mkdir -p "$STAGE/$NATIVE_DIR"
+cp -R "$WV_CLASSES"/. "$STAGE"/
+cp "$SO" "$STAGE/$NATIVE_DIR/libwebview.so"
+( cd "$STAGE" && "$JAR" cf "$WV_JAR" . )
+echo "Built $WV_JAR"
+
+# ---------------------------------------------------------------------------
+# 6. Compile and run the popup demo
+# ---------------------------------------------------------------------------
+DEMO_DIR="$REPO_DIR/demos/WebViewAdoptPopupDemo"
+DEMO_CLASSES="$BUILD_DIR/classes-adopt-popup-demo"
+mkdir -p "$DEMO_CLASSES"
+echo "Compiling demo ..."
+"$JAVAC" -d "$DEMO_CLASSES" -classpath "$WV_JAR" \
+    "$DEMO_DIR/src/ca/weblite/webview/demos/WebViewAdoptPopupDemo.java"
+
+echo "Launching WebViewAdoptPopupDemo (mode=$MODE) ..."
+# Force the X11 GDK backend; embedding via XReparentWindow needs a real X11
+# GdkDisplay on both sides.
+export GDK_BACKEND=x11
+export WEBKIT_DISABLE_DMABUF_RENDERER=1
+export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
+
+exec "$JAVA" \
+    "-Dca.weblite.webview.mode=$MODE" \
+    -cp "$DEMO_CLASSES:$WV_JAR" \
+    ca.weblite.webview.demos.WebViewAdoptPopupDemo

--- a/run-mac-adopt-popup-demo.sh
+++ b/run-mac-adopt-popup-demo.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# One-shot script: build the macOS native lib, build WebView.jar, compile
+# and run the popup-adoption + custom-User-Agent demo (WebViewAdoptPopupDemo).
+#
+# Exercises Canvas 18 (popup adoption: adopt-into-tab / native-window / block
+# via popupDisposition + adoptPopup) and Canvas 21 (WebViewComponent
+# .setUserAgent -- the real HTTP User-Agent header).  See
+# demos/WebViewAdoptPopupDemo/README.md for the manual test checklist.
+#
+# Both features add NEW native symbols (cocoa_adopt_popup / cocoa_discard_popup
+# and cocoa_set_user_agent plus their JNI bridges), so the dylib MUST be
+# recompiled on this Mac -- a stale prebuilt lib will not have them.  This
+# script rebuilds libwebview.dylib whenever src_c/* is newer.
+#
+# Usage:    ./run-mac-adopt-popup-demo.sh
+# Override: JAVA_HOME=/path/to/jdk ./run-mac-adopt-popup-demo.sh
+#
+set -e
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR"
+
+# ---------------------------------------------------------------------------
+# 1. Resolve JAVA_HOME
+# ---------------------------------------------------------------------------
+if [ -z "$JAVA_HOME" ]; then
+    if [ -x /usr/libexec/java_home ]; then
+        JAVA_HOME="$(/usr/libexec/java_home)"
+    fi
+fi
+if [ -z "$JAVA_HOME" ] || [ ! -d "$JAVA_HOME" ]; then
+    echo "JAVA_HOME is not set and could not be resolved automatically." >&2
+    echo "Install a JDK and export JAVA_HOME, e.g.:" >&2
+    echo "  brew install --cask temurin" >&2
+    echo "  export JAVA_HOME=\"\$(/usr/libexec/java_home)\"" >&2
+    exit 1
+fi
+export JAVA_HOME
+echo "Using JAVA_HOME=$JAVA_HOME"
+JAVAC="$JAVA_HOME/bin/javac"
+JAVA="$JAVA_HOME/bin/java"
+JAR="$JAVA_HOME/bin/jar"
+for tool in "$JAVAC" "$JAVA" "$JAR"; do
+    if [ ! -x "$tool" ]; then
+        echo "Missing tool: $tool" >&2; exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 2. Build libwebview.dylib if missing or source is newer
+# ---------------------------------------------------------------------------
+case "$(uname -m)" in
+    arm64|aarch64) NATIVE_DIR=osx_arm64 ;;
+    x86_64)        NATIVE_DIR=osx_64 ;;
+    *)             NATIVE_DIR=osx_64 ;;
+esac
+echo "Native dir: $NATIVE_DIR"
+mkdir -p "$REPO_DIR/src/$NATIVE_DIR"
+DYLIB="$REPO_DIR/src/$NATIVE_DIR/libwebview.dylib"
+NEED_DYLIB=0
+if [ ! -f "$DYLIB" ]; then
+    NEED_DYLIB=1
+else
+    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp; do
+        if [ "$src" -nt "$DYLIB" ]; then NEED_DYLIB=1; break; fi
+    done
+fi
+
+if [ "$NEED_DYLIB" = "1" ]; then
+    echo "Building libwebview.dylib (arch: $(uname -m)) ..."
+    c++ \
+        -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/darwin" \
+        -dynamiclib \
+        src_c/webview_embed.cpp \
+        -o "$DYLIB" \
+        -DWEBVIEW_COCOA=1 \
+        -std=c++11 \
+        -framework WebKit -framework Cocoa -framework QuartzCore \
+        -Wl,-undefined,dynamic_lookup
+    echo "Built $DYLIB"
+else
+    echo "libwebview.dylib up to date."
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Compile WebView Java sources
+# ---------------------------------------------------------------------------
+BUILD_DIR="$REPO_DIR/build"
+WV_CLASSES="$BUILD_DIR/classes-webview"
+WV_JAR="$REPO_DIR/dist/WebView.jar"
+mkdir -p "$WV_CLASSES" "$REPO_DIR/dist"
+echo "Compiling WebView Java sources ..."
+find src -name '*.java' > "$BUILD_DIR/wv-sources.txt"
+"$JAVAC" -d "$WV_CLASSES" \
+    -classpath "lib/*" @"$BUILD_DIR/wv-sources.txt"
+
+# ---------------------------------------------------------------------------
+# 4. Build WebView.jar -- classes + osx_*/libwebview.dylib at the jar root
+# ---------------------------------------------------------------------------
+echo "Building WebView.jar ..."
+STAGE="$BUILD_DIR/stage-webview"
+rm -rf "$STAGE"
+mkdir -p "$STAGE/$NATIVE_DIR"
+cp -R "$WV_CLASSES"/. "$STAGE"/
+cp "$DYLIB" "$STAGE/$NATIVE_DIR/libwebview.dylib"
+( cd "$STAGE" && "$JAR" cf "$WV_JAR" . )
+echo "Built $WV_JAR"
+
+# ---------------------------------------------------------------------------
+# 5. Compile and run the adopt-popup + user-agent demo
+# ---------------------------------------------------------------------------
+DEMO_DIR="$REPO_DIR/demos/WebViewAdoptPopupDemo"
+DEMO_CLASSES="$BUILD_DIR/classes-adopt-popup-demo"
+mkdir -p "$DEMO_CLASSES"
+echo "Compiling demo ..."
+"$JAVAC" -d "$DEMO_CLASSES" \
+    -classpath "$WV_JAR" \
+    "$DEMO_DIR/src/ca/weblite/webview/demos/WebViewAdoptPopupDemo.java"
+
+echo "Launching WebViewAdoptPopupDemo ..."
+exec "$JAVA" \
+    -cp "$DEMO_CLASSES:$WV_JAR" \
+    ca.weblite.webview.demos.WebViewAdoptPopupDemo

--- a/run-windows-adopt-popup-demo.bat
+++ b/run-windows-adopt-popup-demo.bat
@@ -1,0 +1,224 @@
+@echo off
+REM ============================================================================
+REM run-windows-popup-demo.bat
+REM
+REM One-shot build & launch of WebViewAdoptPopupDemo on Windows.  Builds the
+REM WebView2-backed native DLL, packages WebView.jar, compiles the demo, and
+REM runs it.  No Ant required.
+REM
+REM Exercises window.open(url, name, features) and <a target="_blank"> across
+REM three handler modes (Default = allow, Custom = allow + log
+REM popupOpened/popupClosed, Block = setPopupHandler(null) => window.open
+REM returns null).  See demos\WebViewAdoptPopupDemo\README.md for the AC-mapped
+REM manual test checklist (allow, opener linkage, notifications, requested
+REM size, block, window.close()).
+REM
+REM On Windows the allowed popup opens as a separate top-level window via
+REM WebView2's NewWindowRequested event, linked to the opener (so
+REM window.opener / postMessage work -- the mechanism OAuth signInWithPopup
+REM uses); window.close() raises WindowCloseRequested, which closes the
+REM native window and tears the child engine down.  The popup feature adds a
+REM new native symbol, so the DLL MUST be rebuilt on this machine -- a stale
+REM prebuilt webview.dll will not have it.
+REM
+REM Requires:
+REM   - JAVA_HOME set to a JDK 8+ install.
+REM   - Visual Studio 2019 or newer with "Desktop development with C++".
+REM   - The WebView2 runtime (ships with Windows 11; install Evergreen on
+REM     older Windows: https://aka.ms/webview2 ).
+REM ============================================================================
+setlocal enabledelayedexpansion
+
+set "REPO_DIR=%~dp0"
+if "%REPO_DIR:~-1%"=="\" set "REPO_DIR=%REPO_DIR:~0,-1%"
+echo Repo: %REPO_DIR%
+
+REM ---------------------------------------------------------------------------
+REM 1. Resolve JAVA_HOME
+REM ---------------------------------------------------------------------------
+if "%JAVA_HOME%"=="" (
+    echo.
+    echo JAVA_HOME is not set.  Set it to your JDK install and re-run, e.g.:
+    echo.
+    echo     set "JAVA_HOME=C:\Program Files\Amazon Corretto\jdk1.8.0_xxx"
+    echo     run-windows-popup-demo.bat
+    echo.
+    exit /b 1
+)
+if not exist "%JAVA_HOME%\bin\javac.exe" (
+    echo ERROR: javac.exe not found in "%JAVA_HOME%\bin".
+    echo Check that JAVA_HOME points at the JDK root, not the JRE.
+    exit /b 1
+)
+echo Using JAVA_HOME=%JAVA_HOME%
+
+REM ---------------------------------------------------------------------------
+REM 2. Locate Visual Studio via vswhere
+REM ---------------------------------------------------------------------------
+set "vswhere=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%vswhere%" set "vswhere=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%vswhere%" (
+    echo ERROR: vswhere.exe not found.
+    echo Install Visual Studio 2019 or newer with the
+    echo "Desktop development with C++" workload.
+    exit /b 1
+)
+set "vc_dir="
+for /f "usebackq tokens=*" %%i in (`"%vswhere%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+    set "vc_dir=%%i"
+)
+if "%vc_dir%"=="" (
+    echo ERROR: Could not locate a Visual Studio installation with VC tools x86/x64.
+    exit /b 1
+)
+echo Visual Studio: %vc_dir%
+
+REM ---------------------------------------------------------------------------
+REM 3. Activate the MSVC x64 environment
+REM ---------------------------------------------------------------------------
+call "%vc_dir%\Common7\Tools\vsdevcmd.bat" -arch=x64 -host_arch=x64
+if errorlevel 1 (
+    echo ERROR: vsdevcmd.bat failed.
+    exit /b 1
+)
+
+set "SDK_OK="
+for %%I in ("%INCLUDE:;=";"%") do (
+    if exist "%%~I\windows.h" set "SDK_OK=1"
+)
+
+if defined SDK_OK goto :sdk_check_done
+set "KITS_ROOT=C:\Program Files (x86)\Windows Kits\10"
+set "SDK_VER="
+if not exist "%KITS_ROOT%\Include" goto :sdk_check_done
+for /f "delims=" %%V in ('dir /b /ad /on "%KITS_ROOT%\Include" 2^>nul') do (
+    if exist "%KITS_ROOT%\Include\%%V\um\windows.h" set "SDK_VER=%%V"
+)
+if "%SDK_VER%"=="" goto :sdk_check_done
+echo NOTE: vsdevcmd did not register a Windows SDK, but one is present
+echo       on disk.  Manually adding Windows SDK %SDK_VER% at %KITS_ROOT%.
+set "INCLUDE=%INCLUDE%;%KITS_ROOT%\Include\%SDK_VER%\ucrt;%KITS_ROOT%\Include\%SDK_VER%\um;%KITS_ROOT%\Include\%SDK_VER%\shared;%KITS_ROOT%\Include\%SDK_VER%\winrt;%KITS_ROOT%\Include\%SDK_VER%\cppwinrt"
+set "LIB=%LIB%;%KITS_ROOT%\Lib\%SDK_VER%\ucrt\x64;%KITS_ROOT%\Lib\%SDK_VER%\um\x64"
+set "SDK_OK=1"
+:sdk_check_done
+
+if defined SDK_OK goto :build_dll
+echo.
+echo ERROR: Windows SDK headers not found on the cl.exe INCLUDE path.
+echo        vsdevcmd activated successfully but no SDK provides windows.h.
+echo.
+echo Fix: open the Visual Studio Installer, click Modify on your VS install,
+echo and on the "Individual components" tab tick a "Windows 11 SDK" or
+echo "Windows 10 SDK" entry, then re-run this script.
+echo.
+exit /b 1
+:build_dll
+
+REM ---------------------------------------------------------------------------
+REM 4. Build webview.dll (x64)
+REM ---------------------------------------------------------------------------
+set "NATIVE_DIR=windows_64"
+set "DLL_OUT=%REPO_DIR%\src\%NATIVE_DIR%"
+if not exist "%DLL_OUT%" mkdir "%DLL_OUT%"
+set "BUILD_DIR=%REPO_DIR%\build"
+if not exist "%BUILD_DIR%" mkdir "%BUILD_DIR%"
+set "WEBVIEW2_VERSION=1.0.2592.51"
+set "WEBVIEW2_DIR=%REPO_DIR%\windows\script\Microsoft.Web.WebView2.%WEBVIEW2_VERSION%"
+set "WEBVIEW2_NUPKG=%WEBVIEW2_DIR%\Microsoft.Web.WebView2.%WEBVIEW2_VERSION%.nupkg"
+set "WEBVIEW2_URL=https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/%WEBVIEW2_VERSION%"
+
+set "PWSH=%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe"
+if not exist "%PWSH%" set "PWSH=powershell.exe"
+
+if exist "%WEBVIEW2_DIR%\build\native\include\WebView2.h" goto :webview2_ready
+if not exist "%WEBVIEW2_DIR%" mkdir "%WEBVIEW2_DIR%"
+if exist "%WEBVIEW2_NUPKG%" goto :webview2_extract
+echo Downloading Microsoft.Web.WebView2 %WEBVIEW2_VERSION% from NuGet ...
+"%PWSH%" -NoProfile -Command "$ProgressPreference='SilentlyContinue'; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri '%WEBVIEW2_URL%' -OutFile '%WEBVIEW2_NUPKG%' -UseBasicParsing"
+if not exist "%WEBVIEW2_NUPKG%" (
+    echo ERROR: failed to download WebView2 SDK from %WEBVIEW2_URL%.
+    exit /b 1
+)
+:webview2_extract
+echo Extracting Microsoft.Web.WebView2.%WEBVIEW2_VERSION%.nupkg ...
+"%PWSH%" -NoProfile -Command "Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory('%WEBVIEW2_NUPKG%', '%WEBVIEW2_DIR%')"
+if not exist "%WEBVIEW2_DIR%\build\native\include\WebView2.h" (
+    echo ERROR: failed to extract WebView2 SDK.
+    exit /b 1
+)
+:webview2_ready
+
+echo Building webview.dll (x64) ...
+cl /nologo ^
+    /D "WEBVIEW_API=__declspec(dllexport)" ^
+    /D "_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS" ^
+    /I "%JAVA_HOME%\include" ^
+    /I "%JAVA_HOME%\include\win32" ^
+    /I "%REPO_DIR%\windows" ^
+    /I "%WEBVIEW2_DIR%\build\native\include" ^
+    /std:c++17 /EHsc ^
+    /Fo"%BUILD_DIR%\\" ^
+    "%REPO_DIR%\windows\webview.cc" ^
+    "%REPO_DIR%\windows\webview_embed.cc" ^
+    /link /DLL ^
+    "%WEBVIEW2_DIR%\build\native\x64\WebView2LoaderStatic.lib" ^
+    "%JAVA_HOME%\lib\jawt.lib" ^
+    advapi32.lib ole32.lib oleaut32.lib shlwapi.lib shell32.lib user32.lib version.lib winhttp.lib ^
+    /OUT:"%BUILD_DIR%\webview.dll"
+if errorlevel 1 (
+    echo ERROR: cl.exe build failed.
+    exit /b 1
+)
+copy /Y "%BUILD_DIR%\webview.dll" "%DLL_OUT%\webview.dll" >nul
+echo Built %DLL_OUT%\webview.dll
+
+REM ---------------------------------------------------------------------------
+REM 5. Compile WebView Java sources
+REM ---------------------------------------------------------------------------
+set "WV_CLASSES=%BUILD_DIR%\classes-webview"
+if exist "%WV_CLASSES%" rmdir /s /q "%WV_CLASSES%"
+mkdir "%WV_CLASSES%"
+echo Compiling WebView Java sources ...
+dir /s /b "%REPO_DIR%\src\*.java" > "%BUILD_DIR%\wv-sources.txt"
+"%JAVA_HOME%\bin\javac.exe" -d "%WV_CLASSES%" -classpath "%REPO_DIR%\lib\*" @"%BUILD_DIR%\wv-sources.txt"
+if errorlevel 1 (
+    echo ERROR: javac failed.
+    exit /b 1
+)
+
+REM ---------------------------------------------------------------------------
+REM 6. Build WebView.jar
+REM ---------------------------------------------------------------------------
+set "WV_JAR=%REPO_DIR%\dist\WebView.jar"
+if not exist "%REPO_DIR%\dist" mkdir "%REPO_DIR%\dist"
+set "STAGE=%BUILD_DIR%\stage-webview"
+if exist "%STAGE%" rmdir /s /q "%STAGE%"
+mkdir "%STAGE%\%NATIVE_DIR%"
+"%SystemRoot%\System32\xcopy.exe" /e /q /y "%WV_CLASSES%\*" "%STAGE%\" >nul
+if errorlevel 1 (
+    echo ERROR: xcopy of compiled classes into the jar staging dir failed.
+    exit /b 1
+)
+copy /Y "%DLL_OUT%\webview.dll" "%STAGE%\%NATIVE_DIR%\webview.dll" >nul
+pushd "%STAGE%"
+"%JAVA_HOME%\bin\jar.exe" cf "%WV_JAR%" .
+popd
+echo Built %WV_JAR%
+
+REM ---------------------------------------------------------------------------
+REM 7. Compile and launch the popup demo
+REM ---------------------------------------------------------------------------
+set "DEMO_DIR=%REPO_DIR%\demos\WebViewAdoptPopupDemo"
+set "DEMO_CLASSES=%BUILD_DIR%\classes-adopt-popup-demo"
+if not exist "%DEMO_CLASSES%" mkdir "%DEMO_CLASSES%"
+echo Compiling demo ...
+"%JAVA_HOME%\bin\javac.exe" -d "%DEMO_CLASSES%" -classpath "%WV_JAR%" "%DEMO_DIR%\src\ca\weblite\webview\demos\WebViewAdoptPopupDemo.java"
+if errorlevel 1 (
+    echo ERROR: javac failed on demo.
+    exit /b 1
+)
+
+echo Launching WebViewAdoptPopupDemo ...
+"%JAVA_HOME%\bin\java.exe" -cp "%DEMO_CLASSES%;%WV_JAR%" ca.weblite.webview.demos.WebViewAdoptPopupDemo
+
+endlocal

--- a/spdd/analysis/GGQPA-XXX-202608061200-[Analysis]-adopt-popups-into-webviewcomponent-tab.md
+++ b/spdd/analysis/GGQPA-XXX-202608061200-[Analysis]-adopt-popups-into-webviewcomponent-tab.md
@@ -1,0 +1,377 @@
+# SPDD Analysis: Adopt Browser-Initiated Popups Into a Caller-Provided WebViewComponent (STORY-005-001 + macOS)
+
+## Original Business Requirement
+
+> Focused on STORY-005-001 of
+> `requirements/[User-story-5]adopt-popups-into-webviewcomponent-tab.md`
+> (the popup-adoption Java contract + macOS WKWebView reference
+> backend). STORY-005-002 (Linux) / STORY-005-003 (Windows) conform to
+> this contract; STORY-005-004 (swingwebbrowser) consumes it. The full
+> story text is preserved verbatim in that requirements file.
+
+**STORY-005-001 — Popup-Adoption Java Contract and macOS WKWebView Coverage.**
+
+Canvas 15 gave the embedded page a way to raise popups (`window.open`,
+`<a target="_blank">`, `<form method="post" target="…">`) and the
+native engine hosts each popup's opener-linked child web view in a
+**native top-level window it owns** (NSWindow / GtkWindow / HWND). The
+Java `WebViewPopupHandler` only decides allow/deny (`boolean
+popupRequested`) and observes open/close. A tabbed browser
+(swingwebbrowser) wanting popups as **tabs** must block the native
+window and re-open `WebViewPopupEvent.targetUrl()` with
+`WebViewComponent.setUrl(url)` — a GET — which drops the POST body of
+form-POST popups and breaks opener linkage (`window.opener`,
+`postMessage`). The POST body is not reliably exposed to the
+popup-create delegate on any engine, so the request cannot be replayed
+from Java. The only faithful path is to **reuse the engine's own
+opener-linked child** — the view WebKit already drove the original
+request into.
+
+This story designs the cross-platform Java contract for **adopting**
+that child into a caller-supplied `WebViewComponent` (a tab) and ships
+the macOS (WKWebView) reference backend. Backward compatibility with
+Canvas 15 is mandatory. The acceptance criteria (AC1–AC8) are recorded
+verbatim in the requirements file: POST preserved (AC1), opener
+linkage preserved (AC2), no native popup window on adopt (AC3),
+allow/block backward compatibility (AC4/AC5), unclaimed-adoption
+cleanup (AC6), unknown/already-adopted id rejection (AC7), close
+notification + disposal (AC8), plus off-EDT/headless non-functional
+expectations.
+
+## Domain Concept Identification
+
+### Existing Concepts (from codebase)
+
+- **WebViewPopupHandler** (`src/ca/weblite/webview/WebViewPopupHandler.java`):
+  the policy + observation contract. Three `default` methods —
+  `boolean popupRequested` (allow/deny gate, runs synchronously on the
+  native UI thread, off the EDT), `popupOpened` / `popupClosed`
+  (EDT notifications). `DEFAULT` allows all. This is the surface that
+  must grow an "adopt" disposition without breaking the boolean gate.
+- **WebViewPopupEvent** (`WebViewPopupEvent.java`): immutable carrier
+  — `source`, `targetUrl`, `targetName`, `userGesture`,
+  `width`/`height`, `pageUrl`. No HTTP method/body (by design — not
+  available). Reused as-is for adoption; the popup **id** becomes the
+  correlation key.
+- **PopupDispatcher** (`PopupDispatcher.java`): per-component fan-out
+  hub. `dispatchPopupRequested` runs the handler **inline on the
+  native UI thread** and returns its boolean synchronously;
+  `dispatchPopupOpened`/`dispatchPopupClosed` marshal to the EDT via
+  `invokeLater`. Holds `openPopups: ConcurrentHashMap<Long,
+  WebViewPopupEvent>` correlating open→close by engine-assigned
+  `popupId`. This correlation map is the natural home for
+  adopt-pending bookkeeping.
+- **WebViewPopupCallback** (`WebViewPopupCallback.java`): internal JNI
+  bridge — `onPopupRequested` (sync, returns the decision),
+  `onPopupOpened`/`onPopupClosed` (notifications). Delivered from the
+  native `impl_create_web_view` / `on_create_web_view_popup` sites.
+- **WebViewComponent** (`swing/WebViewComponent.java`): abstract Swing
+  surface. Owns `popupDispatcher` (and dialog/console/mouse
+  dispatchers) for the component's whole lifetime, surviving peer
+  create/destroy. Peer created lazily. `setPopupHandler` /
+  `getPopupHandler` delegate to the dispatcher.
+- **EmbeddedWebView** (`EmbeddedWebView.java`): heavyweight engine
+  wrapper. Constructed via `EmbeddedWebView.attach(canvas, debug)` —
+  binds a **freshly created** native engine to a live AWT canvas
+  surface. Anchors native callbacks in a `heap` list;
+  `setPopupCallback` / `setDialogCallback` register global refs;
+  `dispose()` clears callbacks then destroys the peer.
+- **OffscreenWebView** (`OffscreenWebView.java`): lightweight/offscreen
+  engine wrapper; analogous `setPopupCallback` and offscreen peer.
+- **WebViewHeavyweightComponent.createPeer()** /
+  **WebViewLightweightComponent.addNotify()**: the peer-attach sites.
+  Today they call `EmbeddedWebView.attach(...)` /
+  `engine = <create offscreen>`, then install the console / mouse /
+  focus / click / dialog / popup callbacks that delegate to the
+  per-component dispatchers. This is where an **adopt** construction
+  path must branch.
+- **Native popup-create sites** (`src_c/webview_embed.cpp`): macOS
+  `impl_create_web_view` (builds the child `WKWebView` from the passed
+  `WKWebViewConfiguration`, creates an `NSWindow`, sets the child as
+  `contentView`, `makeKeyAndOrderFront:`, registers a child `Engine`
+  in `g_webview_map` keyed by the child view, fires `onPopupOpened`);
+  `impl_web_view_did_close` (tears the child engine down, fires
+  `onPopupClosed`). Linux `on_create_web_view_popup` /
+  `handle_create_web_view` (creates the related-view child, a
+  `GtkWindow`, registers a `PopupEngine`). These already produce the
+  opener-linked child — the adoption change is about **where the child
+  is hosted** (engine-owned window vs. caller's surface) and **when it
+  is shown**.
+- **g_webview_map** / child `Engine` (macOS) & `PopupEngine` (Linux):
+  the native registries that already key a child engine by an opaque
+  handle equal to the `popupId`. Adoption reuses this registry to look
+  up the retained child at reparent time.
+
+### New Concepts Required
+
+- **Popup disposition (BLOCK / NATIVE_WINDOW / ADOPT)**: the enriched
+  outcome of the synchronous native-thread decision. BLOCK and
+  NATIVE_WINDOW reproduce Canvas 15's `false` / `true`. ADOPT means
+  "create the linked child but do not create/show an engine-owned
+  window; retain it under a hidden holder keyed by `popupId` and
+  notify the app to adopt it." Introduced additively so legacy boolean
+  handlers keep mapping to BLOCK/NATIVE_WINDOW.
+- **Adopt notification / adopt request**: the EDT-side signal carrying
+  the `popupId` (and the `WebViewPopupEvent`) that lets the
+  application build a tab and request adoption. Conceptually a new
+  handler observation (e.g. an EDT `popupAdoptable(event)` /
+  `popupOpened` variant carrying an adopt token) — exact surface is a
+  REASONS-Canvas design decision.
+- **Adopting WebViewComponent construction mode**: a `WebViewComponent`
+  whose peer, at attach time, **adopts a pre-existing native child
+  engine** identified by `popupId` (reparenting the child view into
+  this component's realized surface) instead of creating its own
+  engine. Realized at the wrapper layer as a new
+  `EmbeddedWebView.adopt(canvas, popupId, debug)` /
+  `OffscreenWebView.adopt(...)` seam paralleling `attach(...)`.
+- **Hidden holder + retained child + adopt token lifecycle**: native
+  state that keeps the engine-created child alive and unshown between
+  the synchronous ADOPT decision and the asynchronous reparent, plus
+  the bookkeeping (in `PopupDispatcher` and native registry) that
+  tracks pending adoptions, enforces adopt-once, and reclaims
+  unclaimed children (AC6/AC7).
+- **Adopt/reparent native operation**: move an already-created child
+  view from the hidden holder into a JAWT-realized surface — macOS
+  `addSubview:` into the canvas's `NSView`; (later) Linux
+  reparent into the X11/GTK surface; Windows `SetParent` /
+  `put_ParentWindow`. A new native entry point
+  (`webview_embed_adopt_popup(canvasHandle, popupId)`-style).
+
+### Key Business Rules
+
+- **POST + opener linkage are preserved only by reusing the engine's
+  child** — never by re-navigating from Java. Governs the entire
+  design: the adopting component must wrap the *existing* child engine,
+  not create a new one and `setUrl`.
+- **The synchronous native-thread decision must never touch the EDT or
+  Swing** (Canvas 15 deadlock invariant). Governs disposition:
+  ADOPT is *decided* synchronously but *performed* asynchronously.
+- **Backward compatibility**: legacy boolean `popupRequested` and
+  `setPopupHandler(null)` semantics are unchanged (AC4/AC5). Governs
+  the additive shape of the disposition surface.
+- **Adopt-once, no-leak**: a `popupId` may be adopted at most once;
+  unknown/duplicate ids are rejected cleanly (AC7); an ADOPT that is
+  never claimed is reclaimed (AC6). Governs the retained-child
+  lifecycle.
+- **No visible native window on ADOPT** (AC3) and **no perceptible
+  flash** (STORY-005-004 NFR). Governs the hidden-holder requirement.
+- **`getPopupHandler()` never null; disposed dispatcher inert** —
+  existing PopupDispatcher invariants carry forward to the new paths.
+
+## Strategic Approach
+
+### Solution Direction
+
+Extend Canvas 15's existing popup channel rather than build a parallel
+one. The data flow becomes:
+
+1. **Native popup-create site** (macOS `impl_create_web_view`) →
+   synchronous JNI hop → `PopupDispatcher.dispatchPopupRequested` →
+   handler decision. Enrich the decision to carry disposition
+   (BLOCK / NATIVE_WINDOW / ADOPT) while keeping the boolean bridge
+   for legacy handlers.
+2. On **NATIVE_WINDOW / BLOCK**: exactly today's behavior (create +
+   show NSWindow, or return `nil`).
+3. On **ADOPT**: create the linked child (as today, from the passed
+   configuration — this is what preserves POST + opener), but **do not
+   create/show the NSWindow**; retain the child engine in the native
+   registry under a hidden holder keyed by `popupId`; return the child
+   to WebKit so it drives the original request into it; then fire an
+   **EDT adopt notification** carrying the `popupId`.
+4. **Application (EDT)** creates a new tab with an **adopting
+   WebViewComponent**; its peer-attach path calls
+   `EmbeddedWebView.adopt(canvas, popupId, debug)`, which invokes a new
+   native `adopt_popup` that looks up the retained child by `popupId`
+   and **reparents** its view into the canvas surface, transferring
+   engine ownership to this component and installing the standard
+   per-component callbacks (console/mouse/focus/click/dialog/popup) on
+   the adopted engine.
+5. **Close** (`window.close()` / user closes tab) tears down the
+   adopted engine and fires `popupClosed` correlated by `popupId`
+   (AC8).
+
+Leverage existing conventions throughout: the `heap`-anchored callback
+pattern, the `g_webview_map` child-engine registry, the
+`openPopups` correlation map, the dialog/popup EDT-marshaling
+precedent, and the `attach(...)` peer-construction seam (adding a
+sibling `adopt(...)`).
+
+### Key Design Decisions
+
+- **Disposition surface: additive enum vs. new handler method vs.
+  overloaded return.**
+  - *Trade-offs*: Changing `popupRequested`'s return type from
+    `boolean` breaks Canvas 15 callers. A parallel
+    `PopupDisposition popupDisposition(event)` default-method (default
+    derived from the legacy boolean) keeps compatibility and reads
+    cleanly.
+  - *Recommendation*: Add a new default method returning a
+    `PopupDisposition` enum, whose default implementation delegates to
+    the existing boolean (`popupRequested` → true ⇒ NATIVE_WINDOW,
+    false ⇒ BLOCK). Legacy handlers are untouched; adopters override
+    the new method. Final shape (enum vs. richer token) is fixed in
+    the REASONS Canvas.
+
+- **When to notify the app to adopt: reuse `popupOpened` vs. new
+  `popupAdoptable`.**
+  - *Trade-offs*: Overloading `popupOpened` conflates "native window
+    shown" with "ready to adopt". A dedicated EDT notification
+    (carrying an adopt token/`popupId`) is unambiguous and lets the
+    app decide tab creation.
+  - *Recommendation*: A dedicated EDT adopt notification carrying the
+    `popupId` + event, fired only on the ADOPT path.
+
+- **Adopting-component construction: new `adopt(...)` seam vs. mutate
+  `attach(...)`.**
+  - *Trade-offs*: `attach(canvas, debug)` hard-codes "create a new
+    engine". Bolting an adopt-mode flag onto it muddies the common
+    path. A sibling `EmbeddedWebView.adopt(canvas, popupId, debug)`
+    (and `OffscreenWebView.adopt`) that reparents an existing engine
+    is explicit and testable.
+  - *Recommendation*: New `adopt(...)` seam; the Swing components pick
+    `attach` vs. `adopt` based on whether they were constructed with a
+    pending `popupId`. A public factory
+    (`WebViewComponent.adoptPopup(popupId)` or a constructor variant)
+    exposes this to the consumer.
+
+- **Retained-child lifecycle owner: native registry vs. Java
+  dispatcher.**
+  - *Trade-offs*: The child engine lives natively; but adopt-once,
+    unknown-id rejection, and unclaimed-reclaim (AC6/AC7) need
+    Java-visible state for clean errors and a grace timer.
+  - *Recommendation*: Native registry owns the child object;
+    `PopupDispatcher` tracks pending-adopt `popupId`s (extending the
+    `openPopups` map) to enforce adopt-once, produce clean
+    `IllegalStateException`/`IllegalArgumentException` on unknown or
+    already-adopted ids, and drive reclaim on opener dispose /
+    grace-period expiry.
+
+- **Reclaim policy for unclaimed adoptions (AC6).**
+  - *Trade-offs*: A time-based grace risks tearing down a slow app; no
+    reclaim leaks. Tie reclaim to opener-`WebViewComponent` disposal
+    (deterministic) plus a generous bounded grace as a backstop.
+  - *Recommendation*: Reclaim on opener dispose; add a documented
+    bounded grace as a safety net, logged, not silent.
+
+- **Scope of reparenting.** Only a freshly engine-created popup child
+  is adopted, once, at popup time — not arbitrary running components.
+  Keeps the native reparent tractable and sidesteps the Canvas 15
+  "engines can't be created detached and reparented" concern (the
+  child is already created and realized; moving an existing native
+  view between parents is what heavyweight embedding already does).
+
+### Alternatives Considered
+
+- **Surface HTTP method/body to Java and replay via a new
+  `postUrl`**: rejected — the POST body is not reliably exposed at the
+  popup-create delegate on any engine (WKWebView `HTTPBody` is
+  effectively always nil there; WebKitGTK's `WebKitURIRequest` lacks
+  it), so replay cannot be made correct or cross-engine. Also loses
+  opener linkage. This is the core reason adoption reuses the child.
+- **Synchronously return a caller component from `popupRequested`**:
+  rejected — the decision runs off-EDT on the native UI thread and
+  cannot create/realize a Swing peer without an EDT round-trip
+  (deadlock). Forces the two-phase async model.
+- **Reparent the already-shown native popup window into the tab**:
+  rejected — causes a visible flash (window appears then yanks) and
+  fights the OS window manager; the hidden-holder approach avoids
+  both.
+- **Adopt by creating a new engine and transferring the DOM/session**:
+  rejected — no such transfer primitive exists; opener linkage and the
+  in-flight POST navigation live in the engine's own child.
+
+## Risk & Gap Analysis
+
+### Requirement Ambiguities
+
+- **Exact disposition API shape** (enum returned from a new default
+  method vs. a richer decision object) is left to the REASONS Canvas;
+  the story only requires backward-compatible additivity.
+- **The adopt-notification surface** (dedicated method name, whether
+  it also carries the child's requested size) is unspecified at story
+  level.
+- **Grace-period duration for unclaimed adoptions (AC6)** is not
+  numerically specified — must be chosen in the Canvas (Safeguards)
+  and documented.
+- **Public consumer entry point** for constructing the adopting
+  component (`WebViewComponent.adoptPopup(popupId)` factory vs. a
+  builder) is not fixed.
+
+### Edge Cases
+
+- **Popup closes before it is adopted**: `window.close()` fires on a
+  retained-but-unadopted child — must reclaim and not deliver a stale
+  adopt notification (or deliver a "already closed" signal).
+- **App requests adoption for a `popupId` that was reclaimed** (grace
+  expired / opener disposed): must reject cleanly (AC7 path).
+- **Opener component disposed while an adopt is pending**: retained
+  child must be torn down (AC6).
+- **Nested popups from an adopted popup**: the adopted engine inherits
+  the popup callback, so a popup from within an adopted tab must route
+  to the adopting component's handler (as Canvas 15 already inherits
+  callbacks to child engines).
+- **Lightweight/offscreen adoption** (Linux, STORY-005-002): adopting
+  into an offscreen engine differs from reparenting a heavyweight view
+  — flagged for the platform story but the Java contract must not
+  assume heavyweight.
+- **Two rapid popups** before either is adopted: two retained children,
+  two distinct `popupId`s — the correlation map must not collide.
+- **Headless/unit context**: constructing the handler and dispatcher,
+  and the disposition routing, must be testable without a native peer
+  (AC-style unit tests, per repo policy).
+
+### Technical Risks
+
+- **Threading correctness** (highest): the synchronous ADOPT decision
+  runs off-EDT and must not block on the EDT; the reparent runs on the
+  EDT. A regression here reintroduces the AppKit/EDT deadlock Canvas 15
+  and the deadlock-elimination analysis specifically guard against.
+  Mitigation: keep the native-thread path decision-only; do all Swing
+  work in the EDT adopt path; mirror the existing dispatcher split and
+  cover it in `PopupDispatcher` unit tests.
+- **Native reparenting of a live child view** (macOS `addSubview:`
+  moving a `WKWebView` mid-navigation): retain/release balance and
+  first-responder/focus handoff are delicate; the existing Canvas 15
+  retain/release note already flags on-device zombie/Instruments
+  validation. Mitigation: pattern-faithful native code, marked for
+  on-device validation; no automated GUI tests (repo policy).
+- **Untestable native code in this sandbox**: no native toolchain —
+  macOS (and later Linux/Windows) code is written pattern-faithfully
+  and MUST be built + exercised on-device before release, exactly as
+  Canvases 15/16/17.
+- **Lifecycle leaks**: retained children between decision and adopt are
+  a new leak surface (AC6/AC7). Mitigation: Java-side pending-adopt
+  bookkeeping in `PopupDispatcher`, deterministic reclaim on opener
+  dispose, bounded grace backstop, disposed-dispatcher inertness.
+- **Ownership transfer of engine callbacks**: the adopted engine's
+  inherited (opener) popup/dialog global refs must be re-pointed to the
+  adopting component's dispatchers without double-free. Mitigation:
+  follow the Canvas 15 delete-old / new-global-ref lifecycle at the
+  adopt seam.
+- **Backward-compat regression**: the additive disposition must leave
+  the exact `nil`/`NULL`/native-window behavior for non-adopting
+  callers. Mitigation: derive disposition default from the legacy
+  boolean; keep the `dispatchPopupRequested(...) -> boolean` bridge for
+  existing native callback signatures, adding the disposition channel
+  alongside rather than replacing it.
+
+### Acceptance Criteria Coverage
+
+| AC# | Description | Addressable? | Gaps/Notes |
+|-----|-------------|--------------|------------|
+| AC1 | POST-form popup adopted keeps POST body | Yes | Reusing the engine child preserves the in-flight POST; verified on-device via demo/echo server. |
+| AC2 | Adopted popup remains opener-linked | Yes | Child built from passed configuration = related view; unchanged from Canvas 15. |
+| AC3 | Adopt shows no native popup window | Yes | Hidden-holder path; native code must not create/show NSWindow on ADOPT. |
+| AC4 | Legacy allow → native window unchanged | Yes | Disposition default derives from boolean; NATIVE_WINDOW path is today's code. |
+| AC5 | Blocking still blocks | Yes | BLOCK reproduces `nil`/`false`; no child created. |
+| AC6 | Unclaimed adoption reclaimed, no leak | Partial | Needs a chosen grace-period value + opener-dispose reclaim; specify in Canvas Safeguards. |
+| AC7 | Unknown/already-adopted id rejected cleanly | Yes | Java pending-adopt map enforces adopt-once + clean exceptions. |
+| AC8 | Close notifies app; disposes safely | Yes | Reuse `popupClosed` correlation by `popupId`; teardown ordering per Canvas 15 safeguards. |
+| NFR | Off-EDT decision, headless-safe construction | Yes | Mirrors Canvas 15 threading + headless invariants; covered by unit tests. |
+
+**Coverage summary**: 7/8 ACs fully addressable with the proposed
+approach; AC6 is partial pending a Canvas-level decision on the
+reclaim grace-period value and the opener-dispose reclaim trigger. No
+AC is unaddressable. macOS is the reference backend here; Linux/Windows
+native adoption and the swingwebbrowser consumer are the sibling
+stories (005-002/003/004).

--- a/spdd/prompt/18-20260806-1200-[Feat]-Popup-Adoption-Into-Webviewcomponent-Tab.md
+++ b/spdd/prompt/18-20260806-1200-[Feat]-Popup-Adoption-Into-Webviewcomponent-Tab.md
@@ -1,0 +1,763 @@
+---
+generated_at: 2026-08-06T12:00:00-07:00
+---
+
+# REASONS Canvas: Popup Adoption Into a Caller-Provided WebViewComponent — Java API + macOS Coverage (STORY-005-001)
+
+## R · Requirements
+
+- Extend the browser-initiated popup feature
+  ([[browser-initiated-popups-window-open]], Canvas 15) so an
+  application can **adopt** an engine-created popup — the
+  opener-linked child web view WebKit raises for `window.open`, `<a
+  target="_blank">`, or `<form method="post" target="…">` — into a
+  **`WebViewComponent` the application supplies** (a Swing tab),
+  instead of the native top-level window the engine owns today. Ship
+  the cross-platform Java contract and the **macOS (WKWebView)**
+  reference backend. This is exactly the "adopt into a provided
+  `WebViewComponent`" path Canvas 15 named as anticipated future work.
+
+- **Why the existing model is insufficient for a tabbed browser.** A
+  tabbed consumer (swingwebbrowser) that wants popups as tabs must
+  today block the native window (`popupRequested` → `false`) and
+  re-open `WebViewPopupEvent.targetUrl()` via
+  `WebViewComponent.setUrl(url)`. `setUrl` issues a **GET**, so a
+  `<form method="post" target="…">` popup loses its POST body, and the
+  re-opened page is no longer opener-linked (`window.opener` is null,
+  `postMessage`-to-opener fails, OAuth "sign-in with popup" breaks).
+  The POST body is **not reliably exposed** to the popup-create
+  delegate on any engine (WKWebView's `navigationAction.request
+  .HTTPBody` is effectively always nil there; WebKitGTK's
+  `WebKitURIRequest` lacks it), so the request cannot be reconstructed
+  and replayed from Java. The only faithful path is to **reuse the
+  engine's own child** — the view WebKit already drove the original
+  request (verb + body) into, and that is already opener-linked.
+
+- **Presentation model: two-phase adoption.** Adoption is decided
+  synchronously on the native UI thread but performed asynchronously
+  on the EDT, because the platform popup callback must return its
+  decision before yielding to WebKit and cannot round-trip to the EDT
+  without risking the AppKit-main/EDT deadlock (the same constraint
+  Canvas 15 documents). Phase 1 (native UI thread, synchronous): the
+  handler returns a **disposition** — `BLOCK`, `NATIVE_WINDOW`, or
+  `ADOPT`. On `ADOPT` the engine creates the opener-linked child from
+  the exact `WKWebViewConfiguration` WebKit passes (preserving POST +
+  `window.opener`) but does **not** create or show its own `NSWindow`;
+  it retains the child under a **hidden holder** keyed by the
+  engine-assigned `popupId`, returns the child to WebKit (which drives
+  the original request into it), and fires an **EDT adopt
+  notification** carrying the `popupId`. Phase 2 (EDT, asynchronous):
+  the application creates a new tab whose `WebViewComponent` **adopts**
+  the retained child — the native child view is reparented into that
+  component's realized surface and engine ownership transfers to the
+  component.
+
+- **Additive, backward-compatible disposition surface.** Add one
+  `default` method to `WebViewPopupHandler`:
+  `PopupDisposition popupDisposition(WebViewPopupEvent event)`. Its
+  default implementation derives the disposition from the existing
+  `popupRequested` boolean — `true` ⇒ `NATIVE_WINDOW`, `false` ⇒
+  `BLOCK` — so **every Canvas 15 handler keeps working unchanged** and
+  `setPopupHandler(null)` still blocks all popups. Only handlers that
+  want tab adoption override `popupDisposition` to return `ADOPT`. The
+  method runs on the native UI thread, synchronously, off the EDT —
+  same threading rules and Javadoc caveats as `popupRequested`.
+
+- Add a new **public enum** `ca.weblite.webview.PopupDisposition` with
+  three constants: `BLOCK` (block the popup; `window.open` returns
+  `null`), `NATIVE_WINDOW` (host in an engine-owned native window —
+  today's allow behavior), `ADOPT` (retain the child for the
+  application to adopt into a `WebViewComponent`).
+
+- Add a new **EDT notification** to `WebViewPopupHandler`:
+  `default void popupAdoptable(WebViewPopupEvent event, long popupId)`
+  — fired on the EDT after an `ADOPT` decision, once the child is
+  created and retained under the hidden holder. It carries the
+  `popupId` the application passes to `adoptPopup`. Default is a no-op.
+  (A no-op default means an `ADOPT`-returning handler that never
+  overrides `popupAdoptable` leaves the child unclaimed — see the
+  reclaim Safeguard.)
+
+- Expose a **public adopting-construction entry point** on
+  `WebViewComponent`:
+  `public static WebViewComponent adoptPopup(long popupId)` (and a
+  `Mode`-parameterized overload `adoptPopup(Mode, long)`), returning a
+  component whose peer, at attach time, adopts the pre-existing native
+  child engine identified by `popupId` rather than creating its own.
+  The returned component is added to a container by the application
+  exactly like a normal component; adoption happens when the peer is
+  realized (`addNotify` / `createPeer`).
+
+- Wire the adopt seam through the engine wrappers and JNI:
+  - `EmbeddedWebView.adopt(Component parent, long popupId, boolean
+    debug)` — a static factory paralleling `attach(parent, debug)`
+    that calls a new native `webview_embed_adopt_popup(parent,
+    popupId, debug)` (reparent the retained child into `parent`'s
+    surface and return its peer handle) instead of
+    `webview_embed_create`.
+  - `native static long webview_embed_adopt_popup(Component parent,
+    long popupId, int debug)` on `WebViewNative`, following the
+    `webview_embed_create` precedent.
+  - The macOS native `impl_create_web_view` gains an `ADOPT` branch
+    (retain child, no `NSWindow`, fire `popupAdoptable`) and a new
+    `cocoa_adopt_popup` reparent function invoked by the JNI bridge.
+
+- `PopupDispatcher` gains **pending-adopt bookkeeping**: track the
+  `popupId`s currently retained-and-unclaimed; enforce **adopt-once**;
+  reject adoption of an unknown or already-adopted `popupId` with a
+  clear exception (`IllegalArgumentException` for never-issued,
+  `IllegalStateException` for already-adopted); and **reclaim**
+  unclaimed children when the opener component is disposed, plus a
+  bounded grace-period backstop.
+
+- Definition of Done:
+  - A handler returning `ADOPT` from `popupDisposition`, plus an app
+    that on `popupAdoptable` creates a tab via
+    `WebViewComponent.adoptPopup(popupId)`, results in the popup
+    appearing **inside that component** on macOS, with the **POST body
+    preserved** (a `<form method="post">` popup shows the POST
+    response) and **opener linkage intact** (`window.opener` non-null,
+    `postMessage`-to-opener works). No native popup window appears at
+    any point on the `ADOPT` path.
+  - A Canvas 15 handler that allows the popup (`popupRequested` →
+    `true`, or `DEFAULT`) still opens a native window; a blocking
+    handler / `setPopupHandler(null)` still blocks — byte-for-byte the
+    prior behavior.
+  - `adoptPopup` on an unknown `popupId` throws
+    `IllegalArgumentException`; a second `adoptPopup` on the same
+    `popupId` throws `IllegalStateException`; neither leaves a
+    half-constructed component or native view behind.
+  - A popup that is decided `ADOPT` but never adopted is reclaimed
+    (native child + hidden holder torn down) when the opener is
+    disposed or the grace period expires, with a logged diagnostic —
+    no orphaned engine.
+  - Closing an adopted popup (`window.close()` or the tab is closed)
+    fires `popupClosed` correlated by `popupId` and disposes the
+    adopted engine without dereferencing freed native state.
+  - `WebViewAdoptPopupDemo` (or an extension of `WebViewPopupDemo`)
+    exercises adopt vs. native-window vs. block on macOS.
+  - README grows an "Adopting popups into a component" subsection
+    under "Browser-initiated popups".
+  - `PopupDispatcherTest` grows cases for disposition routing,
+    `popupDisposition` default derivation from the boolean,
+    `popupAdoptable` EDT marshaling, adopt-once enforcement,
+    unknown/duplicate-id rejection, pending-adopt reclaim, and
+    dispose fallbacks. Native reparenting is integration-tested via
+    the demo (no-automated-GUI-tests policy).
+
+- Out of scope (explicit non-goals of THIS canvas):
+  - **Linux (WebKitGTK) adoption** — Canvas 19 / STORY-005-002.
+  - **Windows (WebView2) adoption** — Canvas 20 / STORY-005-003.
+  - **swingwebbrowser consumer wiring** (open popups as tabs via
+    `adoptPopup`) — STORY-005-004, in the swingwebbrowser repo.
+  - Reparenting an **arbitrary running** `WebViewComponent` between
+    windows. Only a freshly engine-created popup child is adopted,
+    once, at popup time.
+  - Surfacing the HTTP method/body to Java or adding a `postUrl` /
+    request-object navigation API. Adoption exists precisely because
+    the request cannot be surfaced; the engine's child is reused.
+  - `window.open` feature strings beyond `width`/`height`; per-tab
+    window chrome; HTTP auth / download / permission channels
+    (unchanged from Canvas 15).
+  - Adding the popup/adoption API to the standalone in-process
+    `WebView` class (same boundary Canvas 15 drew — embedded
+    `WebViewComponent` surface only).
+
+## E · Entities
+
+- **PopupDisposition** (new public enum,
+  `src/ca/weblite/webview/PopupDisposition.java`). Three constants:
+  `BLOCK`, `NATIVE_WINDOW`, `ADOPT`. Javadoc maps each to its runtime
+  meaning and to the legacy boolean (`NATIVE_WINDOW` = old `true`,
+  `BLOCK` = old `false`, `ADOPT` = new).
+
+- **WebViewPopupHandler** (modified,
+  `src/ca/weblite/webview/WebViewPopupHandler.java`). Gains:
+  - `default PopupDisposition popupDisposition(WebViewPopupEvent
+    event)` — returns `popupRequested(event) ? NATIVE_WINDOW : BLOCK`.
+    Javadoc: runs on the native UI thread, synchronously, off the EDT;
+    must be fast, thread-safe, no Swing; overriding this supersedes
+    the boolean gate for disposition purposes.
+  - `default void popupAdoptable(WebViewPopupEvent event, long
+    popupId)` — no-op. Javadoc: runs on the EDT; the application
+    should create a component via `WebViewComponent.adoptPopup(popupId)`
+    to host the popup, or the child is reclaimed.
+  - `popupRequested`, `popupOpened`, `popupClosed`, and `DEFAULT`
+    unchanged.
+
+- **WebViewPopupEvent** (unchanged,
+  `src/ca/weblite/webview/WebViewPopupEvent.java`). Reused as-is;
+  carries no HTTP method/body by design. The `popupId` travels
+  alongside the event (as a separate `long` argument on
+  `popupAdoptable` and the callback), not as an event field.
+
+- **PopupDispatcher** (modified,
+  `src/ca/weblite/webview/PopupDispatcher.java`). Gains pending-adopt
+  bookkeeping and disposition routing:
+  - `private final java.util.concurrent.ConcurrentHashMap<Long,
+    WebViewPopupEvent> pendingAdopts = new ConcurrentHashMap<>();` —
+    `popupId`s retained-and-unclaimed (decided `ADOPT`, not yet
+    adopted).
+  - `int dispatchPopupDisposition(String targetUrl, String targetName,
+    boolean userGesture, int width, int height, String pageUrl)` —
+    synchronous; returns the ordinal of the `PopupDisposition` the
+    handler chooses (`handler.popupDisposition(event)`), off the EDT,
+    with the same exception isolation as `dispatchPopupRequested`
+    (`BLOCK` on throw/disposed).
+  - `void dispatchPopupAdoptable(long popupId, String targetUrl,
+    String targetName, boolean userGesture, int width, int height,
+    String pageUrl)` — records the event in `pendingAdopts` and
+    marshals `handler.popupAdoptable(event, popupId)` to the EDT via
+    `invokeLater`.
+  - `WebViewPopupEvent claimAdopt(long popupId)` — atomically removes
+    and returns the pending event for `popupId`; throws
+    `IllegalArgumentException` if never issued, `IllegalStateException`
+    if already claimed. Called by the adopting component at attach.
+  - `void reclaimAdopts()` — invoked from `disposeAll()`: for each
+    still-pending `popupId`, ask the native side to tear down the
+    retained child (via the source component's engine wrapper) and
+    clear the map.
+  - Retains `dispatchPopupRequested` (legacy boolean bridge) so the
+    existing native callback signature and non-adopting callers are
+    untouched.
+
+- **WebViewPopupCallback** (modified,
+  `src/ca/weblite/webview/WebViewPopupCallback.java`). Gains two
+  methods (default where the platform hasn't implemented them, to keep
+  the interface implementable by the Linux/Windows sites until their
+  canvases land):
+  - `default int onPopupDisposition(String targetUrl, String
+    targetName, boolean userGesture, int width, int height, String
+    pageUrl)` — synchronous; returns a `PopupDisposition` ordinal.
+    Default: `onPopupRequested(...) ? NATIVE_WINDOW.ordinal() :
+    BLOCK.ordinal()` so engines that only call `onPopupRequested`
+    still work.
+  - `default void onPopupAdoptable(long popupId, String targetUrl,
+    String targetName, boolean userGesture, int width, int height,
+    String pageUrl)` — notification the child is retained and
+    adoptable.
+  - `onPopupRequested`, `onPopupOpened`, `onPopupClosed` unchanged.
+
+- **WebViewComponent** (modified,
+  `src/ca/weblite/webview/swing/WebViewComponent.java`). Gains:
+  - `public static WebViewComponent adoptPopup(long popupId)` and
+    `public static WebViewComponent adoptPopup(Mode mode, long
+    popupId)` — construct a component flagged to adopt `popupId` at
+    peer-attach.
+  - Existing `setPopupHandler`/`getPopupHandler`/`popupDispatcher`
+    unchanged.
+
+- **EmbeddedWebView** (modified,
+  `src/ca/weblite/webview/EmbeddedWebView.java`). Gains
+  `public static EmbeddedWebView adopt(Component parent, long popupId,
+  boolean debug)` — parallels `attach` but calls
+  `WebViewNative.webview_embed_adopt_popup(parent, popupId, debug ? 1
+  : 0)`, wraps the returned peer, installs the same
+  eval/function/attach bridges, and returns the wrapper. Also
+  `public EmbeddedWebView discardRetainedPopup(long popupId)` — clears
+  a retained-but-unadopted child (reclaim path), calling a native
+  `webview_embed_discard_popup(peer, popupId)`.
+
+- **WebViewNative** (modified,
+  `src/ca/weblite/webview/WebViewNative.java`). Gains, after the popup
+  natives:
+  - `native static long webview_embed_adopt_popup(Component parent,
+    long popupId, int debug);`
+  - `native static void webview_embed_discard_popup(long w, long
+    popupId);`
+  With a block comment documenting per-platform delivery (macOS
+  reparent via `addSubview:`; Linux/Windows in Canvases 19/20).
+
+- **`src_c/webview_embed.cpp`** (modified — macOS). `impl_create_web_view`
+  gains a disposition switch: on `ADOPT` it builds the child from the
+  passed configuration, stores it in a global **retained-popup map**
+  keyed by `popupId` (no `NSWindow`, no `makeKeyAndOrderFront:`),
+  fires `onPopupAdoptable` async, and returns the child; on
+  `NATIVE_WINDOW` it does exactly today's window path; on `BLOCK` it
+  returns `nil`. New `cocoa_adopt_popup(parent NSView*, popupId)`
+  reparents the retained child (`[parentView addSubview:child]`,
+  size to parent bounds) and promotes the retained child `Engine` into
+  a normal embedded engine registered against `parent`'s peer;
+  `cocoa_discard_popup(popupId)` tears an unclaimed child down. Two
+  JNI bridges for the new native methods.
+
+- **WebViewAdoptPopupDemo** (new demo, or a mode added to
+  `WebViewPopupDemo`): exercises adopt / native-window / block.
+
+- **README.md** (modified): "Adopting popups into a component"
+  subsection.
+
+- **PopupDispatcherTest** (modified,
+  `test/ca/weblite/webview/PopupDispatcherTest.java`): disposition +
+  adopt bookkeeping cases.
+
+```mermaid
+classDiagram
+direction TB
+
+class PopupDisposition {
+    <<enumeration>>
+    BLOCK
+    NATIVE_WINDOW
+    ADOPT
+}
+class WebViewPopupHandler {
+    <<interface>>
+    +popupRequested(WebViewPopupEvent) boolean
+    +popupDisposition(WebViewPopupEvent) PopupDisposition
+    +popupAdoptable(WebViewPopupEvent, long) void
+    +popupOpened(WebViewPopupEvent) void
+    +popupClosed(WebViewPopupEvent) void
+    +DEFAULT WebViewPopupHandler$
+}
+class PopupDispatcher {
+    -handler WebViewPopupHandler
+    -openPopups Map~Long,WebViewPopupEvent~
+    -pendingAdopts Map~Long,WebViewPopupEvent~
+    +dispatchPopupDisposition(...) int
+    +dispatchPopupAdoptable(long,...) void
+    +claimAdopt(long) WebViewPopupEvent
+    +reclaimAdopts() void
+    +dispatchPopupRequested(...) boolean
+}
+class WebViewPopupCallback {
+    <<interface>>
+    +onPopupDisposition(...) int
+    +onPopupAdoptable(long,...) void
+    +onPopupRequested(...) boolean
+    +onPopupOpened(...) void
+    +onPopupClosed(...) void
+}
+class WebViewComponent {
+    +adoptPopup(long) WebViewComponent$
+    +adoptPopup(Mode, long) WebViewComponent$
+    +setPopupHandler(WebViewPopupHandler) WebViewComponent
+}
+class EmbeddedWebView {
+    +attach(Component, boolean) EmbeddedWebView$
+    +adopt(Component, long, boolean) EmbeddedWebView$
+    +discardRetainedPopup(long) EmbeddedWebView
+}
+
+WebViewComponent "1" *-- "1" PopupDispatcher : owns
+PopupDispatcher "1" --> "1" WebViewPopupHandler : invokes
+WebViewPopupHandler ..> PopupDisposition : returns
+WebViewComponent ..> EmbeddedWebView : adopt()
+EmbeddedWebView ..> WebViewPopupCallback : invokes via JNI
+WebViewPopupCallback ..> PopupDispatcher : delegates to
+```
+
+## A · Approach
+
+1. **Reuse the engine's child; never replay from Java.** POST body and
+   `window.opener` live inside the WebKit-created child. Adoption
+   returns that exact child to WebKit (so it drives the original
+   navigation-action request into it) and later reparents its native
+   view into the caller's surface. Java never sees or reconstructs the
+   request — sidestepping the unavailable-`HTTPBody` problem entirely.
+
+2. **Two-phase, mirroring Canvas 15's threading split.** Disposition
+   (`popupDisposition`) is synchronous on the native UI thread — it
+   must return before the delegate yields to WebKit, exactly like
+   `popupRequested`. The dispatcher calls it **inline**, off the EDT,
+   and returns the ordinal. `popupAdoptable`, `popupOpened`,
+   `popupClosed` are asynchronous EDT notifications via `invokeLater`.
+   The reparent (`adoptPopup` → `EmbeddedWebView.adopt`) runs entirely
+   on the EDT when the caller's component is realized. No native-thread
+   code ever touches Swing.
+
+3. **Backward compatibility by derivation.** `popupDisposition`'s
+   default returns `NATIVE_WINDOW`/`BLOCK` from the legacy boolean, and
+   `WebViewPopupCallback.onPopupDisposition`'s default returns the same
+   from `onPopupRequested`. Existing handlers, the `DEFAULT` handler,
+   `setPopupHandler(null)` (DROP), and the current native callback
+   signature all keep their exact behavior. The native macOS site
+   calls `onPopupDisposition` (new) rather than `onPopupRequested`, but
+   the default bridges the two so non-overriding handlers are
+   unaffected.
+
+4. **Hidden holder = no window, no flash.** On `ADOPT` the macOS site
+   builds the child from the passed configuration but never allocates
+   an `NSWindow` and never calls `makeKeyAndOrderFront:`. The child is
+   held only by a global retained-popup map (and WebKit's own
+   reference) until adoption. Because a `WKWebView` with no window
+   still loads, WebKit begins the POST navigation immediately; by the
+   time the tab adopts it, content is ready. AC3 (no native window) and
+   the STORY-005-004 no-flash NFR both follow.
+
+5. **Adopt = reparent an already-created view.** Canvas 15's "engines
+   cannot be created detached and reparented" concern was about
+   *creation*; the child here is already created and realized. Moving
+   an existing `WKWebView` from the hidden holder into the tab's JAWT
+   `NSView` via `[parentView addSubview:child]` is the same operation
+   heavyweight embedding performs, and is well-defined mid-navigation.
+   `cocoa_adopt_popup` also promotes the retained child `Engine` to a
+   normal embedded engine keyed by the new parent peer, re-points its
+   callbacks to the adopting component's dispatchers, and installs the
+   standard per-component bridges.
+
+6. **New construction seam, not a mutated one.** `EmbeddedWebView.attach`
+   stays "create a fresh engine". `EmbeddedWebView.adopt(parent,
+   popupId, debug)` is a sibling that calls
+   `webview_embed_adopt_popup` (reparent the retained child) and then
+   installs the identical eval/function/attach bridges. The Swing
+   component chooses `attach` vs. `adopt` based on whether it was
+   constructed via `adoptPopup(popupId)` (a pending-adopt id stored on
+   the component).
+
+7. **Lifecycle owned jointly.** The native retained-popup map owns the
+   child object; `PopupDispatcher.pendingAdopts` owns the Java-visible
+   bookkeeping. `claimAdopt(popupId)` enforces adopt-once and clean
+   rejection. Reclaim triggers: (a) the opener component's
+   `disposeAll()` calls `reclaimAdopts()`, which discards each pending
+   child natively; (b) a bounded grace-period backstop (a single
+   scheduled sweep, not a busy loop) discards children unclaimed after
+   the grace window, logged. Both paths route through
+   `discardRetainedPopup` → `webview_embed_discard_popup`.
+
+8. **Exception + null discipline unchanged.** `dispatchPopupDisposition`
+   wraps the handler call in `try/catch(Throwable)` → forward to the
+   uncaught handler, return `BLOCK` ordinal on error (safe default:
+   block). `dispatchPopupAdoptable` wraps the EDT-marshaled call the
+   same way. Native JNI paths sanitize exceptions after every
+   `Call*Method` and return `nil`/no-window on any non-adopt/allow
+   path. Strings stay null-coerced to empty; sizes stay `-1` for
+   unspecified.
+
+## S · Structure
+
+### Inheritance Relationships
+1. `PopupDisposition` — public enum, three constants.
+2. `WebViewPopupHandler` — public interface; gains two `default`
+   methods (`popupDisposition`, `popupAdoptable`); no required
+   abstract method; still not `@FunctionalInterface`.
+3. `WebViewPopupCallback` — public interface; gains two `default`
+   methods (`onPopupDisposition`, `onPopupAdoptable`).
+4. `PopupDispatcher` — public final class; gains a second correlation
+   map and disposition/adopt/claim/reclaim methods.
+5. `WebViewComponent` (abstract) gains two static factories and a
+   pending-adopt id field; `EmbeddedWebView` gains `adopt` +
+   `discardRetainedPopup`.
+
+### Dependencies
+1. `WebViewPopupHandler` → `PopupDisposition`, `WebViewPopupEvent`.
+2. `PopupDispatcher` → `SwingUtilities`, `ConcurrentHashMap`,
+   `PopupDisposition`, `WebViewPopupEvent`, `WebViewPopupHandler`,
+   `WebViewComponent` (source, for reclaim routing to its engine).
+3. `WebViewComponent.adoptPopup` → `WebViewHeavyweightComponent` /
+   `WebViewLightweightComponent` (pending-adopt id) → `EmbeddedWebView
+   .adopt` / offscreen adopt.
+4. `EmbeddedWebView.adopt` →
+   `WebViewNative.webview_embed_adopt_popup`;
+   `discardRetainedPopup` → `webview_embed_discard_popup`.
+5. Native macOS selectors → retained-popup map → `cocoa_adopt_popup`
+   / `cocoa_discard_popup` → JNI `onPopupDisposition` /
+   `onPopupAdoptable` → `PopupDispatcher` → handler.
+
+### Layered Architecture
+1. **Native engine layer** (`src_c/webview_embed.cpp`, macOS):
+   disposition switch in `impl_create_web_view`, retained-popup map,
+   `cocoa_adopt_popup` / `cocoa_discard_popup`, JNI bridges.
+2. **JNI surface** (`WebViewNative`): two new `native static` decls.
+3. **Engine wrapper layer** (`EmbeddedWebView`): `adopt`,
+   `discardRetainedPopup`.
+4. **Dispatcher layer** (`PopupDispatcher`): disposition routing,
+   pending-adopt bookkeeping, adopt-once, reclaim.
+5. **Component API layer** (`WebViewComponent`): `adoptPopup`
+   factories.
+6. **Public contract layer** (`WebViewPopupHandler`,
+   `PopupDisposition`, `WebViewPopupCallback`).
+7. **Wiring layer** (`WebViewHeavyweightComponent.createPeer` /
+   `addNotify`): choose `attach` vs `adopt`; call
+   `onPopupDisposition` / `onPopupAdoptable` in the installed popup
+   callback.
+8. **Demo layer** (`WebViewAdoptPopupDemo`).
+
+## O · Operations
+
+### 1. Create Enum — PopupDisposition
+File: `src/ca/weblite/webview/PopupDisposition.java`
+1. Public enum with `BLOCK`, `NATIVE_WINDOW`, `ADOPT`. Javadoc maps
+   each to runtime meaning + legacy boolean. Ordinals are the wire
+   contract with native (`BLOCK=0`, `NATIVE_WINDOW=1`, `ADOPT=2`);
+   document that ordering must not change.
+
+### 2. Extend WebViewPopupHandler
+File: `src/ca/weblite/webview/WebViewPopupHandler.java`
+1. `default PopupDisposition popupDisposition(WebViewPopupEvent e) {
+   return popupRequested(e) ? PopupDisposition.NATIVE_WINDOW :
+   PopupDisposition.BLOCK; }` — Javadoc: native UI thread, sync, off
+   EDT; overriding supersedes the boolean for disposition; must be
+   fast/thread-safe/no-Swing.
+2. `default void popupAdoptable(WebViewPopupEvent e, long popupId) { }`
+   — Javadoc: EDT; call `WebViewComponent.adoptPopup(popupId)` to host
+   the popup or it will be reclaimed.
+3. Update class Javadoc: document the three dispositions, the
+   two-phase adopt model, and that `ADOPT` requires overriding
+   `popupAdoptable` + calling `adoptPopup`.
+
+### 3. Extend WebViewPopupCallback
+File: `src/ca/weblite/webview/WebViewPopupCallback.java`
+1. `default int onPopupDisposition(String u, String n, boolean g, int
+   w, int h, String p) { return onPopupRequested(u,n,g,w,h,p) ? 1 : 0;
+   }` — ordinals per Operation 1.
+2. `default void onPopupAdoptable(long popupId, String u, String n,
+   boolean g, int w, int h, String p) { }`.
+3. Javadoc: `onPopupDisposition` returns synchronously on the native
+   UI thread and MUST NOT be EDT-marshaled; `onPopupAdoptable` is a
+   notification.
+
+### 4. Extend PopupDispatcher
+File: `src/ca/weblite/webview/PopupDispatcher.java`
+1. Add `pendingAdopts` map.
+2. `int dispatchPopupDisposition(...)`: if `disposed` return
+   `BLOCK.ordinal()`; build event; `try { return
+   handler.popupDisposition(event).ordinal(); } catch (Throwable t) {
+   forwardUncaught(t); return BLOCK.ordinal(); }`.
+3. `void dispatchPopupAdoptable(long popupId, ...)`: if `disposed`
+   return; build event; `pendingAdopts.put(popupId, event)`;
+   `runOnEdtLater(() -> handler.popupAdoptable(event, popupId))`.
+4. `WebViewPopupEvent claimAdopt(long popupId)`: `remove` from
+   `pendingAdopts`; if the id was never present, distinguish
+   never-issued (`IllegalArgumentException`) from already-claimed by
+   consulting a small `claimed` set (add on successful claim) →
+   `IllegalStateException`. Return the event.
+5. `void reclaimAdopts()`: for each remaining pending `popupId`, route
+   a discard to the source component's engine
+   (`discardRetainedPopup`); clear `pendingAdopts`. Called from
+   `disposeAll()` (after setting `disposed`).
+6. Keep `dispatchPopupRequested` (legacy boolean) intact.
+7. Grace-backstop hook: `schedulePendingSweep(popupId)` arms a single
+   delayed reclaim for that id (see Safeguards for the duration);
+   claiming cancels it.
+
+### 5. Extend WebViewComponent
+File: `src/ca/weblite/webview/swing/WebViewComponent.java`
+1. `public static WebViewComponent adoptPopup(long popupId)` →
+   `adoptPopup(resolveDefaultMode(), popupId)`.
+2. `public static WebViewComponent adoptPopup(Mode mode, long
+   popupId)`: construct the heavyweight/lightweight component with a
+   stored `pendingAdoptPopupId`; Javadoc: the popup id comes from
+   `popupAdoptable`; must be called on the EDT; adoption occurs when
+   the component is realized; throws if the id is unknown/already
+   adopted at attach.
+
+### 6. Extend EmbeddedWebView
+File: `src/ca/weblite/webview/EmbeddedWebView.java`
+1. `public static EmbeddedWebView adopt(Component parent, long
+   popupId, boolean debug)`: validate `parent` non-null + displayable
+   (as `attach`); `long p = WebViewNative.webview_embed_adopt_popup(
+   parent, popupId, debug ? 1 : 0)`; if `0` throw `IllegalStateException`;
+   wrap, install the attach/eval/function bridges exactly as `attach`,
+   return.
+2. `public EmbeddedWebView discardRetainedPopup(long popupId)`:
+   `checkAlive()`; `WebViewNative.webview_embed_discard_popup(peer,
+   popupId)`; return this.
+
+### 7. Extend WebViewNative
+File: `src/ca/weblite/webview/WebViewNative.java`
+1. `native static long webview_embed_adopt_popup(Component parent,
+   long popupId, int debug);`
+2. `native static void webview_embed_discard_popup(long w, long
+   popupId);`
+   Block comment: macOS reparents the retained child via `addSubview:`;
+   Linux/Windows land in Canvases 19/20.
+
+### 8. macOS native — disposition switch + adopt/discard + JNI
+File: `src_c/webview_embed.cpp` (Cocoa)
+1. Add a file-scope `std::map<jlong, Engine*> g_retained_popups` (+
+   mutex) for retained-but-unadopted children.
+2. In `impl_create_web_view`, replace the boolean gate with a
+   disposition call: JNI `onPopupDisposition(...)` → switch:
+   - `BLOCK` (0): return `nil`.
+   - `NATIVE_WINDOW` (1): exactly today's window path (create child,
+     `NSWindow`, `makeKeyAndOrderFront:`, register child engine, fire
+     `onPopupOpened`).
+   - `ADOPT` (2): create child from `configuration`; build a child
+     `Engine` with `popup_window = nil`; `popup_id = (jlong)child_e`;
+     inherit callbacks as global refs; put in `g_retained_popups`;
+     fire `onPopupAdoptable(popup_id, …)` async; **do not** create an
+     `NSWindow`; return `child`.
+3. `cocoa_adopt_popup(Engine* parentEngine, jlong popupId)`: look up
+   the retained child `Engine`; `id childView = child_e->webview`;
+   `id parentView = <parentEngine's content NSView>`;
+   `[parentView addSubview:childView]`; set the child frame to the
+   parent bounds; promote `child_e` to a normal embedded engine keyed
+   by `parentEngine`'s peer (re-point `popup_callback`/`dialog_callback`
+   to the parent's, register in `g_webview_map`, keep the UI delegate);
+   remove from `g_retained_popups`; return the child engine handle.
+4. `cocoa_discard_popup(jlong popupId)`: look up + remove from
+   `g_retained_popups`; `setUIDelegate:nil`; delete inherited global
+   refs; release the child view; delete the engine (mirror
+   `impl_web_view_did_close` teardown ordering, minus the window).
+5. JNI bridges
+   `Java_ca_weblite_webview_WebViewNative_webview_1embed_1adopt_1popup`
+   (resolve `parent`'s peer/`NSView` from the AWT `Component` via the
+   existing JAWT path used by `webview_embed_create`, call
+   `cocoa_adopt_popup`, return the peer handle) and
+   `…_webview_1embed_1discard_1popup` in the existing `extern "C"`
+   block.
+
+### 9. Wire the popup callback for disposition + adoptable
+Files: `WebViewHeavyweightComponent.createPeer()` /
+`WebViewLightweightComponent.addNotify()`
+1. In the installed `WebViewPopupCallback`, override
+   `onPopupDisposition` → `popupDispatcher.dispatchPopupDisposition(...)`
+   and `onPopupAdoptable` → `popupDispatcher.dispatchPopupAdoptable(...)`,
+   alongside the existing `onPopupRequested`/`onPopupOpened`/
+   `onPopupClosed`.
+2. In `createPeer`/`addNotify`, if this component was constructed with
+   a pending-adopt id, call `EmbeddedWebView.adopt(canvas,
+   pendingAdoptPopupId, debug)` instead of `EmbeddedWebView.attach`;
+   before that, claim the id from the **opener's** dispatcher is not
+   possible cross-component — instead the native
+   `webview_embed_adopt_popup` validates the id against
+   `g_retained_popups` and returns `0` for unknown/consumed, which
+   `EmbeddedWebView.adopt` turns into the documented exception. (The
+   Java `pendingAdopts`/`claimAdopt` bookkeeping guards the opener-side
+   reclaim + adopt-once at the API boundary; native validation guards
+   the reparent itself.)
+3. `dispose()` unchanged except `popupDispatcher.disposeAll()` now also
+   triggers `reclaimAdopts()`.
+
+### 10. Demo — WebViewAdoptPopupDemo
+Files: `demos/WebViewAdoptPopupDemo/…` (or a mode on
+`WebViewPopupDemo`)
+1. `JPopupMenu.setDefaultLightWeightPopupEnabled(false)` + tooltip
+   equivalent at startup.
+2. Base64 `data:` page (per the Canvas 15 demo pitfall notes) with a
+   `<form method="post">` submit to a small echo target, a
+   `window.open` button, and a `target=_blank` link. A JComboBox
+   switches handler modes: Adopt (host in a `JFrame`-hosted tab/panel
+   created on `popupAdoptable`), Native window (Canvas 15 allow),
+   Block. Adopt mode logs POST-body round-trip to a console line.
+
+### 11. README + Tests
+Files: `README.md`, `test/ca/weblite/webview/PopupDispatcherTest.java`
+1. README: "Adopting popups into a component" subsection under
+   "Browser-initiated popups" — the disposition enum, the two-phase
+   model, `adoptPopup`, the POST/opener guarantee, and the reclaim
+   contract.
+2. Tests: `popupDisposition` default derivation (true→NATIVE_WINDOW,
+   false→BLOCK); `dispatchPopupDisposition` returns the right ordinal
+   off the EDT and `BLOCK` on throw/disposed; `dispatchPopupAdoptable`
+   marshals to the EDT and populates `pendingAdopts`; `claimAdopt`
+   returns the stored event, throws `IllegalArgumentException`
+   (unknown) / `IllegalStateException` (double claim); `reclaimAdopts`
+   clears pending on `disposeAll`; disposed dispatcher returns
+   `BLOCK`/no-ops.
+
+## N · Norms
+
+- **Mirror Canvas 15's `PopupDispatcher` conventions.** The new
+  disposition path runs the handler **inline on the native UI thread**
+  (like `dispatchPopupRequested`); `popupAdoptable` uses
+  `SwingUtilities.invokeLater` (like `popupOpened`/`popupClosed`).
+- **Ordinal wire contract.** `PopupDisposition` ordinals
+  (`BLOCK=0/NATIVE_WINDOW=1/ADOPT=2`) are shared with native; never
+  reorder. Document on the enum.
+- **Additive-only handler surface.** `popupRequested` stays the legacy
+  gate; `popupDisposition` defaults from it. Never break a Canvas 15
+  handler or `setPopupHandler(null)`.
+- **Accessor / null / size discipline** unchanged from Canvas 15
+  (no-`get` accessors; empty-string for missing strings; `-1` for
+  unspecified sizes; `source` never null).
+- **`getPopupHandler() != null`** invariant preserved; disposed
+  dispatcher is inert for the new paths too (returns `BLOCK`, no-ops
+  adoptable/claim/reclaim without invoking the handler).
+- **Adopt-once, clean rejection.** `claimAdopt` throws
+  `IllegalArgumentException` (never-issued) vs. `IllegalStateException`
+  (already-claimed); `EmbeddedWebView.adopt` maps a native `0` return
+  to `IllegalStateException` with the `popupId` in the message.
+- **No JSON parser; no `__webview_*` binding; no JS shim** for the
+  disposition/adopt channel — native-delegate channel, primitives
+  only.
+- **Per-call `jmethodID` resolution + JNI exception sanitization** in
+  the new native calls, matching the dialog/popup selectors.
+- **`pom.xml` Java 8 target** — enums, `default` methods,
+  `ConcurrentHashMap`, `invokeLater` are all Java 8.
+- **No automated GUI tests** — native reparenting is validated by
+  running the demo on-device; `PopupDispatcherTest` covers the Java
+  contract.
+
+## S · Safeguards
+
+- **Backward compatibility is a never-relax invariant.** A Canvas 15
+  handler (boolean only), the `DEFAULT` handler, `setPopupHandler(null)`
+  (DROP), and the existing native `onPopupRequested` signature MUST
+  behave byte-for-byte as before. `popupDisposition` /
+  `onPopupDisposition` defaults derive from the boolean; the macOS
+  `NATIVE_WINDOW`/`BLOCK` branches are the unchanged Canvas 15 paths.
+- **Off-EDT synchronous decision.** `popupDisposition` /
+  `dispatchPopupDisposition` / `onPopupDisposition` run on the native
+  UI thread, never marshal to the EDT, and return before yielding to
+  WebKit — preserving the deadlock-free property Canvas 15 and the
+  deadlock-elimination analysis established. Handlers must not touch
+  Swing here.
+- **No native window on ADOPT (AC3).** The `ADOPT` branch MUST NOT
+  allocate an `NSWindow` or call `makeKeyAndOrderFront:`. The child is
+  reachable only via `g_retained_popups` + WebKit's own reference
+  until adoption.
+- **Adopt-once + clean rejection (AC7).** `adoptPopup` on an unknown
+  `popupId` throws `IllegalArgumentException`; a second adoption of the
+  same id throws `IllegalStateException`; native
+  `webview_embed_adopt_popup` returns `0` on unknown/consumed and
+  never returns a half-attached peer.
+- **No-leak reclaim (AC6).** A child decided `ADOPT` but never adopted
+  is discarded when (a) the opener component is disposed
+  (`disposeAll` → `reclaimAdopts` → `discardRetainedPopup`), or (b) a
+  bounded grace-period backstop of **30 seconds** (a single scheduled
+  sweep per pending id, cancelled on claim) elapses — whichever comes
+  first — with a logged diagnostic. No busy-wait; no silent drop.
+- **Child-engine teardown ordering.** `cocoa_adopt_popup` and
+  `cocoa_discard_popup` MUST clear the UI delegate and update
+  `g_webview_map` / `g_retained_popups` before releasing native
+  objects, and manage the inherited `popup_callback`/`dialog_callback`
+  global refs with the delete-old / new-global-ref lifecycle — no
+  double-free, no dereference of a freed engine (mirrors
+  `impl_web_view_did_close`).
+- **Opener linkage + POST are mandatory (AC1/AC2).** The adopted child
+  MUST be the WebKit-created child from the passed configuration;
+  creating a fresh view or re-navigating from Java is a defect.
+- **`popupId` correlation is best-effort on close.** `popupClosed`
+  tolerates a missing map entry; a close racing adoption never NPEs.
+- **Disposed dispatcher is inert.** After `disposeAll()`, the
+  disposition path returns `BLOCK`, and adoptable/claim/reclaim do not
+  invoke the handler.
+- **Headless construction.** Constructing the handler, the dispatcher,
+  and a component via `adoptPopup` (before it is realized) MUST NOT
+  throw `HeadlessException`; adoption's native work only happens at
+  peer-realize time.
+- **No `setDebug` coupling; reserved-prefix protection preserved.**
+
+- **Native coverage status (per-iteration, mirrors Canvas 11 / 15).**
+  The full Java contract (Operations 1–7, 9, 11) and the **macOS**
+  native implementation (Operation 8) are this canvas's deliverable;
+  the demo (10) lands with them. **Linux** adoption (Canvas 19 /
+  STORY-005-002) and **Windows** adoption (Canvas 20 /
+  STORY-005-003) extend the same Java contract to WebKitGTK and
+  WebView2 without re-shaping the Java side; **swingwebbrowser**
+  consumer wiring (STORY-005-004) lives in the swingwebbrowser repo.
+  The native code here is pattern-faithful to the shipped Canvas 15
+  popup handlers but the sandbox that generated it has **no native
+  toolchain**, so the disposition switch, `cocoa_adopt_popup`, and
+  `cocoa_discard_popup` MUST be built and exercised on macOS (the
+  reparent retain/release and first-responder handoff are prime
+  candidates for on-device zombie/Instruments validation) before
+  release.
+
+## REASONS-Implements
+
+- `src/ca/weblite/webview/PopupDisposition.java`
+- `src/ca/weblite/webview/WebViewPopupHandler.java`
+- `src/ca/weblite/webview/WebViewPopupCallback.java`
+- `src/ca/weblite/webview/PopupDispatcher.java`
+- `src/ca/weblite/webview/swing/WebViewComponent.java`
+- `src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java`
+- `src/ca/weblite/webview/swing/WebViewLightweightComponent.java`
+- `src/ca/weblite/webview/EmbeddedWebView.java`
+- `src/ca/weblite/webview/WebViewNative.java`
+- `src_c/webview_embed.cpp` (macOS paths)
+- `demos/WebViewAdoptPopupDemo/…`
+- `test/ca/weblite/webview/PopupDispatcherTest.java`
+- `README.md`

--- a/spdd/prompt/18-20260806-1200-[Feat]-Popup-Adoption-Into-Webviewcomponent-Tab.md
+++ b/spdd/prompt/18-20260806-1200-[Feat]-Popup-Adoption-Into-Webviewcomponent-Tab.md
@@ -758,6 +758,8 @@ Files: `README.md`, `test/ca/weblite/webview/PopupDispatcherTest.java`
 - `src/ca/weblite/webview/EmbeddedWebView.java`
 - `src/ca/weblite/webview/WebViewNative.java`
 - `src_c/webview_embed.cpp` (macOS paths)
-- `demos/WebViewAdoptPopupDemo/…`
+- `demos/WebViewAdoptPopupDemo/…` (adopt / native-window / block modes +
+  POST form; also carries the Canvas 21 User-Agent controls)
+- `run-mac-adopt-popup-demo.sh`
 - `test/ca/weblite/webview/PopupDispatcherTest.java`
 - `README.md`

--- a/spdd/prompt/19-20260806-1600-[Feat]-Popup-Adoption-Linux-Coverage.md
+++ b/spdd/prompt/19-20260806-1600-[Feat]-Popup-Adoption-Linux-Coverage.md
@@ -2,7 +2,7 @@
 generated_at: 2026-08-06T16:00:00-07:00
 ---
 
-# REASONS Canvas: Popup Adoption Into a Caller-Provided WebViewComponent — Linux (WebKitGTK) Coverage (STORY-005-002)
+# REASONS Canvas: Popup Adoption Into a Caller-Provided WebViewComponent — Linux (WebKitGTK) Coverage — Heavyweight + Lightweight/Offscreen (STORY-005-002)
 
 ## R · Requirements
 
@@ -17,18 +17,39 @@ generated_at: 2026-08-06T16:00:00-07:00
   application supplies** (a Swing tab), instead of the native GTK
   top-level window the engine owns today (Canvas 16).
 
-- **No Java changes.** The entire Java contract — `PopupDisposition`,
-  `WebViewPopupHandler.popupDisposition` / `popupAdoptable`,
-  `WebViewPopupCallback.onPopupDisposition` / `onPopupAdoptable`,
-  `PopupDispatcher` bookkeeping, `WebViewComponent.adoptPopup`,
-  `EmbeddedWebView.adopt` / `discardRetainedPopup`, and the
-  `webview_embed_adopt_popup` / `webview_embed_discard_popup` JNI
-  declarations — was authored platform-agnostically by Canvas 18 and is
-  **reused unchanged**. This canvas conforms to that contract; it does
-  not re-shape the Java side, and touches no `.java` file. The wire
-  contract (disposition ordinals `BLOCK=0` / `NATIVE_WINDOW=1` /
-  `ADOPT=2`, the `onPopupDisposition` / `onPopupAdoptable` JNI
-  signatures) is exactly the one macOS already speaks.
+- **Both Linux engines are covered.** The adoption target is either
+  Linux engine: the **heavyweight** (`EmbeddedWebView` /
+  `WebViewHeavyweightComponent`, on-screen X11-reparented `Engine`) and
+  the **lightweight/offscreen** (`OffscreenWebView` /
+  `WebViewLightweightComponent`, `GtkOffscreenWindow`-hosted `OffEngine`
+  blitted into Swing). This matters because the DEFAULT Linux mode is
+  the lightweight component; adoption that only worked heavyweight would
+  miss the common case. Both targets claim the retained child from the
+  **same** shared `g_gtk_retained_popups` registry, because the opener
+  that raised the popup may itself be heavyweight OR lightweight (both
+  route `create` through the shared `handle_create_web_view`, which
+  retains the child identically on `ADOPT`).
+
+- **Heavyweight is native-only; lightweight adds internal Java.** The
+  heavyweight path reuses the Canvas 18 Java contract verbatim —
+  `PopupDisposition`, `WebViewPopupHandler.popupDisposition` /
+  `popupAdoptable`, `WebViewPopupCallback.onPopupDisposition` /
+  `onPopupAdoptable`, `PopupDispatcher` bookkeeping,
+  `WebViewComponent.adoptPopup`, `EmbeddedWebView.adopt` /
+  `discardRetainedPopup`, and the `webview_embed_adopt_popup` /
+  `webview_embed_discard_popup` JNI declarations — authored
+  platform-agnostically by Canvas 18 and touching no heavyweight `.java`
+  file. The wire contract (disposition ordinals `BLOCK=0` /
+  `NATIVE_WINDOW=1` / `ADOPT=2`, the `onPopupDisposition` /
+  `onPopupAdoptable` JNI signatures) is exactly the one macOS already
+  speaks. The **lightweight** path adds new internal Java plumbing —
+  `OffscreenWebView.adopt` / `discardRetainedPopup`, two
+  `webview_offscreen_adopt_popup` / `webview_offscreen_discard_popup`
+  `WebViewNative` declarations, and real adoption wiring in
+  `WebViewLightweightComponent.addNotify` (replacing its Canvas-19
+  skip-guard). The **public `WebViewComponent` API is unchanged** — the
+  same `adoptPopup(popupId)` factory drives whichever component the app
+  built; only the lightweight component's internals learn to adopt.
 
 - **Why the existing Linux model is insufficient for a tabbed browser.**
   Same rationale as Canvas 18: a tabbed consumer that wants popups as
@@ -51,10 +72,19 @@ generated_at: 2026-08-06T16:00:00-07:00
   under `g_gtk_retained_popups` keyed by an engine-assigned `popup_id`,
   returns the child to WebKit (which drives the original request into
   it), and fires `onPopupAdoptable(popup_id, …)`. Phase 2 (EDT): the
-  application's `WebViewComponent.adoptPopup(popup_id)` peer attach calls
-  `webview_embed_adopt_popup` → `gtk_adopt_popup`, which reparents the
-  retained child into the component's realized X11 surface and returns
-  the engine pointer.
+  application's `WebViewComponent.adoptPopup(popup_id)` peer attach
+  claims the retained child and reuses it. When the adopting component
+  is **heavyweight**, `EmbeddedWebView.adopt` →
+  `webview_embed_adopt_popup` → `gtk_adopt_popup` reparents the retained
+  child into the component's realized X11 surface and returns the
+  heavyweight engine pointer. When it is **lightweight**,
+  `OffscreenWebView.adopt` → `webview_offscreen_adopt_popup` →
+  `gtk_off_adopt_popup` reuses the retained child inside a fresh
+  `GtkOffscreenWindow` (`OffEngine`), so the child renders into the
+  offscreen surface that Java blits — no X11 reparent into an on-screen
+  window is involved. Phase 1 is identical for both targets (the child
+  is retained windowless in the shared registry regardless of which
+  engine the opener was).
 
 - **The disposition decision is synchronous on the GTK main thread.**
   Exactly like the Canvas 16 `onPopupRequested` gate and the
@@ -67,22 +97,33 @@ generated_at: 2026-08-06T16:00:00-07:00
   `PopupDispatcher` marshals `popupAdoptable` to the EDT via
   `invokeLater` itself.
 
-- **Scope: Linux heavyweight (embed) engine only.** The offscreen /
-  lightweight WebKitGTK path (`OffEngine` /
-  `WebViewLightweightComponent`) is **out of scope** — its Canvas-19
-  guard is left as-is; only the heavyweight `Engine` gains adoption. This
-  matches the macOS boundary (no lightweight adopt) and keeps the risky
-  X11-reparent work confined to the one engine that already does
-  XReparentWindow embedding.
+- **Scope: both Linux engines (heavyweight embed + lightweight
+  offscreen).** The heavyweight `Engine` gains adoption via
+  `gtk_adopt_popup` (X11 reparent) and the lightweight `OffEngine` gains
+  adoption via `gtk_off_adopt_popup` (reuse the child inside a
+  `GtkOffscreenWindow`). Both share the single `g_gtk_retained_popups`
+  registry and the single `gtk_discard_popup` reclaim path. macOS
+  remains heavyweight-only (its offscreen engine is a stub); the
+  lightweight adopt is a WebKitGTK-specific capability the offscreen
+  blit pipeline makes cheap (no X11 reparent risk — the child lives in
+  an offscreen toplevel).
 
 - Definition of Done:
   - A handler returning `ADOPT` from `popupDisposition`, plus an app
     that on `popupAdoptable` creates a tab via
     `WebViewComponent.adoptPopup(popupId)`, results in the popup
-    appearing **inside that component** on Linux, with the **POST body
-    preserved** and **opener linkage intact** (`window.opener`
-    non-null, `postMessage`-to-opener works). No native popup window
-    appears at any point on the `ADOPT` path.
+    appearing **inside that component** on Linux — for **either** a
+    heavyweight or a lightweight/offscreen adopting component — with the
+    **POST body preserved** and **opener linkage intact**
+    (`window.opener` non-null, `postMessage`-to-opener works). No native
+    popup window appears at any point on the `ADOPT` path.
+  - For the **lightweight** target specifically: `adoptPopup` on a
+    lightweight `WebViewComponent` makes
+    `WebViewLightweightComponent.addNotify` call `OffscreenWebView.adopt`
+    (not `create`) and **not** navigate `pendingUrl` (the adopted child
+    already carries its in-flight navigation), and the adopted child's
+    pixels blit into the Swing component via the existing snapshot
+    pipeline. The public `WebViewComponent` API is unchanged.
   - A Canvas 16 handler that allows the popup (`popupRequested` →
     `true`, or `DEFAULT`) still opens a native GTK window; a blocking
     handler / `setPopupHandler(null)` still blocks — byte-for-byte the
@@ -93,17 +134,27 @@ generated_at: 2026-08-06T16:00:00-07:00
     `IllegalStateException`; adoption is once-only (claim removes under
     lock).
   - A popup decided `ADOPT` but never adopted is reclaimed via
-    `webview_embed_discard_popup` → `gtk_discard_popup` (opener disposed
-    or grace-period backstop) — native child torn down, `onPopupClosed`
-    fired, inherited refs freed, no orphaned engine.
+    `gtk_discard_popup` (opener disposed or grace-period backstop) —
+    native child torn down, `onPopupClosed` fired, inherited refs freed,
+    no orphaned engine. Both JNI reclaim bridges converge on the **same**
+    `gtk_discard_popup`: heavyweight via `webview_embed_discard_popup`,
+    lightweight via `webview_offscreen_discard_popup` (the retained child
+    is the same `PopupEngine` in the shared registry, so the reclaim is
+    identical and is NOT duplicated).
   - Closing an adopted popup fires `onPopupClosed` correlated by
     `popup_id` and disposes the engine without dereferencing freed
     native state.
 
 - Out of scope (explicit non-goals):
   - **Windows (WebView2) adoption** — Canvas 20 / STORY-005-003.
-  - The **offscreen / lightweight** WebKitGTK engine (`OffEngine`).
-  - Any **Java** change (contract is Canvas 18's, reused verbatim).
+  - **macOS offscreen adoption** — the macOS/Windows offscreen engines
+    are stubs (`webview_offscreen_create` returns 0), so
+    `webview_offscreen_adopt_popup` returns 0 there and adoption is
+    never triggered on those platforms.
+  - Any change to the **public `WebViewComponent` API** — the lightweight
+    Java additions are internal (`OffscreenWebView`, `WebViewNative`,
+    `WebViewLightweightComponent` internals only). The heavyweight Java
+    contract is Canvas 18's, reused verbatim.
   - **swingwebbrowser** consumer wiring — STORY-005-004.
   - Surfacing the HTTP method/body to Java; reparenting an arbitrary
     running component; `window.open` feature strings beyond
@@ -163,10 +214,94 @@ generated_at: 2026-08-06T16:00:00-07:00
     `UnsatisfiedLinkError` (the exact bug already hit and fixed for the
     dialog setters; see the block comment above the bridges).
 
+- **`src_c/webview_embed.cpp`** (modified — GTK offscreen/lightweight
+  region, inside `#ifdef WEBVIEW_GTK`). New offscreen adoption code:
+  - `gtk_off_create_engine` (modified) — gains an optional
+    `GtkWidget *existing_web = nullptr` trailing parameter, mirroring
+    the `gtk_create_engine` refactor. When non-null the offscreen engine
+    **reuses** that web view (skipping `webkit_web_view_new()`) while
+    still building the `GtkOffscreenWindow`, wiring the external
+    message handler / dialogs / popups / IM-disable / focus-synth, and
+    doing `gtk_container_add` + `gtk_widget_show_all`. The single
+    existing caller (`webview_offscreen_create` bridge) passes the old
+    three-arg form and gets the default `nullptr` (fresh view).
+  - `gtk_off_adopt_popup(env, popupId, width, height, debug)
+    -> OffEngine*` — claims the retained `PopupEngine` from the shared
+    `g_gtk_retained_popups` (adopt-once, under
+    `g_gtk_retained_popups_mutex`; `nullptr` if absent), disconnects its
+    PopupEngine-scoped signal handlers
+    (`g_signal_handlers_disconnect_by_data` via `GtkPump` run_sync),
+    calls `gtk_off_create_engine(env, width, height, debug,
+    existing_web=child)` to reuse the child in a `GtkOffscreenWindow`,
+    transfers the inherited popup/dialog global refs to the `OffEngine`,
+    drops the retained `g_object` ref (the offscreen window now holds
+    the child), and deletes the `PopupEngine` shell. On failure it
+    reconnects the PopupEngine handlers and re-retains the child in the
+    registry (exactly like `gtk_adopt_popup`). The GTK counterpart of
+    `gtk_adopt_popup` for the offscreen engine.
+  - `gtk_discard_popup` (**reused unchanged**) — the offscreen reclaim
+    path claims the SAME `PopupEngine` from the SAME shared registry, so
+    the discard is identical and is NOT duplicated for the offscreen
+    engine.
+  - The two new offscreen JNI bridges (see below) live in the
+    `extern "C"` block.
+
+- **`src_c/webview_embed.cpp`** (`extern "C"` block) — two new offscreen
+  JNI bridges added next to `webview_offscreen_set_popup_callback` /
+  `webview_offscreen_set_user_agent`:
+  - `Java_…_webview_1offscreen_1adopt_1popup(env, jclass, jint width,
+    jint height, jlong popupId, jint debug) -> jlong` — `#ifdef
+    WEBVIEW_GTK` returns `(jlong)embed::gtk_off_adopt_popup(env,
+    popupId, width, height, debug)`; `#else` returns `0`
+    (macOS/Windows offscreen is a stub).
+  - `Java_…_webview_1offscreen_1discard_1popup(env, jclass,
+    jlong /*peer*/, jlong popupId) -> void` — `#ifdef WEBVIEW_GTK`
+    calls `embed::gtk_discard_popup(popupId)` (the shared reclaim).
+  - Both **remain inside the `extern "C"` block** — a JNI method outside
+    it gets C++-mangled and fails at runtime with `UnsatisfiedLinkError`
+    (the exact bug already hit and fixed for the dialog setters).
+
+- **`src/ca/weblite/webview/WebViewNative.java`** (modified) — two new
+  `native static` declarations next to the other `webview_offscreen_*`:
+  - `webview_offscreen_adopt_popup(int width, int height, long popupId,
+    int debug) -> long`.
+  - `webview_offscreen_discard_popup(long peer, long popupId) -> void`.
+
+- **`src/ca/weblite/webview/OffscreenWebView.java`** (modified) — the
+  offscreen wrapper's adoption factory + reclaim:
+  - `static adopt(int width, int height, long popupId, boolean debug)
+    -> OffscreenWebView` — mirrors the `create(w, h, debug)` factory:
+    calls `webview_offscreen_adopt_popup`, throws
+    `IllegalStateException` when the returned peer is `0` (no retained
+    popup for that id / unsupported platform), otherwise wraps the peer
+    and installs the same evalAsync / addJavascriptFunction bridges that
+    `create` installs.
+  - `discardRetainedPopup(long popupId) -> OffscreenWebView` — calls
+    `webview_offscreen_discard_popup(peer, popupId)`; the offscreen
+    counterpart of `EmbeddedWebView.discardRetainedPopup`.
+
+- **`src/ca/weblite/webview/swing/WebViewLightweightComponent.java`**
+  (modified) — `addNotify` real adoption:
+  - The Canvas-19 skip-guard (stderr warning + early return when
+    `pendingAdoptPopupId != 0`) is **replaced** by real adoption: when
+    `pendingAdoptPopupId != 0L` the engine is built via
+    `OffscreenWebView.adopt(w, h, pendingAdoptPopupId, debug)` instead of
+    `OffscreenWebView.create(w, h, debug)`.
+  - `pendingUrl` is NOT navigated on the adopt path (the adopted child
+    carries its own in-flight navigation), mirroring the heavyweight
+    component's `if (pendingAdoptPopupId == 0L) navigate` guard.
+  - A reclaim sink is installed like the heavyweight component's:
+    `popupDispatcher.setReclaimSink(...)` whose `discard(popupId)` calls
+    `engine.discardRetainedPopup(popupId)` (best-effort).
+  - The UA-apply-before-navigate and `applyUserAgentToPeer` override are
+    kept intact.
+
 - **`PopupEngine`** (reused unchanged) — its `window` field is now
   `nullptr` for an ADOPT child (windowless); `web`, `jvm`,
   `popup_callback`, `dialog_callback`, `popup_id` carry the retained
-  child's state until adoption or discard.
+  child's state until adoption or discard. The SAME `PopupEngine` is
+  claimed by either `gtk_adopt_popup` (heavyweight) or
+  `gtk_off_adopt_popup` (lightweight), whichever component adopts it.
 
 ```mermaid
 flowchart TB
@@ -177,11 +312,15 @@ flowchart TB
   disp -->|NATIVE_WINDOW 1| win["GtkWindow + ready-to-show + onPopupOpened (Canvas 16)"]
   disp -->|ADOPT 2| adopt["child windowless + g_object_ref_sink\nregister g_gtk_retained_popups\nfire_popup_notify_adoptable"]
   adopt -.EDT.-> java["WebViewComponent.adoptPopup(popupId)"]
-  java --> bridge["webview_embed_adopt_popup (extern C)"]
+  java -->|heavyweight| bridge["webview_embed_adopt_popup (extern C)"]
   bridge --> gadopt["gtk_adopt_popup"]
   gadopt --> reuse["gtk_create_engine(existing_web=child)\nJAWT + XReparentWindow into parent surface"]
   reuse --> engine["Engine* returned to Java peer"]
-  adopt -. unclaimed .-> discard["webview_embed_discard_popup -> gtk_discard_popup"]
+  java -->|lightweight| obridge["webview_offscreen_adopt_popup (extern C)"]
+  obridge --> goadopt["gtk_off_adopt_popup"]
+  goadopt --> oreuse["gtk_off_create_engine(existing_web=child)\nGtkOffscreenWindow, blitted into Swing"]
+  oreuse --> oengine["OffEngine* returned to Java peer"]
+  adopt -. unclaimed .-> discard["webview_embed_discard_popup OR webview_offscreen_discard_popup\n-> shared gtk_discard_popup"]
 ```
 
 ## A · Approach
@@ -194,15 +333,30 @@ flowchart TB
    `gtk_create_engine` already performs. Java never sees or reconstructs
    the request — sidestepping the unavailable-POST-body problem.
 
-2. **Refactor, don't duplicate, the embedding path.**
+2. **Refactor, don't duplicate, the embedding path — both engines.**
    `gtk_create_engine` gains an optional `existing_web` parameter. When
    non-null it skips `webkit_web_view_new()` and reuses the retained
    child, but runs the identical JAWT lock / `XReparentWindow` / window
    realize / software-compositing / frame-clock / engine-scoped signal
    wiring. `gtk_adopt_popup` is thin: claim, disconnect the child's old
    PopupEngine handlers, call the shared path, transfer callbacks, drop
-   the retained ref. This keeps the reparent logic single-sourced, so
-   adoption cannot drift from normal create embedding.
+   the retained ref. The offscreen engine mirrors this exactly:
+   `gtk_off_create_engine` gains the same optional `existing_web`
+   parameter (reuse vs. `webkit_web_view_new()`), and
+   `gtk_off_adopt_popup` is the offscreen twin of `gtk_adopt_popup` —
+   claim from the shared registry, disconnect, call
+   `gtk_off_create_engine(existing_web=child)`, transfer callbacks, drop
+   the retained ref. This keeps the reuse logic single-sourced per
+   engine, so adoption cannot drift from normal create.
+
+2b. **Shared retained registry + shared reclaim.** Phase 1
+   (`handle_create_web_view` ADOPT branch) is untouched and
+   engine-agnostic: whether the opener is heavyweight or lightweight, the
+   child is retained windowless in the single `g_gtk_retained_popups`
+   under `g_gtk_retained_popups_mutex`. Adoption therefore claims from
+   that same map regardless of adopt target, and the discard/reclaim path
+   is the single `gtk_discard_popup` — the offscreen discard JNI bridge
+   calls it directly rather than adding a parallel offscreen teardown.
 
 3. **Disposition switch inside the shared create handler.**
    `handle_create_web_view` is the one inner handler all three GTK create
@@ -257,20 +411,55 @@ flowchart TB
    `ExceptionDescribe` / `ExceptionClear`. Strings are null-coerced to
    empty; sizes are `-1` for unspecified at create time.
 
+9. **Offscreen ownership is simpler than heavyweight.** On the offscreen
+   adopt there is NO `XReparentWindow` into a foreign on-screen X11 tree:
+   the reused child is added to a fresh `GtkOffscreenWindow` via
+   `gtk_container_add`, which takes the container ref. The retained
+   `g_object_ref_sink` ref is then dropped (the offscreen window owns the
+   child), exactly balancing as in the heavyweight adopt. The child's
+   in-flight (POST) navigation continues to render, now into the
+   offscreen surface that Java snapshots and blits.
+
+10. **Lightweight component: adopt instead of create, don't
+    re-navigate.** `WebViewLightweightComponent.addNotify` chooses
+    `OffscreenWebView.adopt(w, h, pendingAdoptPopupId, debug)` when
+    `pendingAdoptPopupId != 0L`, else `OffscreenWebView.create(w, h,
+    debug)`. The adopted child already carries its navigation, so
+    `pendingUrl` is only navigated on the create path (guard
+    `if (pendingAdoptPopupId == 0L)`), mirroring the heavyweight
+    component. All the other addNotify wiring (console/mouse/dialog/popup
+    bridges, pending-config replay, UA-before-navigate, repaint timer,
+    editing-shortcut dispatcher) is shared with the create path. A
+    reclaim sink is registered on the `popupDispatcher` so the component
+    can discard retained-but-unadopted children through
+    `engine.discardRetainedPopup`.
+
 ## S · Structure
 
-### Layered Architecture (native only; layers above are Canvas 18's, unchanged)
+### Layered Architecture
 1. **Native engine layer** (`src_c/webview_embed.cpp`, GTK region):
-   disposition switch in `handle_create_web_view`, the
-   `g_gtk_retained_popups` registry, `fire_popup_disposition` /
-   `fire_popup_notify_adoptable`, `gtk_create_engine`'s `existing_web`
-   reuse, `gtk_adopt_popup` / `gtk_discard_popup`, `on_ready_to_show_popup`
-   windowless guard.
+   - Heavyweight: disposition switch in `handle_create_web_view`, the
+     `g_gtk_retained_popups` registry, `fire_popup_disposition` /
+     `fire_popup_notify_adoptable`, `gtk_create_engine`'s `existing_web`
+     reuse, `gtk_adopt_popup` / `gtk_discard_popup`,
+     `on_ready_to_show_popup` windowless guard.
+   - Lightweight (new): `gtk_off_create_engine`'s `existing_web` reuse,
+     `gtk_off_adopt_popup`, sharing the SAME `g_gtk_retained_popups`
+     registry and the SAME `gtk_discard_popup` reclaim.
 2. **JNI surface** (`extern "C"` bridges): GTK branch of
-   `webview_embed_adopt_popup` / `webview_embed_discard_popup`.
-3. **Everything above** (`WebViewNative`, `EmbeddedWebView`,
-   `PopupDispatcher`, `WebViewComponent`, `WebViewPopupHandler`,
-   `PopupDisposition`, `WebViewPopupCallback`): **Canvas 18, unmodified.**
+   `webview_embed_adopt_popup` / `webview_embed_discard_popup`
+   (heavyweight, Canvas 18); new `webview_offscreen_adopt_popup` /
+   `webview_offscreen_discard_popup` (lightweight).
+3. **Java layer**:
+   - Heavyweight (`EmbeddedWebView`, `PopupDispatcher`,
+     `WebViewComponent`, `WebViewPopupHandler`, `PopupDisposition`,
+     `WebViewPopupCallback`, `WebViewHeavyweightComponent`): **Canvas 18,
+     unmodified.**
+   - Lightweight (new/modified, internal only): `WebViewNative` (two new
+     offscreen decls), `OffscreenWebView` (`adopt` /
+     `discardRetainedPopup`), `WebViewLightweightComponent` (real
+     adoption + reclaim sink in `addNotify`). The public
+     `WebViewComponent` API and `adoptPopup` factory are unchanged.
 
 ### Dependencies
 1. `handle_create_web_view` → `fire_popup_disposition`,
@@ -278,9 +467,21 @@ flowchart TB
 2. `gtk_adopt_popup` → `g_gtk_retained_popups`, `gtk_create_engine`
    (with `existing_web`), `GtkPump`, the PopupEngine signal handlers
    (reconnect on failure).
-3. `gtk_discard_popup` → `g_gtk_retained_popups`, `fire_gtk_popup_closed`,
-   `GtkPump`.
-4. JNI bridges → `embed::gtk_adopt_popup` / `embed::gtk_discard_popup`.
+3. `gtk_off_adopt_popup` → `g_gtk_retained_popups`,
+   `gtk_off_create_engine` (with `existing_web`), `GtkPump`, the
+   PopupEngine signal handlers (reconnect on failure).
+4. `gtk_discard_popup` → `g_gtk_retained_popups`, `fire_gtk_popup_closed`,
+   `GtkPump` (shared by both engines' reclaim bridges).
+5. Heavyweight JNI bridges → `embed::gtk_adopt_popup` /
+   `embed::gtk_discard_popup`.
+6. Offscreen JNI bridges → `embed::gtk_off_adopt_popup` /
+   `embed::gtk_discard_popup`.
+7. `OffscreenWebView.adopt` → `WebViewNative.webview_offscreen_adopt_popup`;
+   `OffscreenWebView.discardRetainedPopup` →
+   `WebViewNative.webview_offscreen_discard_popup`.
+8. `WebViewLightweightComponent.addNotify` → `OffscreenWebView.adopt` /
+   `OffscreenWebView.create`, `popupDispatcher.setReclaimSink` →
+   `OffscreenWebView.discardRetainedPopup`.
 
 ## O · Operations
 
@@ -343,7 +544,7 @@ File: `src_c/webview_embed.cpp` (GTK)
    `g_object_unref(web)`.
 4. Free the inherited global refs; `delete pe`.
 
-### 7. JNI bridges (GTK branch)
+### 7. JNI bridges — heavyweight (GTK branch)
 File: `src_c/webview_embed.cpp` (`extern "C"`)
 1. `webview_embed_adopt_popup`: `#ifdef WEBVIEW_GTK` →
    `embed::gtk_adopt_popup(env, parent, popupId, debug)`; return
@@ -352,11 +553,84 @@ File: `src_c/webview_embed.cpp` (`extern "C"`)
    `embed::gtk_discard_popup(popupId)`.
 3. Both remain inside `extern "C"`.
 
+### 8. `gtk_off_create_engine` reuse parameter
+File: `src_c/webview_embed.cpp` (GTK offscreen)
+1. Add trailing `GtkWidget *existing_web = nullptr` param; inside the
+   run_sync body, `e->web = existing_web ? existing_web :
+   webkit_web_view_new()`. Everything else (offscreen window, external
+   message handler, dialog/popup signals, IM-disable, focus-synth,
+   `gtk_container_add`, `show_all`) is shared. The one existing caller
+   (the `webview_offscreen_create` bridge) is unchanged and gets the
+   default.
+
+### 9. `gtk_off_adopt_popup`
+File: `src_c/webview_embed.cpp` (GTK offscreen)
+1. Claim the `PopupEngine` from the shared `g_gtk_retained_popups` under
+   `g_gtk_retained_popups_mutex` (adopt-once); `nullptr` if absent or if
+   `pe->web` is null.
+2. `g_signal_handlers_disconnect_by_data(pe->web, pe)` on the GTK thread.
+3. `OffEngine *e = gtk_off_create_engine(env, width, height, debug,
+   GTK_WIDGET(pe->web))`. On failure: reconnect the PopupEngine handlers,
+   re-retain in the registry, return `nullptr`.
+4. Transfer `popup_callback` / `dialog_callback` from `pe` to `e` (null
+   them on `pe`).
+5. `g_object_unref(childw)` on the GTK thread (drop the retained ref; the
+   offscreen window now holds a container ref).
+6. `delete pe`; return `e`.
+
+### 10. Offscreen JNI bridges (GTK branch)
+File: `src_c/webview_embed.cpp` (`extern "C"`)
+1. `webview_offscreen_adopt_popup(env, jclass, jint width, jint height,
+   jlong popupId, jint debug) -> jlong`: `#ifdef WEBVIEW_GTK` →
+   `return (jlong)embed::gtk_off_adopt_popup(env, popupId, width, height,
+   debug)`; `#else return 0`.
+2. `webview_offscreen_discard_popup(env, jclass, jlong /*peer*/,
+   jlong popupId) -> void`: `#ifdef WEBVIEW_GTK` →
+   `embed::gtk_discard_popup(popupId)` (shared reclaim).
+3. Both placed inside `extern "C"`, next to
+   `webview_offscreen_set_popup_callback` /
+   `webview_offscreen_set_user_agent`.
+
+### 11. Java: `WebViewNative` declarations
+File: `src/ca/weblite/webview/WebViewNative.java`
+1. Add `native static long webview_offscreen_adopt_popup(int width,
+   int height, long popupId, int debug)` and `native static void
+   webview_offscreen_discard_popup(long peer, long popupId)` next to the
+   other `webview_offscreen_*` decls.
+
+### 12. Java: `OffscreenWebView.adopt` / `discardRetainedPopup`
+File: `src/ca/weblite/webview/OffscreenWebView.java`
+1. `static adopt(int width, int height, long popupId, boolean debug)`:
+   call `webview_offscreen_adopt_popup`; if peer == 0 throw
+   `IllegalStateException` naming the popupId; else construct the wrapper
+   and install the SAME evalAsync + addJavascriptFunction bridges that
+   `create` installs (factor the shared bind sequence so `create` and
+   `adopt` cannot diverge).
+2. `discardRetainedPopup(long popupId)`: call
+   `webview_offscreen_discard_popup(peer, popupId)`; return `this`.
+
+### 13. Java: `WebViewLightweightComponent.addNotify`
+File: `src/ca/weblite/webview/swing/WebViewLightweightComponent.java`
+1. Replace the Canvas-19 skip-guard (stderr warning + early return on
+   `pendingAdoptPopupId != 0`) with: `engine = (pendingAdoptPopupId !=
+   0L) ? OffscreenWebView.adopt(w, h, pendingAdoptPopupId, debug) :
+   OffscreenWebView.create(w, h, debug)`.
+2. Guard the `engine.navigate(pendingUrl)` with `if (pendingAdoptPopupId
+   == 0L)`.
+3. Install `popupDispatcher.setReclaimSink(...)` whose `discard(popupId)`
+   calls `engine.discardRetainedPopup(popupId)` (best-effort, swallow
+   `RuntimeException`).
+4. Keep UA-apply-before-navigate and `applyUserAgentToPeer` intact.
+
 ## N · Norms
 
-- **No Java changes.** This canvas is native-only; the Java contract is
-  Canvas 18's. The wire contract (ordinals, JNI method signatures) is
-  identical to macOS.
+- **No public-API changes; heavyweight Java untouched.** The heavyweight
+  path is native-only (Canvas 18's Java contract, wire ordinals, and JNI
+  signatures reused verbatim). The lightweight path adds INTERNAL Java
+  only (`WebViewNative` decls, `OffscreenWebView.adopt` /
+  `discardRetainedPopup`, `WebViewLightweightComponent` internals); the
+  public `WebViewComponent` API and `adoptPopup` factory do not change.
+  macOS and Windows code is not touched.
 - **Ordinal wire contract.** `onPopupDisposition` returns
   `BLOCK=0/NATIVE_WINDOW=1/ADOPT=2`; never reorder.
 - **Additive-only.** The `NATIVE_WINDOW` / `BLOCK` branches are the
@@ -377,11 +651,26 @@ File: `src_c/webview_embed.cpp` (`extern "C"`)
 - **Single handler set per signal.** `g_signal_handlers_disconnect_by_data`
   removes the PopupEngine-scoped handlers before the engine-scoped ones
   are connected.
-- **Offscreen path untouched.** No change to `OffEngine` /
-  `WebViewLightweightComponent`; the lightweight Canvas-19 guard stays.
+- **Shared registry + shared reclaim, single-sourced.** Both adopt
+  targets claim from the one `g_gtk_retained_popups`; both reclaim
+  bridges converge on the one `gtk_discard_popup`. The offscreen discard
+  MUST NOT duplicate teardown logic.
+- **Offscreen reuse mirrors heavyweight.** `gtk_off_adopt_popup` follows
+  `gtk_adopt_popup` step-for-step (claim → disconnect → reuse-create →
+  transfer refs → drop retained ref → delete shell; failure path
+  reconnects + re-retains). `gtk_off_create_engine`'s `existing_web`
+  reuse mirrors `gtk_create_engine`'s.
+- **Adopt vs. create parity in the lightweight component.** The adopt
+  path shares ALL of `addNotify`'s bridge/replay/UA wiring with the
+  create path; only the engine-construction call and the `pendingUrl`
+  navigate are gated on `pendingAdoptPopupId`.
+- **`OffscreenWebView.adopt` installs the same bridges as `create`.** The
+  adopted wrapper must be indistinguishable from a created one
+  (evalAsync + addJavascriptFunction bridges present).
 - **C++11, no `-Werror`** (`g++ -std=c++11 -Wall -DWEBVIEW_GTK=1`);
-  avoid hard errors. Default parameter on `gtk_create_engine` keeps the
-  existing single call site compiling unchanged.
+  avoid hard errors. Default parameter on `gtk_create_engine` AND
+  `gtk_off_create_engine` keeps the existing single call sites compiling
+  unchanged. The Java side compiles under Java 8 (`javac`).
 
 ## S · Safeguards
 
@@ -402,9 +691,13 @@ File: `src_c/webview_embed.cpp` (`extern "C"`)
   Linux end of the Canvas 18 reclaim contract (opener dispose +
   grace-period backstop, both driven from the unchanged Java side).
 - **JNI bridges inside `extern "C"`.** The GTK-branch edit does not move
-  the bridges; keeping them inside `extern "C"` is mandatory
+  the heavyweight bridges; keeping them inside `extern "C"` is mandatory
   (UnsatisfiedLinkError otherwise — the documented, previously-fixed
-  bug).
+  bug). The two NEW offscreen bridges
+  (`webview_offscreen_adopt_popup` / `webview_offscreen_discard_popup`)
+  MUST also be added INSIDE the `extern "C"` block — a bridge placed
+  outside it gets C++-mangled and fails at runtime with
+  `UnsatisfiedLinkError` (this exact bug was already hit once).
 - **Opener linkage + POST are mandatory.** The adopted child MUST be the
   `webkit_web_view_new_with_related_view` child; creating a fresh view or
   re-navigating from Java is a defect.
@@ -429,15 +722,52 @@ File: `src_c/webview_embed.cpp` (`extern "C"`)
   - the software-compositing / frame-clock repaint pacing on the reused
     view (the Canvas 6/16 virtualized-X11 concerns apply unchanged).
 
+- **Offscreen adoption — ON-DEVICE VALIDATION REQUIRED.** The offscreen
+  adopt is likewise unbuilt/unexercised in this sandbox (no GTK
+  toolchain). Prime candidates for on-device scrutiny on a real
+  WebKitGTK stack:
+  - the ownership/reparent handoff — a child created windowless (held by
+    `g_object_ref_sink`) is `gtk_container_add`-ed into a fresh
+    `GtkOffscreenWindow`, then the retained ref is dropped; verify the
+    refcount stays balanced (offscreen window container ref + WebKit's
+    own ref) with no premature finalization or use-after-destroy;
+  - **blit of a mid-navigation child** — the reused child may be
+    mid-POST-navigation when reparented from windowless into the
+    offscreen window; verify the snapshot/blit pipeline (cairo surface →
+    `BufferedImage`, ~30Hz via the component repaint timer) begins
+    producing correct frames and does not race the reparent (e.g. a
+    snapshot taken before the offscreen window realizes the child);
+  - the `gtk_off_adopt_popup` failure path (re-retain + reconnect the
+    PopupEngine handlers) leaves the child reclaimable exactly like the
+    heavyweight failure path;
+  - focus-synth / IM-disable on the reused view behaves as it does for a
+    freshly-created offscreen engine (the adopted child skipped the
+    `create`-time focus grab until `gtk_off_create_engine` runs it).
+
 ## REASONS-Implements
 
-- `src_c/webview_embed.cpp` (GTK region: `g_gtk_retained_popups` +
-  mutex, `fire_popup_disposition`, `fire_popup_notify_adoptable`,
-  `handle_create_web_view` disposition switch, `on_ready_to_show_popup`
-  windowless guard, `gtk_create_engine` `existing_web` reuse,
-  `gtk_adopt_popup`, `gtk_discard_popup`)
+- `src_c/webview_embed.cpp` (GTK heavyweight region:
+  `g_gtk_retained_popups` + mutex, `fire_popup_disposition`,
+  `fire_popup_notify_adoptable`, `handle_create_web_view` disposition
+  switch, `on_ready_to_show_popup` windowless guard, `gtk_create_engine`
+  `existing_web` reuse, `gtk_adopt_popup`, `gtk_discard_popup`)
+- `src_c/webview_embed.cpp` (GTK offscreen/lightweight region:
+  `gtk_off_create_engine` `existing_web` reuse, `gtk_off_adopt_popup`;
+  offscreen reclaim reuses the shared `gtk_discard_popup`)
 - `src_c/webview_embed.cpp` (`extern "C"`: GTK branch of
   `Java_ca_weblite_webview_WebViewNative_webview_1embed_1adopt_1popup`
-  and `…_webview_1embed_1discard_1popup`)
-- Conforms to the Canvas 18 Java contract
-  ([[popup-adoption-into-webviewcomponent-tab]]) — **no Java changes**.
+  and `…_webview_1embed_1discard_1popup`; and the two new offscreen
+  bridges `…_webview_1offscreen_1adopt_1popup` and
+  `…_webview_1offscreen_1discard_1popup`)
+- `src/ca/weblite/webview/WebViewNative.java` (two new offscreen
+  `native static` decls: `webview_offscreen_adopt_popup`,
+  `webview_offscreen_discard_popup`)
+- `src/ca/weblite/webview/OffscreenWebView.java` (`adopt(int, int, long,
+  boolean)` factory, `discardRetainedPopup(long)`)
+- `src/ca/weblite/webview/swing/WebViewLightweightComponent.java`
+  (`addNotify` real adoption: `OffscreenWebView.adopt` on
+  `pendingAdoptPopupId != 0`, adopt-path navigate guard, reclaim sink)
+- Heavyweight path conforms to the Canvas 18 Java contract
+  ([[popup-adoption-into-webviewcomponent-tab]]) — **no heavyweight Java
+  changes**. Lightweight path adds internal Java only; the public
+  `WebViewComponent` API is unchanged.

--- a/spdd/prompt/19-20260806-1600-[Feat]-Popup-Adoption-Linux-Coverage.md
+++ b/spdd/prompt/19-20260806-1600-[Feat]-Popup-Adoption-Linux-Coverage.md
@@ -1,0 +1,443 @@
+---
+generated_at: 2026-08-06T16:00:00-07:00
+---
+
+# REASONS Canvas: Popup Adoption Into a Caller-Provided WebViewComponent — Linux (WebKitGTK) Coverage (STORY-005-002)
+
+## R · Requirements
+
+- Extend popup adoption ([[popup-adoption-into-webviewcomponent-tab]],
+  Canvas 18) to the **Linux (WebKitGTK / X11)** heavyweight backend.
+  Canvas 18 shipped the cross-platform Java contract and the **macOS
+  (WKWebView)** reference; this canvas lands the **WebKitGTK** native
+  implementation of the same contract so an application can **adopt**
+  an engine-created popup — the opener-linked child web view WebKit
+  raises for `window.open`, `<a target="_blank">`, or `<form
+  method="post" target="…">` — into a **`WebViewComponent` the
+  application supplies** (a Swing tab), instead of the native GTK
+  top-level window the engine owns today (Canvas 16).
+
+- **No Java changes.** The entire Java contract — `PopupDisposition`,
+  `WebViewPopupHandler.popupDisposition` / `popupAdoptable`,
+  `WebViewPopupCallback.onPopupDisposition` / `onPopupAdoptable`,
+  `PopupDispatcher` bookkeeping, `WebViewComponent.adoptPopup`,
+  `EmbeddedWebView.adopt` / `discardRetainedPopup`, and the
+  `webview_embed_adopt_popup` / `webview_embed_discard_popup` JNI
+  declarations — was authored platform-agnostically by Canvas 18 and is
+  **reused unchanged**. This canvas conforms to that contract; it does
+  not re-shape the Java side, and touches no `.java` file. The wire
+  contract (disposition ordinals `BLOCK=0` / `NATIVE_WINDOW=1` /
+  `ADOPT=2`, the `onPopupDisposition` / `onPopupAdoptable` JNI
+  signatures) is exactly the one macOS already speaks.
+
+- **Why the existing Linux model is insufficient for a tabbed browser.**
+  Same rationale as Canvas 18: a tabbed consumer that wants popups as
+  tabs must today block the native window and re-open the target URL via
+  `setUrl`, which issues a GET (losing a `<form method="post">` body)
+  and drops opener linkage (`window.opener` null, `postMessage`-to-opener
+  broken). WebKitGTK's `WebKitURIRequest` does **not** expose the POST
+  body, so the request cannot be reconstructed and replayed from Java.
+  The only faithful path is to **reuse the engine's own child** — the
+  `webkit_web_view_new_with_related_view(opener)` view WebKit already
+  drove the original request (verb + body) into, which is already
+  opener-linked — and reparent it into the caller's surface.
+
+- **Two-phase adoption, mirroring macOS.** Phase 1 (GTK main thread,
+  synchronous): the `create` signal handler
+  (`handle_create_web_view`) calls `onPopupDisposition` and switches on
+  the returned ordinal. On `ADOPT` it builds the opener-linked child
+  from `webkit_web_view_new_with_related_view`, creates **no**
+  `GtkWindow`, retains the child (holding an explicit strong reference)
+  under `g_gtk_retained_popups` keyed by an engine-assigned `popup_id`,
+  returns the child to WebKit (which drives the original request into
+  it), and fires `onPopupAdoptable(popup_id, …)`. Phase 2 (EDT): the
+  application's `WebViewComponent.adoptPopup(popup_id)` peer attach calls
+  `webview_embed_adopt_popup` → `gtk_adopt_popup`, which reparents the
+  retained child into the component's realized X11 surface and returns
+  the engine pointer.
+
+- **The disposition decision is synchronous on the GTK main thread.**
+  Exactly like the Canvas 16 `onPopupRequested` gate and the
+  `script-dialog` confirm path, the `create` handler must return the
+  child before yielding to WebKit, so `onPopupDisposition` is called
+  **inline** on the GTK main thread and never marshalled to the EDT. The
+  GTK create handler already runs OFF the EDT, so — unlike the macOS
+  AppKit-main path — `onPopupAdoptable` can be a **direct
+  `CallVoidMethod`** (no detached worker thread); the Java
+  `PopupDispatcher` marshals `popupAdoptable` to the EDT via
+  `invokeLater` itself.
+
+- **Scope: Linux heavyweight (embed) engine only.** The offscreen /
+  lightweight WebKitGTK path (`OffEngine` /
+  `WebViewLightweightComponent`) is **out of scope** — its Canvas-19
+  guard is left as-is; only the heavyweight `Engine` gains adoption. This
+  matches the macOS boundary (no lightweight adopt) and keeps the risky
+  X11-reparent work confined to the one engine that already does
+  XReparentWindow embedding.
+
+- Definition of Done:
+  - A handler returning `ADOPT` from `popupDisposition`, plus an app
+    that on `popupAdoptable` creates a tab via
+    `WebViewComponent.adoptPopup(popupId)`, results in the popup
+    appearing **inside that component** on Linux, with the **POST body
+    preserved** and **opener linkage intact** (`window.opener`
+    non-null, `postMessage`-to-opener works). No native popup window
+    appears at any point on the `ADOPT` path.
+  - A Canvas 16 handler that allows the popup (`popupRequested` →
+    `true`, or `DEFAULT`) still opens a native GTK window; a blocking
+    handler / `setPopupHandler(null)` still blocks — byte-for-byte the
+    prior Linux behavior.
+  - `adoptPopup` on an unknown/consumed `popupId` yields a native `0`
+    return (`gtk_adopt_popup` finds nothing in `g_gtk_retained_popups`),
+    which `EmbeddedWebView.adopt` turns into the documented
+    `IllegalStateException`; adoption is once-only (claim removes under
+    lock).
+  - A popup decided `ADOPT` but never adopted is reclaimed via
+    `webview_embed_discard_popup` → `gtk_discard_popup` (opener disposed
+    or grace-period backstop) — native child torn down, `onPopupClosed`
+    fired, inherited refs freed, no orphaned engine.
+  - Closing an adopted popup fires `onPopupClosed` correlated by
+    `popup_id` and disposes the engine without dereferencing freed
+    native state.
+
+- Out of scope (explicit non-goals):
+  - **Windows (WebView2) adoption** — Canvas 20 / STORY-005-003.
+  - The **offscreen / lightweight** WebKitGTK engine (`OffEngine`).
+  - Any **Java** change (contract is Canvas 18's, reused verbatim).
+  - **swingwebbrowser** consumer wiring — STORY-005-004.
+  - Surfacing the HTTP method/body to Java; reparenting an arbitrary
+    running component; `window.open` feature strings beyond
+    `width`/`height` (unchanged from Canvas 16).
+
+## E · Entities
+
+- **`src_c/webview_embed.cpp`** (modified — GTK region, inside
+  `#ifdef WEBVIEW_GTK`). All new native code lands here:
+  - `g_gtk_retained_popups` (`std::map<jlong, PopupEngine*>`) +
+    `g_gtk_retained_popups_mutex` — the WebKitGTK counterpart of the
+    macOS `g_retained_popups`; holds retained-but-unadopted popup
+    children keyed by `popup_id`.
+  - `fire_popup_disposition(jvm, cb, url, name, gesture, w, h, page)
+    -> int` — pure-JNI, synchronous on the GTK main thread; calls
+    `WebViewPopupCallback.onPopupDisposition`, returns the ordinal
+    (`0` = BLOCK on null cb / attach failure / exception). Mirrors the
+    macOS `fire_popup_disposition` and this file's `fire_popup_requested`.
+  - `fire_popup_notify_adoptable(jvm, cb, popup_id, url, name, gesture,
+    w, h, page)` — pure-JNI; fires `onPopupAdoptable` with a **direct
+    `CallVoidMethod`** (GTK handler already off the EDT), same
+    fire-and-forget shape as `fire_gtk_popup_opened`.
+  - `handle_create_web_view` (modified) — the shared `create`-signal
+    inner handler now calls `fire_popup_disposition` and switches:
+    `BLOCK` → `NULL`; `NATIVE_WINDOW` → the unchanged Canvas 16 GtkWindow
+    path; `ADOPT` → windowless child + `g_object_ref_sink` retain +
+    register in `g_gtk_retained_popups` + `fire_popup_notify_adoptable`,
+    connecting create/script-dialog/run-file-chooser/close (NOT
+    ready-to-show).
+  - `on_ready_to_show_popup` (modified) — early-returns when
+    `pe->window == nullptr` so an ADOPT child never shows a window or
+    fires `onPopupOpened`.
+  - `gtk_create_engine` (modified) — gains an optional
+    `GtkWidget *existing_web = nullptr` parameter; when non-null the
+    engine **reuses** that web view (skipping
+    `webkit_web_view_new()`) while performing the identical
+    JAWT/XReparent/window/frame-clock/signal wiring.
+  - `gtk_adopt_popup(env, parent, popupId, debug) -> Engine*` — claims
+    the retained `PopupEngine` (adopt-once), disconnects its
+    PopupEngine-scoped signal handlers, calls `gtk_create_engine(…,
+    existing_web=child)` to reparent the child into `parent`'s surface,
+    transfers the inherited popup/dialog callbacks to the engine, drops
+    the retained ref, deletes the shell, and returns the `Engine*`
+    (`nullptr` for unknown/consumed id, or on attach failure — after
+    re-retaining the child).
+  - `gtk_discard_popup(popupId)` — claims + tears down an unadopted
+    retained child (fires `onPopupClosed`, disconnects handlers,
+    `gtk_widget_destroy` + drops the retained ref, frees inherited refs,
+    deletes the shell). Mirrors `on_close_popup` minus the window.
+  - The two JNI bridges
+    `Java_…_webview_1embed_1adopt_1popup` /
+    `…_webview_1embed_1discard_1popup` (modified) — their `#ifdef
+    WEBVIEW_GTK` branch now calls `embed::gtk_adopt_popup` /
+    `embed::gtk_discard_popup` (previously returned `0` / no-op). They
+    **remain inside the `extern "C"` block** — a newly-added JNI method
+    placed outside it gets C++-mangled and fails at runtime with
+    `UnsatisfiedLinkError` (the exact bug already hit and fixed for the
+    dialog setters; see the block comment above the bridges).
+
+- **`PopupEngine`** (reused unchanged) — its `window` field is now
+  `nullptr` for an ADOPT child (windowless); `web`, `jvm`,
+  `popup_callback`, `dialog_callback`, `popup_id` carry the retained
+  child's state until adoption or discard.
+
+```mermaid
+flowchart TB
+  JS["window.open / target=_blank / form POST"] --> create["WebKitWebView::create signal"]
+  create --> handle["handle_create_web_view (GTK main thread)"]
+  handle --> disp["fire_popup_disposition -> onPopupDisposition (sync)"]
+  disp -->|BLOCK 0| nullret["return NULL"]
+  disp -->|NATIVE_WINDOW 1| win["GtkWindow + ready-to-show + onPopupOpened (Canvas 16)"]
+  disp -->|ADOPT 2| adopt["child windowless + g_object_ref_sink\nregister g_gtk_retained_popups\nfire_popup_notify_adoptable"]
+  adopt -.EDT.-> java["WebViewComponent.adoptPopup(popupId)"]
+  java --> bridge["webview_embed_adopt_popup (extern C)"]
+  bridge --> gadopt["gtk_adopt_popup"]
+  gadopt --> reuse["gtk_create_engine(existing_web=child)\nJAWT + XReparentWindow into parent surface"]
+  reuse --> engine["Engine* returned to Java peer"]
+  adopt -. unclaimed .-> discard["webview_embed_discard_popup -> gtk_discard_popup"]
+```
+
+## A · Approach
+
+1. **Reuse the engine's child; never replay from Java.** POST body and
+   `window.opener` live inside the WebKit-created child. Adoption returns
+   that exact child to WebKit (so it drives the original navigation-action
+   request into it) and later reparents its X11 window into the caller's
+   surface via the same `XReparentWindow` machinery
+   `gtk_create_engine` already performs. Java never sees or reconstructs
+   the request — sidestepping the unavailable-POST-body problem.
+
+2. **Refactor, don't duplicate, the embedding path.**
+   `gtk_create_engine` gains an optional `existing_web` parameter. When
+   non-null it skips `webkit_web_view_new()` and reuses the retained
+   child, but runs the identical JAWT lock / `XReparentWindow` / window
+   realize / software-compositing / frame-clock / engine-scoped signal
+   wiring. `gtk_adopt_popup` is thin: claim, disconnect the child's old
+   PopupEngine handlers, call the shared path, transfer callbacks, drop
+   the retained ref. This keeps the reparent logic single-sourced, so
+   adoption cannot drift from normal create embedding.
+
+3. **Disposition switch inside the shared create handler.**
+   `handle_create_web_view` is the one inner handler all three GTK create
+   wrappers (engine / off_engine / popup) route through, so replacing the
+   `fire_popup_requested` boolean gate with a `fire_popup_disposition`
+   ordinal switch makes ADOPT reachable from the heavyweight engine's
+   `create` signal automatically — `on_create_web_view_engine` already
+   passes the engine's `popup_callback` here (Canvas 16).
+
+4. **Windowless retain via explicit strong ref.** On ADOPT the child is
+   never added to a GTK container, so its floating reference would leave
+   it destroyable. `g_object_ref_sink(childw)` clears the floating flag
+   and gives `g_gtk_retained_popups` an owning reference. This mirrors
+   the NATIVE_WINDOW refcounting (there the GtkWindow container owns the
+   sunk ref) — the child ends up held by our ref + WebKit's own reference
+   on the returned view. The retained ref is balanced by
+   `g_object_unref` in `gtk_adopt_popup` (after the adopting window takes
+   a container ref) or `gtk_widget_destroy` + `g_object_unref` in
+   `gtk_discard_popup`.
+
+5. **Signal-handler handoff on adopt.** The retained child's
+   create/script-dialog/run-file-chooser/close handlers are registered
+   with the `PopupEngine` as user-data. Before reusing the view,
+   `gtk_adopt_popup` calls `g_signal_handlers_disconnect_by_data(web,
+   pe)` so exactly one handler set survives; `gtk_create_engine` then
+   connects the fresh engine-scoped handlers
+   (`on_create_web_view_engine` / `on_script_dialog_engine` /
+   `on_run_file_chooser_engine`). The inherited popup/dialog global refs
+   are transferred from the shell to the engine (nulled on the shell to
+   prevent double-free), so nested popups + dialogs keep working
+   immediately and are later overwritten by the component's own
+   `gtk_set_popup_callback` / `gtk_set_dialog_callback` at attach (which
+   `DeleteGlobalRef` the transferred ref first — no leak).
+
+6. **Threading matches the platform.** `onPopupDisposition` is
+   synchronous inline on the GTK main thread (never EDT-marshalled).
+   `onPopupAdoptable` is a direct `CallVoidMethod` because the GTK
+   handler already runs off the EDT — no detached worker thread is
+   needed (the macOS variant needs one only because the AppKit main
+   thread is blocked in its delegate). The Java dispatcher marshals
+   `popupAdoptable` to the EDT itself.
+
+7. **JNI bridges stay in `extern "C"`.** Only the GTK branch of the two
+   already-present bridges changes (macOS/Windows branches untouched).
+   The bridges keep their position inside the `extern "C"` block so the
+   JVM resolves them — the mangling bug is documented in the block
+   comment and must not regress.
+
+8. **Exception + null discipline unchanged.** `fire_popup_disposition`
+   returns `0` (BLOCK) on null callback / attach failure / exception.
+   Every `Call*Method` is followed by an `ExceptionCheck` /
+   `ExceptionDescribe` / `ExceptionClear`. Strings are null-coerced to
+   empty; sizes are `-1` for unspecified at create time.
+
+## S · Structure
+
+### Layered Architecture (native only; layers above are Canvas 18's, unchanged)
+1. **Native engine layer** (`src_c/webview_embed.cpp`, GTK region):
+   disposition switch in `handle_create_web_view`, the
+   `g_gtk_retained_popups` registry, `fire_popup_disposition` /
+   `fire_popup_notify_adoptable`, `gtk_create_engine`'s `existing_web`
+   reuse, `gtk_adopt_popup` / `gtk_discard_popup`, `on_ready_to_show_popup`
+   windowless guard.
+2. **JNI surface** (`extern "C"` bridges): GTK branch of
+   `webview_embed_adopt_popup` / `webview_embed_discard_popup`.
+3. **Everything above** (`WebViewNative`, `EmbeddedWebView`,
+   `PopupDispatcher`, `WebViewComponent`, `WebViewPopupHandler`,
+   `PopupDisposition`, `WebViewPopupCallback`): **Canvas 18, unmodified.**
+
+### Dependencies
+1. `handle_create_web_view` → `fire_popup_disposition`,
+   `fire_popup_notify_adoptable`, `g_gtk_retained_popups`.
+2. `gtk_adopt_popup` → `g_gtk_retained_popups`, `gtk_create_engine`
+   (with `existing_web`), `GtkPump`, the PopupEngine signal handlers
+   (reconnect on failure).
+3. `gtk_discard_popup` → `g_gtk_retained_popups`, `fire_gtk_popup_closed`,
+   `GtkPump`.
+4. JNI bridges → `embed::gtk_adopt_popup` / `embed::gtk_discard_popup`.
+
+## O · Operations
+
+### 1. Retained-popup registry
+File: `src_c/webview_embed.cpp` (GTK, after `PopupEngine`)
+1. Add `static std::mutex g_gtk_retained_popups_mutex;` and
+   `static std::map<jlong, PopupEngine *> g_gtk_retained_popups;` with an
+   ON-DEVICE-VALIDATION comment.
+
+### 2. Disposition + adoptable JNI helpers
+File: `src_c/webview_embed.cpp` (GTK)
+1. `fire_popup_disposition` after `fire_popup_requested`: attach env,
+   `GetMethodID("onPopupDisposition",
+   "(Ljava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)I")`,
+   `CallIntMethod`, sanitize exceptions, return the ordinal (0 on any
+   failure).
+2. `fire_popup_notify_adoptable` after `fire_gtk_popup_opened`: attach
+   env, `GetMethodID("onPopupAdoptable",
+   "(JLjava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)V")`,
+   direct `CallVoidMethod`, sanitize.
+
+### 3. Disposition switch in `handle_create_web_view`
+File: `src_c/webview_embed.cpp` (GTK)
+1. Replace the `fire_popup_requested` gate with `int disposition =
+   fire_popup_disposition(...)`; `disposition == 0` → `return NULL`;
+   `adopt = (disposition == 2)`.
+2. `NATIVE_WINDOW`: unchanged — GtkWindow + `gtk_container_add` +
+   ready-to-show + `onPopupOpened`.
+3. `ADOPT`: no window; `g_object_ref_sink(childw)`; build the
+   PopupEngine with `window = nullptr`; connect create/script-dialog/
+   run-file-chooser/close (NOT ready-to-show); register in
+   `g_gtk_retained_popups`; `fire_popup_notify_adoptable`.
+4. `on_ready_to_show_popup`: early-return when `pe->window == nullptr`.
+
+### 4. `gtk_create_engine` reuse parameter
+File: `src_c/webview_embed.cpp` (GTK)
+1. Add `GtkWidget *existing_web = nullptr` param; inside the run_sync
+   body, `e->web = existing_web ? existing_web : webkit_web_view_new()`.
+   Everything else (JAWT, XReparent, signals, container_add,
+   frame-clock) is shared.
+
+### 5. `gtk_adopt_popup`
+File: `src_c/webview_embed.cpp` (GTK)
+1. Claim the `PopupEngine` from `g_gtk_retained_popups` under lock
+   (adopt-once); `nullptr` if absent.
+2. `g_signal_handlers_disconnect_by_data(pe->web, pe)` on the GTK thread.
+3. `Engine *e = gtk_create_engine(env, parent, debug, GTK_WIDGET(pe->web))`.
+   On failure: reconnect the PopupEngine handlers, re-retain in the
+   registry, return `nullptr`.
+4. Transfer `popup_callback` / `dialog_callback` from `pe` to `e` (null
+   them on `pe`).
+5. `g_object_unref(childw)` on the GTK thread (drop the retained ref).
+6. `delete pe`; return `e`.
+
+### 6. `gtk_discard_popup`
+File: `src_c/webview_embed.cpp` (GTK)
+1. Claim from the registry (no-op if absent).
+2. `fire_gtk_popup_closed`.
+3. On the GTK thread: disconnect handlers, `gtk_widget_destroy(web)`,
+   `g_object_unref(web)`.
+4. Free the inherited global refs; `delete pe`.
+
+### 7. JNI bridges (GTK branch)
+File: `src_c/webview_embed.cpp` (`extern "C"`)
+1. `webview_embed_adopt_popup`: `#ifdef WEBVIEW_GTK` →
+   `embed::gtk_adopt_popup(env, parent, popupId, debug)`; return
+   `(jlong)e`.
+2. `webview_embed_discard_popup`: `#ifdef WEBVIEW_GTK` →
+   `embed::gtk_discard_popup(popupId)`.
+3. Both remain inside `extern "C"`.
+
+## N · Norms
+
+- **No Java changes.** This canvas is native-only; the Java contract is
+  Canvas 18's. The wire contract (ordinals, JNI method signatures) is
+  identical to macOS.
+- **Ordinal wire contract.** `onPopupDisposition` returns
+  `BLOCK=0/NATIVE_WINDOW=1/ADOPT=2`; never reorder.
+- **Additive-only.** The `NATIVE_WINDOW` / `BLOCK` branches are the
+  unchanged Canvas 16 Linux paths; a boolean-only handler, `DEFAULT`,
+  and `setPopupHandler(null)` behave byte-for-byte as before.
+- **Synchronous, off-EDT disposition.** `fire_popup_disposition` runs
+  inline on the GTK main thread and is never marshalled to the EDT.
+- **Direct-call adoptable notify.** `fire_popup_notify_adoptable` uses a
+  plain `CallVoidMethod` (GTK handler already off the EDT); no detached
+  worker thread (the macOS-only requirement).
+- **Per-call `jmethodID` resolution + JNI exception sanitization** in
+  the new native calls, matching the dialog/popup selectors.
+- **GTK object ownership discipline.** ADOPT holds the child via
+  `g_object_ref_sink`; adopt balances with `g_object_unref` after the
+  window's container ref; discard balances with `gtk_widget_destroy` +
+  `g_object_unref`. Inherited global refs are transferred (nulled on the
+  shell) so `delete pe` never double-frees.
+- **Single handler set per signal.** `g_signal_handlers_disconnect_by_data`
+  removes the PopupEngine-scoped handlers before the engine-scoped ones
+  are connected.
+- **Offscreen path untouched.** No change to `OffEngine` /
+  `WebViewLightweightComponent`; the lightweight Canvas-19 guard stays.
+- **C++11, no `-Werror`** (`g++ -std=c++11 -Wall -DWEBVIEW_GTK=1`);
+  avoid hard errors. Default parameter on `gtk_create_engine` keeps the
+  existing single call site compiling unchanged.
+
+## S · Safeguards
+
+- **Backward compatibility is a never-relax invariant.** A Canvas 16
+  handler, `DEFAULT`, and `setPopupHandler(null)` MUST behave
+  byte-for-byte as before on Linux; the `NATIVE_WINDOW` / `BLOCK`
+  branches are the unchanged paths.
+- **No native window on ADOPT.** The ADOPT branch MUST NOT create a
+  GtkWindow or connect `ready-to-show`; `on_ready_to_show_popup`
+  early-returns on a windowless child so `onPopupOpened` never fires for
+  an adopt popup.
+- **Adopt-once + clean rejection.** `gtk_adopt_popup` removes the id from
+  `g_gtk_retained_popups` under lock, so a second adopt (or unknown id)
+  finds nothing and returns `nullptr` → JNI `0` →
+  `IllegalStateException`. A never-half-attached engine is returned.
+- **No-leak reclaim.** `gtk_discard_popup` fires `onPopupClosed`, tears
+  the child down, frees the inherited refs, and deletes the shell — the
+  Linux end of the Canvas 18 reclaim contract (opener dispose +
+  grace-period backstop, both driven from the unchanged Java side).
+- **JNI bridges inside `extern "C"`.** The GTK-branch edit does not move
+  the bridges; keeping them inside `extern "C"` is mandatory
+  (UnsatisfiedLinkError otherwise — the documented, previously-fixed
+  bug).
+- **Opener linkage + POST are mandatory.** The adopted child MUST be the
+  `webkit_web_view_new_with_related_view` child; creating a fresh view or
+  re-navigating from Java is a defect.
+
+- **Native coverage status — ON-DEVICE VALIDATION REQUIRED.** The
+  generating sandbox has **no GTK toolchain**, so this native code is
+  pattern-faithful to the shipped Canvas 16 popup handlers and the
+  Canvas 18 macOS adopt/discard, but is **unbuilt and unexercised
+  here**. Prime candidates for on-device scrutiny on a real
+  WebKitGTK/X11 stack:
+  - the `XReparentWindow` of the reused child under the new AWT canvas
+    window (inside `gtk_create_engine`);
+  - the widget ownership handoff — the `g_object_ref_sink` retained
+    reference, the adopting window's container reference, and WebKit's
+    own reference on the returned child — verified balanced across
+    adopt AND discard (watch for leaks / premature finalization /
+    use-after-destroy);
+  - whether the child's in-flight POST navigation keeps rendering after
+    being reparented from windowless to the adopting surface;
+  - the `g_signal_handlers_disconnect_by_data` handoff (no double
+    `create` handling, no dangling PopupEngine dereference);
+  - the software-compositing / frame-clock repaint pacing on the reused
+    view (the Canvas 6/16 virtualized-X11 concerns apply unchanged).
+
+## REASONS-Implements
+
+- `src_c/webview_embed.cpp` (GTK region: `g_gtk_retained_popups` +
+  mutex, `fire_popup_disposition`, `fire_popup_notify_adoptable`,
+  `handle_create_web_view` disposition switch, `on_ready_to_show_popup`
+  windowless guard, `gtk_create_engine` `existing_web` reuse,
+  `gtk_adopt_popup`, `gtk_discard_popup`)
+- `src_c/webview_embed.cpp` (`extern "C"`: GTK branch of
+  `Java_ca_weblite_webview_WebViewNative_webview_1embed_1adopt_1popup`
+  and `…_webview_1embed_1discard_1popup`)
+- Conforms to the Canvas 18 Java contract
+  ([[popup-adoption-into-webviewcomponent-tab]]) — **no Java changes**.

--- a/spdd/prompt/20-20260806-1600-[Feat]-Popup-Adoption-Windows-Coverage.md
+++ b/spdd/prompt/20-20260806-1600-[Feat]-Popup-Adoption-Windows-Coverage.md
@@ -482,12 +482,17 @@ File: `windows/webview_embed.cc`
   ordering (opener dispose runs `reclaimAdopts` before the opener engine is
   destroyed) is what keeps this safe.
 
-- **Native coverage status — ON-DEVICE VALIDATION REQUIRED.** The generating
-  sandbox has **no MSVC / WebView2 SDK toolchain**, so this native code is
-  pattern-faithful to the shipped Canvas 17 popup handler and the Canvas 18
-  macOS / Canvas 19 Linux adopt/discard, but is **unbuilt and unexercised
-  here**. Windows CI compiles `windows/webview_embed.cc` with `cl /std:c++17
-  /EHsc` against the WebView2 SDK headers + `jawt.lib`. Prime candidates for
+- **Native coverage status — CORE PATH VALIDATED ON-DEVICE.** The generating
+  sandbox has **no MSVC / WebView2 SDK toolchain**, so this native code was
+  authored pattern-faithful to the shipped Canvas 17 popup handler and the
+  Canvas 18 macOS / Canvas 19 Linux adopt/discard. The **core adopt path has
+  since been confirmed working on a real WebView2 stack**: a POST/opener-linked
+  popup decided `ADOPT` is retained, reparented into a `WebViewComponent` tab
+  via `put_ParentWindow`, and renders with the POST body + `window.opener`
+  preserved and no native window flash. Windows CI compiles
+  `windows/webview_embed.cc` with `cl /std:c++17 /EHsc` against the WebView2 SDK
+  headers + `jawt.lib`. The happy-path confirmation does **not** fully exercise
+  the teardown / reclaim / race edges, which remain prime candidates for
   on-device scrutiny on a real WebView2 stack:
   - the `put_ParentWindow` reparent of a **live, mid-navigation** controller
     from the hidden holder HWND into the adopting AWT canvas child HWND —

--- a/spdd/prompt/20-20260806-1600-[Feat]-Popup-Adoption-Windows-Coverage.md
+++ b/spdd/prompt/20-20260806-1600-[Feat]-Popup-Adoption-Windows-Coverage.md
@@ -1,0 +1,531 @@
+---
+generated_at: 2026-08-06T16:00:00-07:00
+---
+
+# REASONS Canvas: Popup Adoption Into a Caller-Provided WebViewComponent — Windows (WebView2) Coverage — Heavyweight (STORY-005-003)
+
+## R · Requirements
+
+- Extend popup adoption ([[popup-adoption-into-webviewcomponent-tab]],
+  Canvas 18) to the **Windows (WebView2 / Chromium-Edge)** heavyweight
+  backend. Canvas 18 shipped the cross-platform Java contract and the
+  **macOS (WKWebView)** reference; Canvas 19 landed **Linux
+  (WebKitGTK)**; this canvas lands the **WebView2** native implementation
+  of the same contract so an application can **adopt** an engine-created
+  popup — the opener-linked child web view WebView2 raises for
+  `window.open`, `<a target="_blank">`, or `<form method="post"
+  target="…">` — into a **`WebViewComponent` the application supplies** (a
+  Swing tab), instead of the native top-level window the engine owns today
+  (Canvas 17).
+
+- **Windows heavyweight is native-only — no Java changes.** The Windows
+  path reuses the Canvas 18 Java contract verbatim — `PopupDisposition`,
+  `WebViewPopupHandler.popupDisposition` / `popupAdoptable`,
+  `WebViewPopupCallback.onPopupDisposition` / `onPopupAdoptable`,
+  `PopupDispatcher` bookkeeping, `WebViewComponent.adoptPopup`,
+  `EmbeddedWebView.adopt` / `discardRetainedPopup`, and the
+  `webview_embed_adopt_popup` / `webview_embed_discard_popup` `WebViewNative`
+  declarations — authored platform-agnostically by Canvas 18 and touching
+  no `.java` file. The wire contract (disposition ordinals `BLOCK=0` /
+  `NATIVE_WINDOW=1` / `ADOPT=2`, the `onPopupDisposition` /
+  `onPopupAdoptable` JNI signatures) is exactly the one macOS and Linux
+  already speak. Windows has no lightweight/offscreen engine
+  (`webview_offscreen_create` returns 0), so this canvas is
+  **heavyweight-only**; the two offscreen adopt/discard JNI bridges are
+  Windows stubs (return 0 / no-op) for link-symmetry, and adoption into a
+  lightweight component is never triggered on Windows.
+
+- **Why the existing Windows model is insufficient for a tabbed browser.**
+  Same rationale as Canvas 18/19: a tabbed consumer that wants popups as
+  tabs must today block the native window and re-open the target URL via
+  `setUrl`, which issues a GET (losing a `<form method="post">` body) and
+  drops opener linkage (`window.opener` null, `postMessage`-to-opener
+  broken). WebView2's `ICoreWebView2NewWindowRequestedEventArgs` does
+  **not** expose the POST body, so the request cannot be reconstructed and
+  replayed from Java. The only faithful path is to **reuse the engine's own
+  child** — the linked child WebView2 returns to the page via
+  `put_NewWindow`, which WebView2 already drove the original request (verb +
+  body) into and which is already opener-linked — and reparent it into the
+  caller's surface via `ICoreWebView2Controller::put_ParentWindow`.
+
+- **Two-phase adoption, mirroring macOS/Linux.** Phase 1 (WebView2 worker
+  thread, but asynchronous by necessity — see below): the
+  `NewWindowRequested` handler calls `onPopupDisposition` and switches on
+  the returned ordinal. On `ADOPT` it builds the opener-linked child
+  controller from the opener's **same** `ICoreWebView2Environment` against a
+  **hidden holder HWND** (`CreateWindowEx` a top-level window that is
+  **never** `ShowWindow`n), returns the child to WebView2 via
+  `put_NewWindow` (which drives the original request into it), retains the
+  child in `g_win_retained_popups` keyed by an engine-assigned `popupId`
+  (`(jlong)(LONG_PTR)rp`), and fires `onPopupAdoptable(popupId, …)`. Phase 2
+  (EDT): the application's `WebViewComponent.adoptPopup(popupId)` peer
+  attach claims the retained child and reuses it —
+  `EmbeddedWebView.adopt` → `webview_embed_adopt_popup` reparents the
+  retained controller into the component's realized AWT HWND
+  (`put_ParentWindow`), sizes it to the parent client rect, makes it
+  visible, and returns the adopted engine pointer.
+
+- **The disposition decision + retain happen inside the deferral, on the
+  WebView2 worker thread.** Because controller creation on WebView2 is
+  **asynchronous** (`CreateCoreWebView2Controller` + a completion handler),
+  the `ADOPT` retain + `onPopupAdoptable` notify + deferral `Complete()`
+  all run **inside the controller-completion handler**, exactly like the
+  Canvas-17 `NATIVE_WINDOW` path already does for the shown window. The
+  disposition hop itself (`onPopupDisposition`) is a **synchronous**
+  `CallIntMethod` run on the short-lived JNI worker thread the
+  `NewWindowRequested` handler spins up (the deferral is held across it),
+  matching the Canvas-17 `onPopupRequested` boolean gate; `onPopupAdoptable`
+  is fire-and-forget and the Java `PopupDispatcher` marshals `popupAdoptable`
+  to the EDT itself.
+
+- **Apartment-thread affinity is the defining Windows constraint.** A
+  WebView2 `ICoreWebView2Controller` is bound to the thread that created it
+  and cannot be moved to another thread. The retained child controller was
+  created on the **opener engine's dedicated WebView2 worker thread**, so
+  every controller/webview call on it — during retain, during the
+  `put_ParentWindow` reparent at adoption, and during teardown at discard —
+  MUST run on that same worker thread. The adopted `Engine` therefore
+  **reuses the opener's worker thread** (`thread_id = opener thread_id`,
+  `shared_thread = true`) rather than spinning its own, and its
+  `destroy_engine` closes the controller synchronously on that shared thread
+  instead of posting `WM_EMBED_QUIT` (which would tear down the opener's
+  message loop and the opener engine with it).
+
+- Definition of Done:
+  - A handler returning `ADOPT` from `popupDisposition`, plus an app that on
+    `popupAdoptable` creates a tab via
+    `WebViewComponent.adoptPopup(popupId)`, results in the popup appearing
+    **inside that component** on Windows (heavyweight) with the **POST body
+    preserved** and **opener linkage intact** (`window.opener` non-null,
+    `postMessage`-to-opener works). No native popup window appears at any
+    point on the `ADOPT` path.
+  - A Canvas 17 handler that allows the popup (`popupRequested` → `true`, or
+    `DEFAULT`) still opens a native WebView2-owned window; a blocking handler
+    / `setPopupHandler(null)` still blocks — byte-for-byte the prior Windows
+    behavior (the `NATIVE_WINDOW` / `BLOCK` branches are the unchanged
+    Canvas-17 paths).
+  - `adoptPopup` on an unknown/consumed `popupId` yields a native `0` return
+    (`webview_embed_adopt_popup` finds nothing in `g_win_retained_popups`),
+    which `EmbeddedWebView.adopt` turns into the documented
+    `IllegalStateException`; adoption is once-only (claim removes under the
+    mutex).
+  - A popup decided `ADOPT` but never adopted is reclaimed via
+    `webview_embed_discard_popup` (opener disposed or grace-period backstop,
+    both driven from the unchanged Java side) — native child torn down,
+    `onPopupClosed` fired, inherited global refs freed, holder HWND
+    destroyed, COM refs released, no orphaned engine.
+  - Closing a retained-but-unadopted popup with `window.close()` fires
+    `onPopupClosed` correlated by `popupId` and tears the child down without
+    dereferencing freed native state.
+
+- Out of scope (explicit non-goals):
+  - **Windows lightweight/offscreen adoption** — Windows has no offscreen
+    engine; the offscreen adopt/discard JNI bridges are Windows stubs
+    (return 0 / no-op), matching `webview_offscreen_create` returning 0.
+  - Any change to the **public `WebViewComponent` API** or any **Java** file
+    — the Windows path is native-only and reuses Canvas 18's contract
+    verbatim. **macOS and Linux code is not touched.**
+  - **swingwebbrowser** consumer wiring — STORY-005-004.
+  - Surfacing the HTTP method/body to Java; reparenting an arbitrary running
+    component; `window.open` feature strings beyond `width`/`height`
+    (unchanged from Canvas 17).
+
+## E · Entities
+
+- **`windows/webview_embed.cc`** (modified — the ONLY file this canvas
+  touches). All new native code lands here, in `namespace embed_win` and in
+  the JNI export region:
+  - `Engine::shared_thread` (new `bool` field) — TRUE for an adopted engine
+    that reuses the opener's WebView2 worker thread; gates `destroy_engine`
+    so it Close()es the controller on the shared thread instead of posting
+    `WM_EMBED_QUIT`.
+  - `fire_popup_disposition_win(Engine*, url, gesture, w, h, page) -> jint`
+    — synchronous `CallIntMethod` on `onPopupDisposition`
+    (`"(Ljava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)I"`);
+    returns the ordinal, `0` (BLOCK) on null callback / attach failure /
+    exception. Mirrors `fire_popup_requested_win`.
+  - `fire_popup_adoptable_win(Engine*, popup_id, url, gesture, w, h, page)`
+    — fire-and-forget `CallVoidMethod` on `onPopupAdoptable`
+    (`"(JLjava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)V"`),
+    same shape as `fire_popup_opened_win`.
+  - `struct RetainedPopup` — holds the retained child's
+    `ICoreWebView2Controller*` + `ICoreWebView2*` (AddRef'd), the opener's
+    `ICoreWebView2Environment*` (AddRef'd), the hidden holder `HWND`, the
+    `JavaVM*`, `popup_id`, `url`/`page`, the `worker_thread_id` (the
+    apartment the COM objects belong to), the inherited popup/dialog callback
+    global refs, and the retained-phase event tokens
+    (`new_window_token` / `script_dialog_token` / `close_token`).
+  - `g_win_retained_popups_mutex` + `g_win_retained_popups`
+    (`std::map<jlong, RetainedPopup*>`) — the WebView2 counterpart of the
+    macOS `g_retained_popups` / Linux `g_gtk_retained_popups`.
+  - `ensure_popup_holder_class_registered()` — a `DefWindowProc` hidden
+    holder window class (`"WebViewEmbedPopupHolder"`), never shown.
+  - `post_to_worker_thread(DWORD tid, DispatchFn)` — posts a
+    `WM_EMBED_DISPATCH` op onto a specific WebView2 worker thread (the
+    apartment owning a retained child).
+  - `fire_popup_closed_retained(RetainedPopup*)` +
+    `retained_popup_teardown(RetainedPopup*, bool fire_closed)` +
+    `free_inherited_refs(...)` — reclaim helpers (Close/Release the
+    controller/webview, destroy the holder, Release the environment, free the
+    inherited global refs, `delete` the shell); MUST run on the child's
+    worker thread.
+  - `RetainedPopupCloseHandler` (`ICoreWebView2WindowCloseRequestedEventHandler`)
+    — `window.close()` on a retained-but-unadopted child claims it under the
+    mutex and tears it down (fires `onPopupClosed`).
+  - `NewWindowRequestedHandler::Invoke` (modified) — replaces the Canvas-17
+    boolean gate with the `fire_popup_disposition_win` ordinal switch:
+    `BLOCK` → `put_Handled(TRUE)` + Complete; `NATIVE_WINDOW` → the unchanged
+    Canvas-17 shown-window path; `ADOPT` → hidden holder +
+    `CreateCoreWebView2Controller` from the opener's environment, and inside
+    the completion: `put_NewWindow(child)` + `put_Handled(TRUE)` + Complete +
+    retain in `g_win_retained_popups` + inherit callbacks + wire the child's
+    `WindowCloseRequested` → discard + `fire_popup_adoptable_win`. The
+    handler is already registered (Canvas 17) in the controller-ready path;
+    only its body changed — **no duplicate registration**.
+  - `adopt_retained_popup(env, parent, rp, debug) -> Engine*` — builds a
+    normal `embed_win::Engine` reusing the claimed child's controller/webview
+    (transferring COM refs + inherited global refs into it), then on the
+    shared worker thread removes the retained-phase handlers, creates the
+    standard `"WebViewEmbedChild"` HWND under `parent`, reparents the
+    controller into it (`put_ParentWindow`), sizes it to the parent client
+    rect, makes it visible, wires the adopted engine's own handlers
+    (message / focus / script-dialog / new-window), **destroys the now-unused
+    hidden holder HWND** (`DestroyWindow(rp->holder)` on the same worker
+    thread that created it, after the reparent), and frees the retained shell.
+    Returns the Engine immediately (valid controller/webview) so Java gets a
+    usable peer.
+  - `destroy_engine` (modified) — the `shared_thread` branch synchronously
+    Close()es the controller + destroys the child HWND on the shared worker
+    thread; the non-shared path is unchanged.
+  - `Java_…_webview_1embed_1adopt_1popup(env, jclass, jobject component,
+    jlong popupId, jint debug) -> jlong` (new JNI bridge) — resolves the
+    parent HWND via the SAME JAWT path as `webview_embed_create`
+    (`JawtLock` → `JAWT_Win32DrawingSurfaceInfo::hwnd`), claims the
+    `RetainedPopup` under the mutex (adopt-once; `0` if absent), calls
+    `adopt_retained_popup`, returns `(jlong)engine`. **Defined INSIDE the
+    explicit `extern "C"` block** (next to the offscreen adopt/discard stubs
+    and `set_popup_callback`) so it gets C linkage directly. The checked-in
+    `ca_weblite_webview_WebViewNative.h` is stale and does **not** declare
+    these newer natives, so relying on the header for C linkage would let C++
+    name-mangle the symbol and the JVM would fail to resolve it at runtime
+    (`UnsatisfiedLinkError`) even though it compiles clean.
+  - `Java_…_webview_1embed_1discard_1popup(env, jclass, jlong /*wv*/,
+    jlong popupId) -> void` (new JNI bridge) — claims + tears down an
+    unadopted `RetainedPopup` on its owning worker thread. Same declaration
+    style (inside the `extern "C"` block).
+  - `Java_…_webview_1embed_1set_1user_1agent` (Canvas 21 bridge) — likewise
+    defined inside the `extern "C"` block for the same stale-header reason.
+  - `Java_…_webview_1offscreen_1adopt_1popup` / `…_discard_1popup` — Windows
+    stubs (return 0 / no-op) inside the existing `extern "C"` block, for
+    link-symmetry with the Linux offscreen bridges (Canvas 19).
+
+```mermaid
+flowchart TB
+  JS["window.open / target=_blank / form POST"] --> nwr["ICoreWebView2::NewWindowRequested (worker thread)"]
+  nwr --> disp["fire_popup_disposition_win -> onPopupDisposition (sync, deferral held)"]
+  disp -->|BLOCK 0| block["put_Handled(TRUE) + Complete"]
+  disp -->|NATIVE_WINDOW 1| win["hidden? no -- shown WebViewEmbedPopup window + onPopupOpened (Canvas 17)"]
+  disp -->|ADOPT 2| holder["hidden holder HWND (never shown)\nCreateCoreWebView2Controller from opener env"]
+  holder --> comp["completion: put_NewWindow(child) + put_Handled + Complete\nretain g_win_retained_popups\nfire onPopupAdoptable"]
+  comp -.EDT.-> java["WebViewComponent.adoptPopup(popupId)"]
+  java --> bridge["webview_embed_adopt_popup (JAWT HWND)"]
+  bridge --> claim["claim RetainedPopup under mutex"]
+  claim --> adopt["adopt_retained_popup: reuse controller\nput_ParentWindow(child HWND) + put_Bounds + put_IsVisible\nshared_thread engine"]
+  adopt --> engine["Engine* returned to Java peer"]
+  comp -. unclaimed .-> discard["webview_embed_discard_popup\n-> retained_popup_teardown (worker thread)"]
+```
+
+## A · Approach
+
+1. **Reuse the engine's child; never replay from Java.** POST body and
+   `window.opener` live inside the WebView2-created linked child. Adoption
+   returns that exact child to WebView2 via `put_NewWindow` (so it drives the
+   original navigation request into it) and later reparents its controller
+   into the caller's surface via `put_ParentWindow`. Java never sees or
+   reconstructs the request — sidestepping the unavailable-POST-body problem.
+
+2. **Disposition switch inside the existing NewWindowRequested handler.**
+   The Canvas-17 handler already: extracts uri/user-gesture/window-features/
+   page, `GetDeferral` + `AddRef`, hops to Java on a short-lived worker,
+   then `dispatch_to_thread` back onto the WebView2 worker to act + Complete.
+   The only change is swapping the `fire_popup_requested_win` boolean gate for
+   a `fire_popup_disposition_win` ordinal, and adding the `ADOPT` branch
+   alongside the unchanged `BLOCK` / `NATIVE_WINDOW` branches. The handler
+   registration (controller-ready path) is untouched — no duplication.
+
+3. **Async retain in the controller completion.** Because WebView2 controller
+   creation is asynchronous, the `ADOPT` branch creates the child controller
+   against the hidden holder and does the retain + `onPopupAdoptable` +
+   deferral `Complete` **inside** `CreateCoreWebView2Controller`'s completion
+   handler — the same structure the Canvas-17 `NATIVE_WINDOW` path uses for
+   its shown window. `put_NewWindow(child)` + `put_Handled(TRUE)` return the
+   linked child to the page; the controller is left `put_IsVisible(FALSE)`
+   and the holder is never `ShowWindow`n, so no window flashes.
+
+4. **Hidden holder = no window, no flash.** WebView2 requires a real parent
+   HWND to create a controller. A top-level `"WebViewEmbedPopupHolder"`
+   window is created but **never shown**; the child renders offscreen there
+   until adoption calls `put_ParentWindow` to move it into the adopting AWT
+   canvas HWND. This is the WebView2 analogue of the macOS hidden holder and
+   the Linux windowless `g_object_ref_sink` retain.
+
+5. **Apartment-correct reuse via a shared worker thread.** The retained
+   controller is bound to the opener's WebView2 worker thread and cannot
+   migrate. The adopted `Engine` sets `thread_id` to the opener's worker
+   thread and `shared_thread = true`; all controller ops (reparent, bounds,
+   visibility, handler (de)registration, and eventual Close) run there via
+   `dispatch_to_thread` / `post_to_worker_thread`. `destroy_engine`'s
+   `shared_thread` branch Close()es the controller synchronously on that
+   thread instead of quitting its message loop, so the opener survives the
+   adopted child's disposal.
+
+6. **Retained → adopted handler handoff.** The retained-phase child carries
+   `NewWindowRequested` / `ScriptDialogOpening` / `WindowCloseRequested`
+   handlers bound to the **opener** engine (so nested popups + dialogs keep
+   working while retained). At adoption the tokens are used to
+   `remove_*` those handlers before the adopted engine registers its own
+   (message / focus / script-dialog / new-window) bound to itself — exactly
+   one handler set survives, the Windows analogue of Linux's
+   `g_signal_handlers_disconnect_by_data`.
+
+7. **COM + global-ref ownership transfer.** The retained child's controller,
+   webview, and environment are AddRef'd COM references, and the inherited
+   popup/dialog callbacks are JNI global refs, all owned by the
+   `RetainedPopup`. `adopt_retained_popup` **transfers** (copies, does not
+   re-AddRef) those into the adopted `Engine`, then frees the shell with a
+   plain `delete` (no re-release) — so the adopted engine's normal
+   `destroy_engine` balances them. `retained_popup_teardown` (discard /
+   `window.close`) instead Releases/frees them itself. Adopt-once and
+   discard-once are enforced by removing the id from the registry under the
+   mutex — whoever removes it owns the teardown.
+
+8. **Exception + null discipline unchanged.** `fire_popup_disposition_win`
+   returns `0` (BLOCK) on null callback / attach failure / exception; every
+   `Call*Method` is followed by `ExceptionCheck` / `ExceptionDescribe` /
+   `ExceptionClear`. Strings are null-coerced to empty. An `ADOPT` that
+   cannot build a linked child (no environment, holder creation fails,
+   controller creation fails) safely falls back to `put_Handled(TRUE)` +
+   Complete (blocked) and tears any half-built shell down.
+
+## S · Structure
+
+### Layered Architecture
+1. **Native engine layer** (`windows/webview_embed.cc`, `namespace
+   embed_win`): the `Engine::shared_thread` field, `fire_popup_disposition_win`
+   / `fire_popup_adoptable_win`, the `RetainedPopup` registry +
+   holder-window class + reclaim helpers + `RetainedPopupCloseHandler`, the
+   `NewWindowRequestedHandler::Invoke` disposition switch, `adopt_retained_popup`,
+   and the `destroy_engine` shared-thread branch.
+2. **JNI surface** (`windows/webview_embed.cc`, JNI export region): the
+   `webview_embed_adopt_popup` / `webview_embed_discard_popup` bridges, plus
+   the offscreen adopt/discard Windows stubs — all defined **inside** the
+   `extern "C"` block (the checked-in JNI header is stale and does not declare
+   the newer natives, so their C linkage must come from the block, not the
+   header).
+3. **Java layer**: **Canvas 18, unmodified.** The Windows path speaks the
+   same wire contract and the same `webview_embed_adopt_popup` /
+   `webview_embed_discard_popup` native declarations. No Java, macOS, or
+   Linux file is touched.
+
+### Dependencies
+1. `NewWindowRequestedHandler::Invoke` → `fire_popup_disposition_win`,
+   `fire_popup_adoptable_win`, `g_win_retained_popups`,
+   `ensure_popup_holder_class_registered`, `RetainedPopupCloseHandler`,
+   `retained_popup_teardown`, the opener's `ICoreWebView2Environment`.
+2. `webview_embed_adopt_popup` → `JawtLock` (parent HWND),
+   `g_win_retained_popups`, `adopt_retained_popup`.
+3. `adopt_retained_popup` → `post_to_worker_thread`, `MsgHandler` /
+   `FocusHandler` / `ScriptDialogHandler` / `NewWindowRequestedHandler`,
+   `ensure_class_registered`, the shared worker thread.
+4. `webview_embed_discard_popup` → `g_win_retained_popups`,
+   `post_to_worker_thread`, `retained_popup_teardown`.
+5. `destroy_engine` (shared_thread branch) → `dispatch_to_thread`.
+
+## O · Operations
+
+### 1. Engine::shared_thread + retained-popup registry
+File: `windows/webview_embed.cc`
+1. Add `bool shared_thread = false;` to `struct Engine` with the apartment /
+   worker-thread rationale.
+2. Add `static std::mutex g_win_retained_popups_mutex;` and
+   `static std::map<jlong, RetainedPopup*> g_win_retained_popups;` plus the
+   `RetainedPopup` struct, an ON-DEVICE-VALIDATION comment.
+
+### 2. Disposition + adoptable JNI helpers
+File: `windows/webview_embed.cc`
+1. `fire_popup_disposition_win` after `fire_popup_closed_win`: attach env,
+   `GetMethodID("onPopupDisposition",
+   "(Ljava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)I")`,
+   `CallIntMethod`, sanitize, return ordinal (`0` on any failure).
+2. `fire_popup_adoptable_win`: attach env,
+   `GetMethodID("onPopupAdoptable",
+   "(JLjava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)V")`, direct
+   `CallVoidMethod`, sanitize.
+
+### 3. Holder class + reclaim helpers + close handler
+File: `windows/webview_embed.cc`
+1. `ensure_popup_holder_class_registered()` (`DefWindowProc`, never shown).
+2. `post_to_worker_thread(DWORD, DispatchFn)`.
+3. `fire_popup_closed_retained` / `free_inherited_refs` /
+   `retained_popup_teardown` (Close/Release controller+webview, DestroyWindow
+   holder, Release environment, free inherited global refs, delete shell).
+4. `RetainedPopupCloseHandler` — claim under the mutex, teardown, fire
+   `onPopupClosed`.
+
+### 4. Disposition switch in NewWindowRequestedHandler::Invoke
+File: `windows/webview_embed.cc`
+1. Replace `fire_popup_requested_win` with `int disposition =
+   fire_popup_disposition_win(...)`.
+2. `disposition == 0` (BLOCK): `put_Handled(TRUE)` + Complete + Release.
+3. `disposition == 2` (ADOPT): hidden holder + inherit callbacks + build
+   `RetainedPopup` + `CreateCoreWebView2Controller`(holder); in the
+   completion `put_NewWindow(child)` + `put_Handled(TRUE)` + Complete +
+   `put_IsVisible(FALSE)` + wire retained-phase handlers (store tokens) +
+   register in `g_win_retained_popups` (`popup_id = (jlong)(LONG_PTR)rp`) +
+   `fire_popup_adoptable_win`. Failure paths block + teardown.
+4. `disposition == 1` (NATIVE_WINDOW): the unchanged Canvas-17 shown-window
+   path.
+5. The handler registration in the controller-ready path is untouched (no
+   duplicate `add_NewWindowRequested`).
+
+### 5. adopt_retained_popup + destroy_engine shared-thread branch
+File: `windows/webview_embed.cc`
+1. `adopt_retained_popup(env, parent, rp, debug)`: build `Engine` with
+   `shared_thread = true`, `thread_id = rp->worker_thread_id`, transfer COM
+   refs + inherited global refs; on the shared worker thread remove
+   retained-phase handlers, create the `"WebViewEmbedChild"` HWND under
+   `parent`, `put_ParentWindow(child)` + `put_Bounds` + `put_IsVisible(TRUE)`,
+   wire the adopted engine's handlers, `DestroyWindow(rp->holder)` (the hidden
+   holder is unused once the controller is reparented; destroy it on its
+   creating worker thread), `delete rp`; return the Engine.
+2. `destroy_engine`: if `shared_thread`, synchronously Close()+Release the
+   controller/webview and DestroyWindow the child on the shared thread (do NOT
+   post `WM_EMBED_QUIT`), then fall through to free global refs + delete e.
+
+### 6. JNI bridges
+File: `windows/webview_embed.cc`
+1. `webview_embed_adopt_popup` (declared like `webview_embed_create`): JAWT
+   parent HWND, claim under mutex (`0` if absent), `adopt_retained_popup`,
+   return `(jlong)e`.
+2. `webview_embed_discard_popup`: claim under mutex (no-op if absent),
+   `post_to_worker_thread(rp->worker_thread_id, teardown)`.
+3. `webview_offscreen_adopt_popup` / `webview_offscreen_discard_popup`:
+   Windows stubs (return 0 / no-op) inside the `extern "C"` block.
+
+## N · Norms
+
+- **No public-API changes; Java / macOS / Linux untouched.** The Windows path
+  is native-only and reuses Canvas 18's Java contract, wire ordinals, and JNI
+  signatures verbatim.
+- **Ordinal wire contract.** `onPopupDisposition` returns
+  `BLOCK=0 / NATIVE_WINDOW=1 / ADOPT=2`; never reorder.
+- **Additive-only.** The `NATIVE_WINDOW` / `BLOCK` branches are the unchanged
+  Canvas-17 Windows paths; a boolean-only handler, `DEFAULT`, and
+  `setPopupHandler(null)` behave byte-for-byte as before.
+- **Synchronous disposition, async retain.** `fire_popup_disposition_win` is a
+  synchronous `CallIntMethod` while the deferral is held; the retain +
+  `onPopupAdoptable` + deferral Complete run in the controller completion
+  (async controller creation). `onPopupAdoptable` is fire-and-forget; Java
+  marshals `popupAdoptable` to the EDT.
+- **Apartment-thread affinity.** Every `ICoreWebView2*` call on the retained /
+  adopted child runs on the opener's WebView2 worker thread. The adopted
+  engine shares that thread (`shared_thread`); `destroy_engine` never quits
+  it.
+- **Per-call `jmethodID` resolution + JNI exception sanitization** in the new
+  native calls, matching the dialog/popup helpers.
+- **COM ownership discipline.** Controller/webview/environment are AddRef'd on
+  the retained shell; adoption transfers them (no re-AddRef) so the adopted
+  engine's `destroy_engine` balances them; discard Releases them itself.
+  Inherited global refs are transferred on adopt (freed by `destroy_engine`)
+  or freed on discard — no double-free, no dereference of a freed engine.
+- **Single handler set per event.** Retained-phase handlers are `remove_*`d
+  before the adopted engine's handlers are added.
+- **JNI bridge linkage.** Every native added after the checked-in
+  `ca_weblite_webview_WebViewNative.h` was last regenerated —
+  `webview_embed_adopt_popup`, `webview_embed_discard_popup`,
+  `webview_embed_set_user_agent`, and the offscreen adopt/discard stubs —
+  MUST be defined **inside** the explicit `extern "C"` block so C linkage is
+  guaranteed at the definition. The stale header only declares the older
+  natives (e.g. `webview_embed_create`); a newer bridge placed outside the
+  block would be C++ name-mangled and fail to resolve at runtime
+  (`UnsatisfiedLinkError`) despite compiling clean — a defect a compile-only
+  CI cannot catch (it bit the macOS adopt/discard bridges on-device first).
+- **C++17, `cl /std:c++17 /EHsc`** against the WebView2 SDK
+  (`Microsoft.Web.WebView2.0.8.355`) + `jawt.lib`; avoid hard errors. The
+  Java side compiles under Java 8 (unchanged).
+
+## S · Safeguards
+
+- **Backward compatibility is a never-relax invariant.** A Canvas 17 handler,
+  `DEFAULT`, and `setPopupHandler(null)` MUST behave byte-for-byte as before
+  on Windows; the `NATIVE_WINDOW` / `BLOCK` branches are the unchanged paths.
+- **No native window on ADOPT.** The holder HWND is NEVER `ShowWindow`n and
+  the controller is `put_IsVisible(FALSE)` while retained; no window flashes
+  and `onPopupOpened` is not fired for an adopt popup.
+- **Adopt-once + clean rejection.** `webview_embed_adopt_popup` removes the id
+  from `g_win_retained_popups` under the mutex, so a second adopt (or unknown
+  id) finds nothing and returns `0` → `IllegalStateException`. A
+  never-half-attached engine is returned (the retained child already exists
+  before the bridge runs).
+- **No-leak reclaim.** `webview_embed_discard_popup` fires `onPopupClosed`,
+  Close/Release the controller+webview, DestroyWindow the holder, Release the
+  environment, frees the inherited refs, and deletes the shell — the Windows
+  end of the Canvas 18 reclaim contract (opener dispose + grace-period
+  backstop, both driven from the unchanged Java side).
+- **Opener linkage + POST are mandatory.** The adopted child MUST be the
+  WebView2-created linked child returned via `put_NewWindow`; creating a fresh
+  controller or re-navigating from Java is a defect.
+- **Shared-thread teardown.** An adopted engine's `destroy_engine` MUST NOT
+  post `WM_EMBED_QUIT` (it would kill the opener); it Close()es on the shared
+  worker thread. If the opener is disposed first, its worker thread ends and
+  `post_to_worker_thread` becomes a no-op — the unchanged Java reclaim
+  ordering (opener dispose runs `reclaimAdopts` before the opener engine is
+  destroyed) is what keeps this safe.
+
+- **Native coverage status — ON-DEVICE VALIDATION REQUIRED.** The generating
+  sandbox has **no MSVC / WebView2 SDK toolchain**, so this native code is
+  pattern-faithful to the shipped Canvas 17 popup handler and the Canvas 18
+  macOS / Canvas 19 Linux adopt/discard, but is **unbuilt and unexercised
+  here**. Windows CI compiles `windows/webview_embed.cc` with `cl /std:c++17
+  /EHsc` against the WebView2 SDK headers + `jawt.lib`. Prime candidates for
+  on-device scrutiny on a real WebView2 stack:
+  - the `put_ParentWindow` reparent of a **live, mid-navigation** controller
+    from the hidden holder HWND into the adopting AWT canvas child HWND —
+    verify the child keeps rendering its in-flight POST navigation and does
+    not blank/reset;
+  - the **COM ownership handoff** — controller / webview / environment
+    AddRef'd on the retained shell, transferred (not re-AddRef'd) into the
+    adopted engine, balanced by exactly one `destroy_engine` — verified with
+    no leak / premature release / double-free across BOTH adopt and discard
+    (the transfer-vs-teardown split is the riskiest handoff);
+  - the **apartment / worker-thread affinity** — every controller call on the
+    retained + adopted child, the `shared_thread` `destroy_engine` Close, and
+    the `post_to_worker_thread` teardown all landing on the opener's WebView2
+    worker thread, never a foreign thread;
+  - the **retained → adopted handler handoff** (`remove_*` before re-`add_*`)
+    — no double `NewWindowRequested` / `ScriptDialogOpening` handling, no
+    dangling opener-bound handler firing after adoption;
+  - the **JNI global-ref lifecycle** — inherited popup/dialog refs created at
+    retain, transferred at adopt (freed by `destroy_engine`) or freed at
+    discard, with no leak and no use of a freed ref;
+  - `window.close()` on a **retained-but-unadopted** child racing an adoption
+    — exactly one of `RetainedPopupCloseHandler` / `webview_embed_adopt_popup`
+    wins the registry claim and owns the teardown.
+
+## REASONS-Implements
+
+- `windows/webview_embed.cc`
+  (`Engine::shared_thread`; `fire_popup_disposition_win` /
+  `fire_popup_adoptable_win`; `RetainedPopup` + `g_win_retained_popups` +
+  mutex; `ensure_popup_holder_class_registered`; `post_to_worker_thread`;
+  `fire_popup_closed_retained` / `free_inherited_refs` /
+  `retained_popup_teardown`; `RetainedPopupCloseHandler`; the
+  `NewWindowRequestedHandler::Invoke` disposition switch + ADOPT branch;
+  `adopt_retained_popup`; the `destroy_engine` shared-thread branch; the
+  `webview_embed_adopt_popup` / `webview_embed_discard_popup` JNI bridges; the
+  `webview_offscreen_adopt_popup` / `webview_offscreen_discard_popup` Windows
+  stubs)
+- Conforms to the Canvas 18 Java contract
+  ([[popup-adoption-into-webviewcomponent-tab]]) — **no Java changes**; macOS
+  (Canvas 18) and Linux (Canvas 19) native code untouched. Windows is
+  heavyweight-only (no offscreen engine).

--- a/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
+++ b/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
@@ -46,6 +46,10 @@ generated_at: 2026-08-06T14:00:00-07:00
   - A headless `WebViewComponentUserAgentTest` verifies the Java
     store/reset/get contract without a native peer.
   - README gains a "Custom user agent" subsection.
+  - On-device: `WebViewAdoptPopupDemo` (shared with Canvas 18) grows a
+    User-Agent field + Set/Reset so the real HTTP header change is
+    verifiable via an httpbin echo; run with
+    `./run-mac-adopt-popup-demo.sh`.
 
 - Out of scope: per-request UA switching; UA-Client-Hints
   (`Sec-CH-UA`) customisation; spoofing `navigator.userAgent` from
@@ -278,4 +282,6 @@ File: `windows/webview_embed.cc`
 - `src_c/webview_embed.cpp` (macOS + Linux)
 - `windows/webview_embed.cc` (Windows)
 - `test/ca/weblite/webview/WebViewComponentUserAgentTest.java`
+- `demos/WebViewAdoptPopupDemo/…` (UA field; shared with Canvas 18)
+- `run-mac-adopt-popup-demo.sh`
 - `README.md`

--- a/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
+++ b/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
@@ -1,0 +1,281 @@
+---
+generated_at: 2026-08-06T14:00:00-07:00
+---
+
+# REASONS Canvas: Custom User-Agent for the Embedded WebView
+
+## R · Requirements
+
+- Let callers override the embedded WebView's **User-Agent** so web
+  apps that gate on the UA string accept the embedded browser. Expose
+  `WebViewComponent.setUserAgent(String)` / `getUserAgent()`, wired to
+  each engine's native custom-UA facility so the override changes the
+  **actual HTTP `User-Agent` request header** (not merely the
+  JS-visible `navigator.userAgent`). This is the header a server sees.
+
+- **Why.** WKWebView's default UA omits the `Version/… Safari/…`
+  tokens (`Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)
+  AppleWebKit/605.1.15 (KHTML, like Gecko)`), so UA-sniffing sites
+  reject it as "unsupported browser". A JS `navigator.userAgent` shim
+  cannot fix server-side sniffing; only an engine-level custom UA can.
+
+- **Contract.**
+  - `setUserAgent(String ua)` — store the UA and apply it to the
+    engine. `null` or empty **restores the engine default** (clears
+    the override). May be called **before display** (stored, applied
+    at peer attach, so the first request carries it) or **after**
+    (applied live; takes effect on the next navigation — engines do
+    not retro-rewrite the current page's request).
+  - `getUserAgent()` — returns the pending/applied override, or
+    `null` when none is set (engine default in force).
+  - Accessor style follows `setUrl`/`getUrl` (get-style), not the
+    no-`get` event style.
+
+- **Backward compatible.** When `setUserAgent` is never called,
+  `pendingUserAgent` is `null`, the native setter is never invoked,
+  and the engine's default UA is used — byte-for-byte today's
+  behaviour.
+
+- Definition of Done:
+  - `wv.setUserAgent("…Safari…")` before display makes the first and
+    subsequent navigations send that `User-Agent` header on all three
+    engines.
+  - `setUserAgent(null)` / `setUserAgent("")` reverts to the engine
+    default.
+  - `getUserAgent()` reflects the last set value (`null` when unset).
+  - A headless `WebViewComponentUserAgentTest` verifies the Java
+    store/reset/get contract without a native peer.
+  - README gains a "Custom user agent" subsection.
+
+- Out of scope: per-request UA switching; UA-Client-Hints
+  (`Sec-CH-UA`) customisation; spoofing `navigator.userAgent` from
+  Java (that is a caller-side `addOnBeforeLoad` concern); the
+  standalone in-process `WebView` class (embedded surface only, same
+  boundary as Canvas 15/18).
+
+## E · Entities
+
+- **WebViewComponent** (modified). Gains:
+  - `protected String pendingUserAgent = null;` (adjacent to
+    `pendingUrl`/`debug`).
+  - `public WebViewComponent setUserAgent(String ua)` — normalise
+    empty to `null`, store, and apply live to the peer if attached.
+  - `public String getUserAgent()` — return `pendingUserAgent`.
+- **WebViewHeavyweightComponent** (modified). In `createPeer()`, after
+  `EmbeddedWebView.attach`/`adopt` and **before** the initial
+  `navigate`, apply `pendingUserAgent` when non-null via
+  `embedded.setUserAgent(...)`. Live setter path when already attached.
+- **WebViewLightweightComponent** (modified). Same at the
+  `addNotify()` engine-create site, before `engine.navigate`.
+- **EmbeddedWebView** (modified). `public EmbeddedWebView
+  setUserAgent(String ua)` → `checkAlive()`;
+  `WebViewNative.webview_embed_set_user_agent(peer, ua)`.
+- **OffscreenWebView** (modified). `public OffscreenWebView
+  setUserAgent(String ua)` → `webview_offscreen_set_user_agent(peer,
+  ua)`.
+- **WebViewNative** (modified). `native static void
+  webview_embed_set_user_agent(long w, String ua);` and `native static
+  void webview_offscreen_set_user_agent(long peer, String ua);`.
+- **`src_c/webview_embed.cpp`** (modified — macOS + Linux),
+  **`windows/webview_embed.cc`** (modified — Windows): per-engine
+  setters + JNI bridges.
+- **WebViewComponentUserAgentTest** (new), **README.md** (modified).
+
+```mermaid
+classDiagram
+direction TB
+class WebViewComponent {
+  #pendingUserAgent String
+  +setUserAgent(String) WebViewComponent
+  +getUserAgent() String
+}
+class EmbeddedWebView { +setUserAgent(String) EmbeddedWebView }
+class OffscreenWebView { +setUserAgent(String) OffscreenWebView }
+class WebViewNative {
+  +webview_embed_set_user_agent(long, String)$ void
+  +webview_offscreen_set_user_agent(long, String)$ void
+}
+WebViewComponent ..> EmbeddedWebView : applies UA
+WebViewComponent ..> OffscreenWebView : applies UA
+EmbeddedWebView ..> WebViewNative : JNI
+OffscreenWebView ..> WebViewNative : JNI
+```
+
+## A · Approach
+
+1. **Pending-then-apply, mirroring `pendingUrl`.** The UA is caller
+   state that must survive the peer create/destroy cycle. Store it on
+   the component; apply at peer attach (before the first `navigate`)
+   and live on subsequent `setUserAgent` calls when the peer exists.
+   No override → native setter never called → engine default.
+
+2. **Empty means default.** `setUserAgent(null|"")` stores `null`;
+   the native setter, when invoked with `null`, clears the engine
+   override (macOS `customUserAgent = nil`; GTK
+   `webkit_settings_set_user_agent(settings, NULL)` restores default;
+   WebView2 `put_UserAgent(L"")` — empty restores default).
+
+3. **Per-engine native facility.**
+   - macOS WKWebView: `-[WKWebView setCustomUserAgent:]` with an
+     `NSString*` (or `nil` to clear).
+   - Linux WebKitGTK: `webkit_settings_set_user_agent(
+     webkit_web_view_get_settings(web), ua_or_null)`.
+   - Windows WebView2: `ICoreWebView2Settings2::put_UserAgent(
+     wide(ua))` (query the `_2` settings interface;
+     no-op if unavailable on an old runtime).
+   Each takes effect on the **next** navigation, so apply before the
+   first `navigate` in the attach path.
+
+4. **JNI mechanics.** UTF-8 in, per-engine string conversion,
+   exception-free (never throw across JNI). A `null` jstring maps to
+   the clear path.
+
+## S · Structure
+
+### Inheritance Relationships
+1. `WebViewComponent` (abstract) gains one field + two concrete
+   methods; abstract surface unchanged.
+2. `EmbeddedWebView` / `OffscreenWebView` each gain one `setUserAgent`.
+
+### Dependencies
+1. `WebViewComponent.setUserAgent` → subclass engine wrapper
+   (`EmbeddedWebView`/`OffscreenWebView`).
+2. Engine wrappers → `WebViewNative` natives → per-engine setter.
+3. `createPeer()` / `addNotify()` → apply pending UA before navigate.
+
+### Layered Architecture
+1. Native engine layer (`src_c/webview_embed.cpp`,
+   `windows/webview_embed.cc`): setters + JNI bridges.
+2. JNI surface (`WebViewNative`): two decls.
+3. Engine wrapper layer (`EmbeddedWebView`/`OffscreenWebView`).
+4. Component API layer (`WebViewComponent`).
+5. Wiring layer (`createPeer`/`addNotify`).
+
+## O · Operations
+
+### 1. Extend WebViewComponent
+File: `src/ca/weblite/webview/swing/WebViewComponent.java`
+1. Add `protected String pendingUserAgent = null;` near `pendingUrl`.
+2. `public WebViewComponent setUserAgent(String ua)`: normalise
+   `ua == null || ua.isEmpty()` → `null`; store; if the peer is
+   attached, apply live (subclass hook — see Ops 2/3). Return `this`.
+   Javadoc: `null`/empty restores the engine default; before display
+   it is applied to the first request, after display it takes effect
+   on the next navigation; changes the HTTP `User-Agent` header.
+3. `public String getUserAgent()`: return `pendingUserAgent`.
+4. To let the base `setUserAgent` apply live without knowing the
+   engine type, add `protected void applyUserAgentToPeer(String ua)
+   { }` (no-op default) overridden by the two subclasses.
+
+### 2. Wire heavyweight
+File: `WebViewHeavyweightComponent.java`
+1. In `createPeer()`, after the engine is obtained and **before**
+   `embedded.navigate(pendingUrl)` (and before the adopt-skip guard's
+   navigate), `if (pendingUserAgent != null)
+   embedded.setUserAgent(pendingUserAgent);`.
+2. Override `applyUserAgentToPeer(String ua)`:
+   `EmbeddedWebView e = embedded; if (e != null) e.setUserAgent(ua);`.
+
+### 3. Wire lightweight
+File: `WebViewLightweightComponent.java`
+1. In `addNotify()`, after the engine is created and before
+   `engine.navigate(pendingUrl)`, apply `pendingUserAgent` when
+   non-null.
+2. Override `applyUserAgentToPeer(String ua)` against `engine`.
+
+### 4. EmbeddedWebView / OffscreenWebView setters
+1. `EmbeddedWebView.setUserAgent(String ua)`: `checkAlive()`;
+   `WebViewNative.webview_embed_set_user_agent(peer, ua)`; return
+   `this`.
+2. `OffscreenWebView.setUserAgent(String ua)`:
+   `WebViewNative.webview_offscreen_set_user_agent(peer, ua)`; return
+   `this`.
+
+### 5. WebViewNative decls
+File: `WebViewNative.java`
+1. `native static void webview_embed_set_user_agent(long w, String ua);`
+2. `native static void webview_offscreen_set_user_agent(long peer, String ua);`
+   Block comment: `ua == null` clears the override (engine default);
+   takes effect on the next navigation; never throws via JNI.
+
+### 6. macOS + Linux native
+File: `src_c/webview_embed.cpp`
+1. macOS `cocoa_set_user_agent(Engine*, const char* ua_or_null)`:
+   on main thread, `[e->webview setCustomUserAgent: ua ? ns_str(ua) :
+   nil]`.
+2. Linux `gtk_set_user_agent(Engine*, ...)` / `gtk_off_set_user_agent`:
+   `WebKitSettings* s = webkit_web_view_get_settings(WEBKIT_WEB_VIEW(
+   e->web)); webkit_settings_set_user_agent(s, ua /* NULL ok */);`.
+3. JNI bridges
+   `Java_..._webview_1embed_1set_1user_1agent` /
+   `..._webview_1offscreen_1set_1user_1agent` in the existing
+   `extern "C"` block: `GetStringUTFChars` (null-safe), dispatch per
+   `#ifdef`, `ReleaseStringUTFChars`.
+
+### 7. Windows native
+File: `windows/webview_embed.cc`
+1. `set_user_agent(Engine*, const char* ua_or_null)`: query
+   `ICoreWebView2Settings2` from the controller's settings;
+   `put_UserAgent(widen(ua ? ua : ""))`; no-op if the `_2` interface
+   is unavailable.
+2. JNI bridge `Java_..._webview_1embed_1set_1user_1agent`.
+
+### 8. Test + README
+1. `test/ca/weblite/webview/WebViewComponentUserAgentTest.java`
+   (StubComponent, overriding `applyUserAgentToPeer` to record):
+   default `getUserAgent()==null`; `setUserAgent("x")` →
+   `getUserAgent()=="x"`; `setUserAgent(null)` and `setUserAgent("")`
+   → `null`; chaining returns `this`; live-apply hook fires when the
+   stub reports an attached peer.
+2. README "Custom user agent" subsection: the API, the null-resets
+   semantics, the "changes the HTTP header (unlike a JS shim)" note,
+   and the next-navigation timing.
+
+## N · Norms
+
+- **Mirror `pendingUrl`** lifecycle: store on the component, apply at
+  attach before first navigate, and live afterwards.
+- **`null`/empty == engine default** at every layer; never send an
+  empty UA to the engine as an override.
+- **`getUserAgent()` returns `null` when unset** (not `""`).
+- **JNI never throws**; null jstring is the clear path; UTF-8
+  conversion released on every path.
+- **Java 8 target**; get-style accessors (`setUserAgent`/
+  `getUserAgent`) matching `setUrl`/`getUrl`.
+- **No new dependency; no JS shim; no reserved binding.**
+
+## S · Safeguards
+
+- **Backward compatibility (never-relax):** unset UA → native setter
+  not invoked → engine default unchanged.
+- **Reset semantics:** `setUserAgent(null)` and `setUserAgent("")`
+  both clear the override on every engine (macOS `nil`, GTK `NULL`,
+  WebView2 empty string).
+- **Timing:** applied before the first `navigate` at attach so the
+  initial request carries it; live changes affect the next
+  navigation only (documented; engines do not rewrite in-flight
+  requests).
+- **Headless-safe:** `setUserAgent`/`getUserAgent` before the peer
+  exists only touch the `pendingUserAgent` field; no
+  `HeadlessException`.
+- **WebView2 old-runtime tolerance:** absent `ICoreWebView2Settings2`
+  → silent no-op, not a crash.
+- **Native coverage status (mirrors Canvas 15/18):** the Java
+  contract (Ops 1–5, 8) plus the macOS + Linux native setters (Op 6)
+  and the Windows setter (Op 7) are this canvas's deliverable. The
+  native code is pattern-faithful to the existing engine setters but
+  the generating sandbox has **no native toolchain**, so all three
+  per-engine setters MUST be built and exercised on-device (confirm
+  the `User-Agent` header via an echo endpoint) before release.
+
+## REASONS-Implements
+- `src/ca/weblite/webview/swing/WebViewComponent.java`
+- `src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java`
+- `src/ca/weblite/webview/swing/WebViewLightweightComponent.java`
+- `src/ca/weblite/webview/EmbeddedWebView.java`
+- `src/ca/weblite/webview/OffscreenWebView.java`
+- `src/ca/weblite/webview/WebViewNative.java`
+- `src_c/webview_embed.cpp` (macOS + Linux)
+- `windows/webview_embed.cc` (Windows)
+- `test/ca/weblite/webview/WebViewComponentUserAgentTest.java`
+- `README.md`

--- a/src/ca/weblite/webview/EmbeddedWebView.java
+++ b/src/ca/weblite/webview/EmbeddedWebView.java
@@ -596,6 +596,19 @@ public class EmbeddedWebView {
     }
 
     /**
+     * Override the WebView's User-Agent (changes the HTTP {@code User-Agent}
+     * header).  {@code null} or empty restores the engine default.  Takes
+     * effect on the next navigation.
+     *
+     * @return {@code this} for chaining
+     */
+    public EmbeddedWebView setUserAgent(String ua) {
+        checkAlive();
+        WebViewNative.webview_embed_set_user_agent(peer, ua);
+        return this;
+    }
+
+    /**
      * Windows-only: force Win32 keyboard focus back to the AWT-owned parent
      * HWND, so subsequent keystrokes route to AWT instead of the WebView2
      * child HWND.  Used by the Java-side global focus-owner listener when

--- a/src/ca/weblite/webview/EmbeddedWebView.java
+++ b/src/ca/weblite/webview/EmbeddedWebView.java
@@ -176,6 +176,69 @@ public class EmbeddedWebView {
                 "Native webview_embed_create returned 0; could not obtain a " +
                 "native window handle or initialize the embedded WebView.");
         }
+        return wrapAndBind(p);
+    }
+
+    /**
+     * Adopt a browser-initiated popup child that the engine retained (not
+     * shown) after a {@link ca.weblite.webview.PopupDisposition#ADOPT}
+     * decision, reparenting it into {@code parent}'s realized native surface.
+     * Parallels {@link #attach}, but instead of creating a fresh engine it
+     * reuses the existing opener-linked child identified by {@code popupId} —
+     * preserving that child's in-flight request (POST verb and body) and
+     * {@code window.opener} linkage.  The same eval / function / attach
+     * bridges as {@code attach} are installed on the adopted engine.
+     *
+     * @param parent  a displayable heavyweight AWT component (as {@code attach})
+     * @param popupId the engine-assigned handle from
+     *                {@link ca.weblite.webview.WebViewPopupHandler#popupAdoptable}
+     * @param debug   enable developer tools where supported
+     * @return the wrapper for the adopted engine
+     * @throws IllegalStateException if {@code popupId} is unknown, already
+     *         adopted, expired, or adoption is unsupported on this platform
+     *         (the native adopt returned 0)
+     */
+    public static EmbeddedWebView adopt(Component parent, long popupId,
+                                        boolean debug) {
+        if (parent == null) {
+            throw new IllegalArgumentException("parent must not be null");
+        }
+        if (!parent.isDisplayable()) {
+            throw new IllegalStateException(
+                "parent is not displayable; addNotify() has not been called.");
+        }
+        long p = WebViewNative.webview_embed_adopt_popup(
+            parent, popupId, debug ? 1 : 0);
+        if (p == 0L) {
+            throw new IllegalStateException(
+                "Native webview_embed_adopt_popup returned 0 for popupId "
+                + popupId + "; the retained popup is unknown, already "
+                + "adopted, expired, or adoption is unsupported on this "
+                + "platform.");
+        }
+        return wrapAndBind(p);
+    }
+
+    /**
+     * Discard a retained-but-unadopted popup child (the ADOPT reclaim path).
+     * A no-op for an unknown {@code popupId}.  Used by the owning component's
+     * reclaim sink; does not affect this engine's own page.
+     *
+     * @return {@code this} for chaining
+     */
+    public EmbeddedWebView discardRetainedPopup(long popupId) {
+        checkAlive();
+        WebViewNative.webview_embed_discard_popup(peer, popupId);
+        return this;
+    }
+
+    /**
+     * Wrap a freshly-obtained native embed peer (from
+     * {@code webview_embed_create} or {@code webview_embed_adopt_popup}) and
+     * install the attach / eval / function bridges.  Shared by {@link #attach}
+     * and {@link #adopt}.
+     */
+    private static EmbeddedWebView wrapAndBind(long p) {
         final EmbeddedWebView ewv = new EmbeddedWebView(p);
         // Register the attach-completion callback BEFORE installing the
         // eval bridge or returning.  The native side either fires the

--- a/src/ca/weblite/webview/OffscreenWebView.java
+++ b/src/ca/weblite/webview/OffscreenWebView.java
@@ -101,6 +101,56 @@ public class OffscreenWebView {
         long p = WebViewNative.webview_offscreen_create(
             Math.max(1, width), Math.max(1, height), debug ? 1 : 0);
         if (p == 0L) return null;
+        return wrapAndInstallBridges(p);
+    }
+
+    /**
+     * Adopt a browser-initiated popup child that the offscreen engine
+     * retained (not shown) after a
+     * {@link ca.weblite.webview.PopupDisposition#ADOPT} decision, reusing it
+     * inside a fresh {@code GtkOffscreenWindow}.  The offscreen counterpart of
+     * {@link EmbeddedWebView#adopt}: instead of creating a fresh engine it
+     * reuses the existing opener-linked child identified by {@code popupId} —
+     * preserving that child's in-flight request (POST verb and body) and
+     * {@code window.opener} linkage — and installs the SAME evalAsync /
+     * addJavascriptFunction bridges as {@link #create}.
+     *
+     * <p>The retained child lives in the SAME native registry regardless of
+     * whether the opener was a heavyweight or lightweight component, so a
+     * popup raised by either can be adopted into a lightweight component.
+     *
+     * @param width   initial offscreen viewport width in pixels
+     * @param height  initial offscreen viewport height in pixels
+     * @param popupId the engine-assigned handle from
+     *                {@link ca.weblite.webview.WebViewPopupHandler#popupAdoptable}
+     * @param debug   enable developer tools where supported
+     * @return the wrapper for the adopted offscreen engine
+     * @throws IllegalStateException if {@code popupId} is unknown, already
+     *         adopted, expired, or adoption is unsupported on this platform
+     *         (the native adopt returned 0 — e.g. macOS / Windows, where the
+     *         offscreen engine is a stub)
+     */
+    public static OffscreenWebView adopt(int width, int height, long popupId,
+                                         boolean debug) {
+        long p = WebViewNative.webview_offscreen_adopt_popup(
+            Math.max(1, width), Math.max(1, height), popupId, debug ? 1 : 0);
+        if (p == 0L) {
+            throw new IllegalStateException(
+                "no retained popup to adopt for popupId " + popupId
+                + "; it is unknown, already adopted, expired, or the "
+                + "offscreen engine is unsupported on this platform.");
+        }
+        return wrapAndInstallBridges(p);
+    }
+
+    /**
+     * Wrap a freshly-obtained offscreen peer (from
+     * {@code webview_offscreen_create} or {@code webview_offscreen_adopt_popup})
+     * and install the evalAsync + addJavascriptFunction bridges.  Shared by
+     * {@link #create} and {@link #adopt} so an adopted wrapper is
+     * indistinguishable from a created one.
+     */
+    private static OffscreenWebView wrapAndInstallBridges(long p) {
         final OffscreenWebView ow = new OffscreenWebView(p);
         // Install the evalAsync bridge BEFORE returning so the SHIM_JS is
         // in place at document-start for every subsequent navigation, and
@@ -130,6 +180,22 @@ public class OffscreenWebView {
         ow.heap.add(fnCb);
         WebViewNative.webview_offscreen_bind(p, FunctionDispatcher.INBOUND_CHANNEL, fnCb, p);
         return ow;
+    }
+
+    /**
+     * Discard a retained-but-unadopted popup child (the ADOPT reclaim path).
+     * The offscreen counterpart of
+     * {@link EmbeddedWebView#discardRetainedPopup}.  A no-op for an unknown
+     * {@code popupId}.  Used by the owning lightweight component's reclaim
+     * sink; does not affect this engine's own page.  The native side converges
+     * on the same shared reclaim as the heavyweight discard.
+     *
+     * @return {@code this} for chaining
+     */
+    public OffscreenWebView discardRetainedPopup(long popupId) {
+        checkAlive();
+        WebViewNative.webview_offscreen_discard_popup(peer, popupId);
+        return this;
     }
 
     /** @return the native peer pointer, or 0 if disposed. */

--- a/src/ca/weblite/webview/OffscreenWebView.java
+++ b/src/ca/weblite/webview/OffscreenWebView.java
@@ -397,6 +397,20 @@ public class OffscreenWebView {
         return this;
     }
 
+    /**
+     * Override the WebView's User-Agent (changes the HTTP {@code User-Agent}
+     * header).  {@code null} or empty restores the engine default.  Takes
+     * effect on the next navigation.  Linux only; a native-side no-op where
+     * the offscreen engine is a stub.
+     *
+     * @return {@code this} for chaining
+     */
+    public OffscreenWebView setUserAgent(String ua) {
+        checkAlive();
+        WebViewNative.webview_offscreen_set_user_agent(peer, ua);
+        return this;
+    }
+
     /** Release native resources. */
     public void dispose() {
         if (peer != 0L) {

--- a/src/ca/weblite/webview/PopupDispatcher.java
+++ b/src/ca/weblite/webview/PopupDispatcher.java
@@ -65,9 +65,54 @@ public final class PopupDispatcher {
     private final ConcurrentHashMap<Long, WebViewPopupEvent> openPopups =
         new ConcurrentHashMap<Long, WebViewPopupEvent>();
 
+    /** Default grace period (ms) after which a popup decided
+     *  {@link PopupDisposition#ADOPT} but never adopted is reclaimed. */
+    static final long DEFAULT_ADOPT_GRACE_MS = 30000L;
+
+    /** Popups decided {@link PopupDisposition#ADOPT} that have been retained
+     *  natively but not yet claimed by {@link #claimAdopt}.  Keyed by the
+     *  engine-assigned popup id. */
+    private final ConcurrentHashMap<Long, WebViewPopupEvent> pendingAdopts =
+        new ConcurrentHashMap<Long, WebViewPopupEvent>();
+
+    /** Popup ids that have been successfully adopted, so a second
+     *  {@link #claimAdopt} of the same id can be rejected with a distinct
+     *  {@link IllegalStateException} rather than the "unknown id"
+     *  {@link IllegalArgumentException}. */
+    private final java.util.Set<Long> claimedAdopts =
+        java.util.Collections.newSetFromMap(
+            new ConcurrentHashMap<Long, Boolean>());
+
+    /** Per-pending-id grace tasks, so a claim can cancel the reclaim. */
+    private final ConcurrentHashMap<Long, java.util.TimerTask> graceTasks =
+        new ConcurrentHashMap<Long, java.util.TimerTask>();
+
+    /** Lazily-created daemon timer that fires the unclaimed-adopt reclaim.
+     *  Created on first {@link #dispatchPopupAdoptable} so components that
+     *  never adopt spawn no timer thread.  Guarded by {@code this}. */
+    private java.util.Timer graceTimer;
+
+    private final long adoptGraceMs = DEFAULT_ADOPT_GRACE_MS;
+
+    /** Installed by the owning Swing component so the dispatcher can ask the
+     *  native engine to discard a retained-but-unadopted popup child. */
+    public interface ReclaimSink {
+        /** Discard the retained popup child with the given id. */
+        void discard(long popupId);
+    }
+
+    private volatile ReclaimSink reclaimSink;
+
     public PopupDispatcher(WebViewComponent source) {
         if (source == null) throw new NullPointerException("source");
         this.source = source;
+    }
+
+    /** Install (or clear, when {@code null}) the sink used to discard
+     *  retained-but-unadopted popup children during reclaim.  Set by the
+     *  component at peer-attach time. */
+    public void setReclaimSink(ReclaimSink sink) {
+        this.reclaimSink = sink;
     }
 
     /** Replace the active handler.  Passing {@code null} installs an internal
@@ -88,6 +133,16 @@ public final class PopupDispatcher {
     public void disposeAll() {
         disposed = true;
         openPopups.clear();
+        // Reclaim any retained-but-unadopted popup children before the native
+        // peer is destroyed, then cancel the grace timer.
+        reclaimAdopts();
+        synchronized (this) {
+            if (graceTimer != null) {
+                graceTimer.cancel();
+                graceTimer = null;
+            }
+        }
+        graceTasks.clear();
     }
 
     /** @return whether the dispatcher has been disposed. */
@@ -114,6 +169,141 @@ public final class PopupDispatcher {
             forwardUncaught(t);
             return false;
         }
+    }
+
+    /** Synchronous disposition gate — the enriched successor to
+     *  {@link #dispatchPopupRequested}.  Runs the handler inline on the
+     *  calling (native UI) thread and returns the chosen
+     *  {@link PopupDisposition}'s ordinal; never marshals to the EDT.  A
+     *  disposed dispatcher, a {@code null} return, or a thrown decision all
+     *  yield {@link PopupDisposition#BLOCK} (safe default: block). */
+    public int dispatchPopupDisposition(String targetUrl, String targetName,
+                                        boolean userGesture, int width,
+                                        int height, String pageUrl) {
+        if (disposed) return PopupDisposition.BLOCK.ordinal();
+        final WebViewPopupEvent event = new WebViewPopupEvent(
+            source, targetUrl, targetName, userGesture, width, height, pageUrl);
+        try {
+            PopupDisposition d = handler.popupDisposition(event);
+            return (d == null ? PopupDisposition.BLOCK : d).ordinal();
+        } catch (Throwable t) {
+            forwardUncaught(t);
+            return PopupDisposition.BLOCK.ordinal();
+        }
+    }
+
+    /** Async notification that a popup was decided
+     *  {@link PopupDisposition#ADOPT} and is retained under a hidden holder.
+     *  Records the pending adoption (for {@link #claimAdopt} and reclaim),
+     *  arms the grace-period backstop, and delivers
+     *  {@link WebViewPopupHandler#popupAdoptable} on the EDT. */
+    public void dispatchPopupAdoptable(long popupId, String targetUrl,
+                                       String targetName, boolean userGesture,
+                                       int width, int height, String pageUrl) {
+        if (disposed) return;
+        final Long key = Long.valueOf(popupId);
+        final WebViewPopupEvent event = new WebViewPopupEvent(
+            source, targetUrl, targetName, userGesture, width, height, pageUrl);
+        pendingAdopts.put(key, event);
+        scheduleGrace(key);
+        runOnEdtLater(new Runnable() {
+            @Override public void run() {
+                handler.popupAdoptable(event, popupId);
+            }
+        });
+    }
+
+    /** Claim a pending adoption by its {@code popupId}, enforcing
+     *  adopt-once.  Called by the adopting component at peer-attach.
+     *
+     *  @return the event recorded at {@link #dispatchPopupAdoptable}
+     *  @throws IllegalArgumentException if {@code popupId} was never issued
+     *          (or already expired / reclaimed)
+     *  @throws IllegalStateException    if {@code popupId} was already adopted
+     */
+    public WebViewPopupEvent claimAdopt(long popupId) {
+        final Long key = Long.valueOf(popupId);
+        WebViewPopupEvent event = pendingAdopts.remove(key);
+        if (event == null) {
+            if (claimedAdopts.contains(key)) {
+                throw new IllegalStateException(
+                    "popup " + popupId + " has already been adopted");
+            }
+            throw new IllegalArgumentException(
+                "unknown or expired popup id: " + popupId);
+        }
+        claimedAdopts.add(key);
+        cancelGrace(key);
+        return event;
+    }
+
+    /** Discard every retained-but-unadopted popup child via the reclaim
+     *  sink, clearing the pending map.  Invoked from {@link #disposeAll} and
+     *  never throws out to the caller. */
+    public void reclaimAdopts() {
+        final ReclaimSink sink = reclaimSink;
+        for (Long id : pendingAdopts.keySet()) {
+            WebViewPopupEvent removed = pendingAdopts.remove(id);
+            cancelGrace(id);
+            if (removed == null) continue;
+            if (sink != null) {
+                try {
+                    sink.discard(id.longValue());
+                } catch (Throwable t) {
+                    forwardUncaught(t);
+                }
+            }
+        }
+    }
+
+    /** @return the number of retained-but-unadopted popup children (test /
+     *  diagnostic hook). */
+    public int pendingAdoptCount() {
+        return pendingAdopts.size();
+    }
+
+    // ---------------------------------------------------------------------
+    // Grace-period reclaim backstop.
+    // ---------------------------------------------------------------------
+
+    private void scheduleGrace(final Long key) {
+        java.util.Timer timer;
+        synchronized (this) {
+            if (disposed) return;
+            if (graceTimer == null) {
+                graceTimer =
+                    new java.util.Timer("webview-popup-adopt-grace", true);
+            }
+            timer = graceTimer;
+        }
+        java.util.TimerTask task = new java.util.TimerTask() {
+            @Override public void run() {
+                WebViewPopupEvent removed = pendingAdopts.remove(key);
+                graceTasks.remove(key);
+                if (removed == null) return; // already claimed or reclaimed
+                ReclaimSink sink = reclaimSink;
+                if (sink != null) {
+                    try {
+                        sink.discard(key.longValue());
+                    } catch (Throwable t) {
+                        forwardUncaught(t);
+                    }
+                }
+            }
+        };
+        graceTasks.put(key, task);
+        try {
+            timer.schedule(task, adoptGraceMs);
+        } catch (Throwable ignored) {
+            // Timer was cancelled concurrently (disposeAll); the reclaim on
+            // that path already handled this id.
+            graceTasks.remove(key);
+        }
+    }
+
+    private void cancelGrace(Long key) {
+        java.util.TimerTask task = graceTasks.remove(key);
+        if (task != null) task.cancel();
     }
 
     /** Async notification that a popup window opened; delivered on the EDT. */

--- a/src/ca/weblite/webview/PopupDisposition.java
+++ b/src/ca/weblite/webview/PopupDisposition.java
@@ -1,0 +1,45 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+/**
+ * How the library should handle a browser-initiated popup — the enriched
+ * outcome of {@link WebViewPopupHandler#popupDisposition}.
+ *
+ * <p>Extends the Canvas 15 allow/deny model (a plain {@code boolean}) with a
+ * third option, {@link #ADOPT}, that lets the application host the popup's
+ * engine-created child web view inside a {@link
+ * ca.weblite.webview.swing.WebViewComponent} it supplies (a tab) instead of
+ * the native top-level window the engine owns by default.
+ *
+ * <p><strong>Ordinal wire contract.</strong> The ordinals of these constants
+ * ({@code BLOCK = 0}, {@code NATIVE_WINDOW = 1}, {@code ADOPT = 2}) are shared
+ * with the native engine through {@link WebViewPopupCallback#onPopupDisposition}
+ * and MUST NOT be reordered — the native disposition switch keys off these
+ * integer values.
+ */
+public enum PopupDisposition {
+
+    /** Block the popup: {@code window.open} returns {@code null} and no child
+     *  web view is created.  Equivalent to the Canvas 15 {@code false}
+     *  allow/deny decision. */
+    BLOCK,
+
+    /** Allow the popup and host it in an engine-owned native top-level window
+     *  (the Canvas 15 behaviour).  Equivalent to the Canvas 15 {@code true}
+     *  allow/deny decision. */
+    NATIVE_WINDOW,
+
+    /** Allow the popup but do not open a native window: the engine creates the
+     *  opener-linked child web view (preserving the in-flight request — POST
+     *  verb and body — and {@code window.opener}), retains it under a hidden
+     *  holder keyed by an engine-assigned {@code popupId}, and notifies the
+     *  application via {@link WebViewPopupHandler#popupAdoptable} so it can
+     *  host the child in a {@link
+     *  ca.weblite.webview.swing.WebViewComponent#adoptPopup(long)}.  A child
+     *  that is never adopted is reclaimed (see {@link PopupDispatcher}). */
+    ADOPT
+}

--- a/src/ca/weblite/webview/WebViewNative.java
+++ b/src/ca/weblite/webview/WebViewNative.java
@@ -302,6 +302,14 @@ native static void webview_embed_set_dialog_callback(long w, WebViewDialogCallba
 // silent no-op.  Never throws via JNI.
 native static void webview_embed_set_popup_callback(long w, WebViewPopupCallback cb);
 
+// Override the embedded WebView's User-Agent (changes the actual HTTP
+// User-Agent request header).  ua == null (or empty) clears the override and
+// restores the engine default.  Takes effect on the next navigation.  Per
+// platform: macOS -[WKWebView setCustomUserAgent:]; Linux
+// webkit_settings_set_user_agent; Windows ICoreWebView2Settings2::put_UserAgent.
+// Passing 0 for w is a silent no-op.  Never throws via JNI.
+native static void webview_embed_set_user_agent(long w, String ua);
+
 // Adopt a browser-initiated popup child that was retained (not shown) after
 // an ADOPT disposition, reparenting it into `parent`'s realized native
 // surface and returning an opaque engine pointer for it (as
@@ -435,6 +443,12 @@ native static void webview_offscreen_set_dialog_callback(long peer, WebViewDialo
 // Windows native binaries provide a no-op stub (the offscreen engine on
 // those platforms is itself a stub).  Never throws via JNI.
 native static void webview_offscreen_set_popup_callback(long peer, WebViewPopupCallback cb);
+
+// Offscreen counterpart to webview_embed_set_user_agent.  Linux sets the
+// WebKitGTK settings user-agent; macOS / Windows offscreen engines are stubs
+// and this is a native-side no-op.  ua == null clears the override.  Never
+// throws via JNI.
+native static void webview_offscreen_set_user_agent(long peer, String ua);
 
 
 }

--- a/src/ca/weblite/webview/WebViewNative.java
+++ b/src/ca/weblite/webview/WebViewNative.java
@@ -302,6 +302,24 @@ native static void webview_embed_set_dialog_callback(long w, WebViewDialogCallba
 // silent no-op.  Never throws via JNI.
 native static void webview_embed_set_popup_callback(long w, WebViewPopupCallback cb);
 
+// Adopt a browser-initiated popup child that was retained (not shown) after
+// an ADOPT disposition, reparenting it into `parent`'s realized native
+// surface and returning an opaque engine pointer for it (as
+// webview_embed_create would), or 0 when `popupId` is unknown / already
+// adopted / expired.  The reused child preserves its in-flight request (POST
+// verb + body) and window.opener linkage.  Delivery per platform: macOS
+// reparents the WKWebView via addSubview: into the parent NSView; Linux
+// (Canvas 19) and Windows (Canvas 20) land their reparent in follow-up
+// canvases (this build returns 0 on those platforms).  Never throws via JNI.
+native static long webview_embed_adopt_popup(java.awt.Component parent,
+                                             long popupId, int debug);
+
+// Discard a retained-but-unadopted popup child (the ADOPT reclaim path):
+// tear down its native view + child engine without ever showing a window.
+// `w` is any live embed peer from the same process (the opener's).  Unknown
+// popupId is a silent no-op.  Never throws via JNI.
+native static void webview_embed_discard_popup(long w, long popupId);
+
 
 // ---------------------------------------------------------------------------
 // Lightweight / offscreen API (currently Linux-only).

--- a/src/ca/weblite/webview/WebViewNative.java
+++ b/src/ca/weblite/webview/WebViewNative.java
@@ -450,5 +450,25 @@ native static void webview_offscreen_set_popup_callback(long peer, WebViewPopupC
 // throws via JNI.
 native static void webview_offscreen_set_user_agent(long peer, String ua);
 
+// Offscreen counterpart to webview_embed_adopt_popup (Canvas 19).  Adopt a
+// browser-initiated popup child that was retained (not shown) after an ADOPT
+// disposition, reusing it inside a fresh GtkOffscreenWindow (OffEngine) and
+// returning an opaque offscreen peer pointer (as webview_offscreen_create
+// would), or 0 when `popupId` is unknown / already adopted / expired, or on an
+// unsupported platform (macOS / Windows offscreen engines are stubs).  The
+// reused child preserves its in-flight request (POST verb + body) and
+// window.opener linkage.  Claims from the SAME retained-popup registry as the
+// heavyweight webview_embed_adopt_popup.  Never throws via JNI.
+native static long webview_offscreen_adopt_popup(int width, int height,
+                                                 long popupId, int debug);
+
+// Offscreen counterpart to webview_embed_discard_popup (Canvas 19).  Discard a
+// retained-but-unadopted popup child (the ADOPT reclaim path): tear down its
+// native view + child engine without ever showing a window.  Converges on the
+// SAME shared native reclaim (gtk_discard_popup) as the heavyweight bridge, so
+// `peer` is unused (kept for signature symmetry with the heavyweight bridge).
+// Unknown popupId is a silent no-op.  Never throws via JNI.
+native static void webview_offscreen_discard_popup(long peer, long popupId);
+
 
 }

--- a/src/ca/weblite/webview/WebViewPopupCallback.java
+++ b/src/ca/weblite/webview/WebViewPopupCallback.java
@@ -46,6 +46,38 @@ public interface WebViewPopupCallback {
                              boolean userGesture, int width, int height,
                              String pageUrl);
 
+    /**
+     * Invoked synchronously when the page requests a popup, to obtain the
+     * enriched disposition.  Returns a {@link PopupDisposition} ordinal —
+     * {@code 0 = BLOCK}, {@code 1 = NATIVE_WINDOW}, {@code 2 = ADOPT} — which
+     * the native side switches on to block, open a native window, or retain
+     * the child for adoption.  Like {@link #onPopupRequested}, the native
+     * side is blocked awaiting the return value and it MUST NOT be marshalled
+     * to the EDT.
+     *
+     * <p>The default derives the disposition from {@link #onPopupRequested}
+     * ({@code true → NATIVE_WINDOW.ordinal()}, {@code false → BLOCK.ordinal()})
+     * so an engine that only calls {@code onPopupRequested} keeps working.
+     */
+    default int onPopupDisposition(String targetUrl, String targetName,
+                                   boolean userGesture, int width, int height,
+                                   String pageUrl) {
+        return onPopupRequested(targetUrl, targetName, userGesture,
+                                width, height, pageUrl)
+            ? PopupDisposition.NATIVE_WINDOW.ordinal()
+            : PopupDisposition.BLOCK.ordinal();
+    }
+
+    /** Invoked (as a notification) after an {@code ADOPT} disposition, once
+     *  the opener-linked child has been created and retained under a hidden
+     *  holder.  {@code popupId} is the engine-assigned handle the application
+     *  passes to {@code WebViewComponent.adoptPopup}.  Default is a no-op so
+     *  engines that have not implemented adoption need not call it. */
+    default void onPopupAdoptable(long popupId, String targetUrl,
+                                  String targetName, boolean userGesture,
+                                  int width, int height, String pageUrl) {
+    }
+
     /** Invoked after the popup's native window has been created and shown.
      *  {@code popupId} is an engine-assigned opaque handle correlating this
      *  open with its later {@link #onPopupClosed}. */

--- a/src/ca/weblite/webview/WebViewPopupHandler.java
+++ b/src/ca/weblite/webview/WebViewPopupHandler.java
@@ -53,6 +53,58 @@ public interface WebViewPopupHandler {
         return true;
     }
 
+    /**
+     * Decide how to handle a popup — the enriched successor to {@link
+     * #popupRequested}.  Return {@link PopupDisposition#BLOCK} to block it,
+     * {@link PopupDisposition#NATIVE_WINDOW} to host it in an engine-owned
+     * native window (the Canvas 15 allow behaviour), or {@link
+     * PopupDisposition#ADOPT} to have the engine retain the opener-linked
+     * child for the application to host in a {@link
+     * ca.weblite.webview.swing.WebViewComponent} (a tab).
+     *
+     * <p>Runs on the <strong>native UI thread</strong>,
+     * <strong>synchronously</strong> and <strong>off the EDT</strong> — the
+     * same threading contract as {@link #popupRequested}: it must be fast,
+     * thread-safe, and MUST NOT touch Swing state.
+     *
+     * <p><strong>Backward compatibility.</strong> The default implementation
+     * derives the disposition from {@link #popupRequested}: {@code true} maps
+     * to {@link PopupDisposition#NATIVE_WINDOW} and {@code false} to {@link
+     * PopupDisposition#BLOCK}.  Existing handlers that override only {@code
+     * popupRequested} therefore behave exactly as before.  Override this
+     * method (returning {@link PopupDisposition#ADOPT}) to opt into tab
+     * adoption; a handler that returns {@code ADOPT} should also override
+     * {@link #popupAdoptable}.
+     *
+     * @param event the popup request
+     * @return the disposition; never {@code null} (the dispatcher treats a
+     *         {@code null} return as {@link PopupDisposition#BLOCK})
+     */
+    default PopupDisposition popupDisposition(WebViewPopupEvent event) {
+        return popupRequested(event)
+            ? PopupDisposition.NATIVE_WINDOW
+            : PopupDisposition.BLOCK;
+    }
+
+    /**
+     * Notification that a popup was decided {@link PopupDisposition#ADOPT}:
+     * the engine has created and retained the opener-linked child, and it is
+     * ready to be adopted into a {@link
+     * ca.weblite.webview.swing.WebViewComponent}.  Runs on the <strong>EDT
+     * </strong>.  Default is a no-op.
+     *
+     * <p>To host the popup, create a component with {@link
+     * ca.weblite.webview.swing.WebViewComponent#adoptPopup(long)} passing the
+     * given {@code popupId} and add it to a container (e.g. a new tab).  If no
+     * component adopts the {@code popupId}, the retained child is reclaimed
+     * (on opener disposal or after a bounded grace period).
+     *
+     * @param event   the popup request
+     * @param popupId the engine-assigned handle to pass to {@code adoptPopup}
+     */
+    default void popupAdoptable(WebViewPopupEvent event, long popupId) {
+    }
+
     /** Notification that a popup window has been created and shown.  Runs
      *  on the Swing EDT.  Default is a no-op. */
     default void popupOpened(WebViewPopupEvent event) {

--- a/src/ca/weblite/webview/swing/WebViewComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewComponent.java
@@ -85,6 +85,12 @@ public abstract class WebViewComponent extends JComponent {
      *  methods. */
     protected final PopupDispatcher popupDispatcher = new PopupDispatcher(this);
 
+    /** When non-zero, this component was created via {@link #adoptPopup} and
+     *  its peer, at attach time, adopts the pre-existing native popup child
+     *  with this engine-assigned id rather than creating a fresh engine.
+     *  Zero (the default) means normal, engine-creating construction. */
+    protected long pendingAdoptPopupId = 0L;
+
     /** Implementation mode for {@link #create(Mode)}. */
     public enum Mode {
         /** Native WebView embedded as a heavyweight AWT peer.  Highest
@@ -125,6 +131,38 @@ public abstract class WebViewComponent extends JComponent {
                 throw new IllegalArgumentException(
                     "Unknown WebViewComponent.Mode: " + mode);
         }
+    }
+
+    /**
+     * Create a component that <strong>adopts</strong> a browser-initiated
+     * popup — the opener-linked child web view the engine retained after a
+     * {@link ca.weblite.webview.PopupDisposition#ADOPT} decision — instead of
+     * creating its own engine.  Adoption happens when the returned component's
+     * peer is realized (it is added to a showing container); the child's
+     * in-flight navigation (POST verb and body) and {@code window.opener}
+     * linkage are preserved because the engine's own child is reused.
+     *
+     * <p>Call this on the EDT from {@link
+     * ca.weblite.webview.WebViewPopupHandler#popupAdoptable}, passing the
+     * {@code popupId} it delivered, then add the component to a container
+     * (e.g. a new tab).  Uses the platform-default {@link Mode}.
+     *
+     * <p>Adopting an unknown / already-adopted / expired {@code popupId}
+     * fails when the peer is realized (the native adopt returns no engine),
+     * surfaced as an {@link IllegalStateException} from the attach path.
+     *
+     * @param popupId the engine-assigned handle from {@code popupAdoptable}
+     * @return a component that will adopt the popup on realization
+     */
+    public static WebViewComponent adoptPopup(long popupId) {
+        return adoptPopup(resolveDefaultMode(), popupId);
+    }
+
+    /** {@link #adoptPopup(long)} with an explicit implementation {@link Mode}. */
+    public static WebViewComponent adoptPopup(Mode mode, long popupId) {
+        WebViewComponent c = create(mode);
+        c.pendingAdoptPopupId = popupId;
+        return c;
     }
 
     /**

--- a/src/ca/weblite/webview/swing/WebViewComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewComponent.java
@@ -207,6 +207,43 @@ public abstract class WebViewComponent extends JComponent {
     /** @return the current (or pending) URL. */
     public abstract String getUrl();
 
+    /** Custom User-Agent override, or {@code null} for the engine default.
+     *  Survives the native peer's create/destroy cycle so it is applied to
+     *  the first request when the peer attaches. */
+    protected String pendingUserAgent = null;
+
+    /**
+     * Override the embedded WebView's User-Agent.  Unlike a JavaScript
+     * {@code navigator.userAgent} shim, this changes the actual HTTP
+     * {@code User-Agent} request header the server sees.
+     *
+     * <p>Passing {@code null} or the empty string restores the engine
+     * default.  May be called before display (stored and applied to the
+     * first request when the peer attaches) or after (applied live; it
+     * takes effect on the <em>next</em> navigation — engines do not rewrite
+     * the in-flight request for the current page).
+     *
+     * @param ua the User-Agent string, or {@code null} / {@code ""} to reset
+     * @return {@code this} for chaining
+     */
+    public WebViewComponent setUserAgent(String ua) {
+        pendingUserAgent = (ua == null || ua.isEmpty()) ? null : ua;
+        applyUserAgentToPeer(pendingUserAgent);
+        return this;
+    }
+
+    /** @return the custom User-Agent override, or {@code null} when the
+     *  engine default is in force. */
+    public String getUserAgent() {
+        return pendingUserAgent;
+    }
+
+    /** Apply the (possibly {@code null}) User-Agent to the live native peer.
+     *  No-op on the base class and when no peer is attached; subclasses
+     *  forward to their engine wrapper's {@code setUserAgent}. */
+    protected void applyUserAgentToPeer(String ua) {
+    }
+
     /** Toggle developer tools (where supported).  Must be called before display. */
     public abstract WebViewComponent setDebug(boolean debug);
 

--- a/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
@@ -9,6 +9,7 @@ import ca.weblite.webview.AsyncJavascriptFunction;
 import ca.weblite.webview.ConsoleDispatcher;
 import ca.weblite.webview.EditingCommand;
 import ca.weblite.webview.EmbeddedWebView;
+import ca.weblite.webview.PopupDispatcher;
 import ca.weblite.webview.JavascriptFunction;
 import ca.weblite.webview.WebView;
 import ca.weblite.webview.WebViewClickCallback;
@@ -457,7 +458,14 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
             return;
         }
         try {
-            embedded = EmbeddedWebView.attach(canvas, debug);
+            if (pendingAdoptPopupId != 0L) {
+                // Adopt a retained popup child (PopupDisposition.ADOPT) into
+                // this component's surface instead of creating a fresh engine.
+                embedded = EmbeddedWebView.adopt(
+                    canvas, pendingAdoptPopupId, debug);
+            } else {
+                embedded = EmbeddedWebView.attach(canvas, debug);
+            }
         } catch (RuntimeException ex) {
             embedded = null;
             throw ex;
@@ -515,7 +523,13 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
         for (Map.Entry<String, AsyncJavascriptFunction> e : pendingAsyncFunctions.entrySet()) {
             embedded.addJavascriptFunction(e.getKey(), e.getValue());
         }
-        embedded.navigate(pendingUrl);
+        // An adopted popup already carries the engine's own in-flight
+        // navigation (the original request WebKit drove into the child, POST
+        // body intact); navigating pendingUrl here would clobber it.  Only
+        // navigate for the normal engine-creating path.
+        if (pendingAdoptPopupId == 0L) {
+            embedded.navigate(pendingUrl);
+        }
         sizeNative();
         // On macOS the WKWebView attaches asynchronously: the sizeNative()
         // above runs before the native view exists and is a no-op, and a
@@ -612,6 +626,21 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
                     targetUrl, targetName, userGesture, width, height, pageUrl);
             }
             @Override
+            public int onPopupDisposition(String targetUrl, String targetName,
+                                          boolean userGesture, int width,
+                                          int height, String pageUrl) {
+                return popupDispatcher.dispatchPopupDisposition(
+                    targetUrl, targetName, userGesture, width, height, pageUrl);
+            }
+            @Override
+            public void onPopupAdoptable(long popupId, String targetUrl,
+                                         String targetName, boolean userGesture,
+                                         int width, int height, String pageUrl) {
+                popupDispatcher.dispatchPopupAdoptable(
+                    popupId, targetUrl, targetName, userGesture, width, height,
+                    pageUrl);
+            }
+            @Override
             public void onPopupOpened(long popupId, String targetUrl,
                                       String targetName, boolean userGesture,
                                       int width, int height, String pageUrl) {
@@ -623,6 +652,20 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
             public void onPopupClosed(long popupId, String targetUrl,
                                       String pageUrl) {
                 popupDispatcher.dispatchPopupClosed(popupId, targetUrl, pageUrl);
+            }
+        });
+        // Let the dispatcher discard retained-but-unadopted popup children
+        // (PopupDisposition.ADOPT reclaim) through this engine.
+        popupDispatcher.setReclaimSink(new PopupDispatcher.ReclaimSink() {
+            @Override
+            public void discard(long popupId) {
+                EmbeddedWebView e = embedded;
+                if (e == null) return;
+                try {
+                    e.discardRetainedPopup(popupId);
+                } catch (RuntimeException ignored) {
+                    // Reclaim is best-effort; teardown must not fail on it.
+                }
             }
         });
         // Seed the peer's initial visibility from the component's current

--- a/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
@@ -453,6 +453,14 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
         return true;
     }
 
+    @Override
+    protected void applyUserAgentToPeer(String ua) {
+        EmbeddedWebView e = embedded;
+        if (e != null) {
+            e.setUserAgent(ua);
+        }
+    }
+
     private void createPeer() {
         if (embedded != null || !canvas.isDisplayable()) {
             return;
@@ -522,6 +530,11 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
         }
         for (Map.Entry<String, AsyncJavascriptFunction> e : pendingAsyncFunctions.entrySet()) {
             embedded.addJavascriptFunction(e.getKey(), e.getValue());
+        }
+        // Apply any custom User-Agent BEFORE the first navigate so the
+        // initial request carries it.
+        if (pendingUserAgent != null) {
+            embedded.setUserAgent(pendingUserAgent);
         }
         // An adopted popup already carries the engine's own in-flight
         // navigation (the original request WebKit drove into the child, POST

--- a/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
@@ -199,6 +199,22 @@ public class WebViewLightweightComponent extends WebViewComponent {
     public void addNotify() {
         super.addNotify();
         if (engine != null) return;
+        if (pendingAdoptPopupId != 0L) {
+            // Popup adoption for the lightweight / offscreen engine lands in
+            // Canvas 19 (STORY-005-002, Linux).  Until then, adopting into an
+            // offscreen component is unsupported: leave the engine null (blank
+            // component) rather than silently creating an unrelated engine.
+            // The retained native child is reclaimed by the opener's grace
+            // backstop.  The reference adoption backend (Canvas 18) is macOS
+            // heavyweight.
+            System.err.println(
+                "[webview] popup adoption is not yet implemented for the "
+                + "lightweight/offscreen engine (Canvas 19); popupId "
+                + pendingAdoptPopupId + " will be reclaimed. Use the "
+                + "heavyweight mode for adoption on the reference (macOS) "
+                + "backend.");
+            return;
+        }
         int w = Math.max(1, getWidth());
         int h = Math.max(1, getHeight());
         engine = OffscreenWebView.create(w, h, debug);
@@ -290,6 +306,21 @@ public class WebViewLightweightComponent extends WebViewComponent {
                                             int height, String pageUrl) {
                 return popupDispatcher.dispatchPopupRequested(
                     targetUrl, targetName, userGesture, width, height, pageUrl);
+            }
+            @Override
+            public int onPopupDisposition(String targetUrl, String targetName,
+                                          boolean userGesture, int width,
+                                          int height, String pageUrl) {
+                return popupDispatcher.dispatchPopupDisposition(
+                    targetUrl, targetName, userGesture, width, height, pageUrl);
+            }
+            @Override
+            public void onPopupAdoptable(long popupId, String targetUrl,
+                                         String targetName, boolean userGesture,
+                                         int width, int height, String pageUrl) {
+                popupDispatcher.dispatchPopupAdoptable(
+                    popupId, targetUrl, targetName, userGesture, width, height,
+                    pageUrl);
             }
             @Override
             public void onPopupOpened(long popupId, String targetUrl,

--- a/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
@@ -196,6 +196,14 @@ public class WebViewLightweightComponent extends WebViewComponent {
     }
 
     @Override
+    protected void applyUserAgentToPeer(String ua) {
+        OffscreenWebView e = engine;
+        if (e != null) {
+            e.setUserAgent(ua);
+        }
+    }
+
+    @Override
     public void addNotify() {
         super.addNotify();
         if (engine != null) return;
@@ -349,6 +357,11 @@ public class WebViewLightweightComponent extends WebViewComponent {
             engine.addJavascriptFunction(ent.getKey(), ent.getValue());
         }
         allocateBuffer(w, h);
+        // Apply any custom User-Agent BEFORE the first navigate so the
+        // initial request carries it.
+        if (pendingUserAgent != null) {
+            engine.setUserAgent(pendingUserAgent);
+        }
         engine.navigate(pendingUrl);
         repaintTimer = new Timer(REPAINT_INTERVAL_MS, e -> repaint());
         repaintTimer.setRepeats(true);

--- a/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
@@ -11,6 +11,7 @@ import ca.weblite.webview.EditingCommand;
 import ca.weblite.webview.GdkInput;
 import ca.weblite.webview.JavascriptFunction;
 import ca.weblite.webview.OffscreenWebView;
+import ca.weblite.webview.PopupDispatcher;
 import ca.weblite.webview.WebView;
 import ca.weblite.webview.WebViewDialogCallback;
 import ca.weblite.webview.WebViewPopupCallback;
@@ -207,25 +208,23 @@ public class WebViewLightweightComponent extends WebViewComponent {
     public void addNotify() {
         super.addNotify();
         if (engine != null) return;
-        if (pendingAdoptPopupId != 0L) {
-            // Popup adoption for the lightweight / offscreen engine lands in
-            // Canvas 19 (STORY-005-002, Linux).  Until then, adopting into an
-            // offscreen component is unsupported: leave the engine null (blank
-            // component) rather than silently creating an unrelated engine.
-            // The retained native child is reclaimed by the opener's grace
-            // backstop.  The reference adoption backend (Canvas 18) is macOS
-            // heavyweight.
-            System.err.println(
-                "[webview] popup adoption is not yet implemented for the "
-                + "lightweight/offscreen engine (Canvas 19); popupId "
-                + pendingAdoptPopupId + " will be reclaimed. Use the "
-                + "heavyweight mode for adoption on the reference (macOS) "
-                + "backend.");
-            return;
-        }
         int w = Math.max(1, getWidth());
         int h = Math.max(1, getHeight());
-        engine = OffscreenWebView.create(w, h, debug);
+        if (pendingAdoptPopupId != 0L) {
+            // Canvas 19 (lightweight/offscreen coverage): adopt the retained
+            // popup child into THIS offscreen component instead of creating a
+            // fresh engine.  The adopted child reuses the opener-linked
+            // WebKitGTK view inside a GtkOffscreenWindow, preserving its
+            // in-flight (POST) navigation + window.opener linkage.  The
+            // retained child lives in the shared native registry, so a popup
+            // raised by either a heavyweight or lightweight opener can be
+            // adopted here.  A 0 native peer (unknown/consumed id or
+            // unsupported platform) surfaces as IllegalStateException from
+            // OffscreenWebView.adopt.
+            engine = OffscreenWebView.adopt(w, h, pendingAdoptPopupId, debug);
+        } else {
+            engine = OffscreenWebView.create(w, h, debug);
+        }
         if (engine == null) {
             // Unsupported platform or native failure -- leave the
             // engine null so subsequent ops are no-ops.  paintComponent
@@ -344,6 +343,22 @@ public class WebViewLightweightComponent extends WebViewComponent {
                 popupDispatcher.dispatchPopupClosed(popupId, targetUrl, pageUrl);
             }
         });
+        // Let the dispatcher discard retained-but-unadopted popup children
+        // (PopupDisposition.ADOPT reclaim) through this offscreen engine.
+        // Mirrors WebViewHeavyweightComponent's reclaim sink; the native side
+        // converges on the same shared gtk_discard_popup.
+        popupDispatcher.setReclaimSink(new PopupDispatcher.ReclaimSink() {
+            @Override
+            public void discard(long popupId) {
+                OffscreenWebView e = engine;
+                if (e == null) return;
+                try {
+                    e.discardRetainedPopup(popupId);
+                } catch (RuntimeException ignored) {
+                    // Reclaim is best-effort; teardown must not fail on it.
+                }
+            }
+        });
         for (String js : pendingInit) {
             engine.addOnBeforeLoad(js);
         }
@@ -362,7 +377,14 @@ public class WebViewLightweightComponent extends WebViewComponent {
         if (pendingUserAgent != null) {
             engine.setUserAgent(pendingUserAgent);
         }
-        engine.navigate(pendingUrl);
+        // An adopted popup already carries the engine's own in-flight
+        // navigation (the original request WebKit drove into the child, POST
+        // body intact); navigating pendingUrl here would clobber it.  Only
+        // navigate for the normal engine-creating path — mirrors
+        // WebViewHeavyweightComponent's adopt guard.
+        if (pendingAdoptPopupId == 0L) {
+            engine.navigate(pendingUrl);
+        }
         repaintTimer = new Timer(REPAINT_INTERVAL_MS, e -> repaint());
         repaintTimer.setRepeats(true);
         repaintTimer.start();

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -1784,6 +1784,15 @@ static void gtk_set_popup_callback(Engine *e, JNIEnv *env, jobject cb) {
     }
 }
 
+// Canvas 21: override the WebKitGTK User-Agent (changes the HTTP header).
+// ua == nullptr restores the engine default.  Takes effect on the next
+// navigation.
+static void gtk_set_user_agent(Engine *e, const char *ua) {
+    if (!e || !e->web) return;
+    WebKitSettings *s = webkit_web_view_get_settings(WEBKIT_WEB_VIEW(e->web));
+    if (s) webkit_settings_set_user_agent(s, ua);
+}
+
 // ===========================================================================
 // Linux / GTK lightweight (offscreen) engine
 //
@@ -2117,6 +2126,13 @@ static void gtk_off_set_popup_callback(OffEngine *e, JNIEnv *env,
     if (cb) {
         e->popup_callback = env->NewGlobalRef(cb);
     }
+}
+
+// Canvas 21: offscreen counterpart to gtk_set_user_agent.
+static void gtk_off_set_user_agent(OffEngine *e, const char *ua) {
+    if (!e || !e->web) return;
+    WebKitSettings *s = webkit_web_view_get_settings(WEBKIT_WEB_VIEW(e->web));
+    if (s) webkit_settings_set_user_agent(s, ua);
 }
 
 static void gtk_off_init_script(OffEngine *e, std::string js) {
@@ -4695,6 +4711,20 @@ static void cocoa_discard_popup(jlong popupId) {
     });
 }
 
+// Canvas 21: override the WKWebView's User-Agent (changes the HTTP header).
+// ua == nullptr clears the override (customUserAgent = nil -> engine default).
+// Runs on the AppKit main thread; takes effect on the next navigation.
+static void cocoa_set_user_agent(Engine *e, const char *ua) {
+    if (!e) return;
+    bool has = (ua != nullptr);
+    std::string s = has ? ua : std::string();
+    cocoa_run_on_main_async([e, s, has] {
+        if (e->destroyed.load() || !e->webview) return;
+        id v = has ? ns_str(s.c_str()) : (id)nullptr;
+        msg<void, id>(e->webview, sel("setCustomUserAgent:"), v);
+    });
+}
+
 // Asynchronous engine destroy.  Returns immediately on the calling
 // thread (typically the EDT) after a small Java-side cleanup; the
 // AppKit teardown, view-hierarchy removal, KVO observer unregister,
@@ -5588,6 +5618,34 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
     // returns null there so this is never reached.
     (void)env; (void)cb;
 #endif
+}
+
+// Custom User-Agent registration — Canvas 21.  ua == null clears the override
+// (engine default).  Takes effect on the next navigation.
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1user_1agent
+  (JNIEnv *env, jclass, jlong wv, jstring ua) {
+    if (wv == 0) return;
+    const char *s = ua ? env->GetStringUTFChars(ua, nullptr) : nullptr;
+#ifdef WEBVIEW_GTK
+    embed::gtk_set_user_agent((embed::Engine *)wv, s);
+#elif defined(WEBVIEW_COCOA)
+    embed::cocoa_set_user_agent((embed::Engine *)wv, s);
+#else
+    (void)wv;
+#endif
+    if (ua && s) env->ReleaseStringUTFChars(ua, s);
+}
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1set_1user_1agent
+  (JNIEnv *env, jclass, jlong peer, jstring ua) {
+    if (peer == 0) return;
+    const char *s = ua ? env->GetStringUTFChars(ua, nullptr) : nullptr;
+#ifdef WEBVIEW_GTK
+    embed::gtk_off_set_user_agent((embed::OffEngine *)peer, s);
+#else
+    (void)peer;
+#endif
+    if (ua && s) env->ReleaseStringUTFChars(ua, s);
 }
 
 } // extern "C"

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -5170,32 +5170,12 @@ JNIEXPORT jlong JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1cr
 #endif
 }
 
-// Canvas 18: adopt a retained popup child into `parent`'s surface.  macOS
-// reparents the retained WKWebView; Linux (Canvas 19) and Windows (Canvas 20)
-// land their reparent later, so this returns 0 there (EmbeddedWebView.adopt
-// turns 0 into a documented IllegalStateException).
-JNIEXPORT jlong JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1adopt_1popup
-  (JNIEnv *env, jclass, jobject parent, jlong popupId, jint debug) {
-#ifdef WEBVIEW_COCOA
-    Engine *e = embed::cocoa_adopt_popup(env, parent, popupId, debug);
-    return (jlong)e;
-#else
-    (void)env; (void)parent; (void)popupId; (void)debug;
-    return 0;
-#endif
-}
-
-// Canvas 18: discard a retained-but-unadopted popup child (ADOPT reclaim).
-// `w` (any live embed peer from the same process) is unused on macOS because
-// the retained-popup registry is process-global keyed by popupId.
-JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1discard_1popup
-  (JNIEnv *, jclass, jlong /*w*/, jlong popupId) {
-#ifdef WEBVIEW_COCOA
-    embed::cocoa_discard_popup(popupId);
-#else
-    (void)popupId;
-#endif
-}
+// NOTE: the popup-adoption JNI bridges (webview_embed_adopt_popup /
+// webview_embed_discard_popup) are defined INSIDE the `extern "C"` block below
+// (next to webview_embed_set_user_agent), not here.  They are newly-added
+// methods with no prototype in the generated JNI header, so — like the dialog
+// setters — they must be wrapped in `extern "C"` or the JVM can't resolve
+// them (UnsatisfiedLinkError).  See the block comment above that `extern "C"`.
 
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1destroy
   (JNIEnv *, jclass, jlong wv) {
@@ -5617,6 +5597,33 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
     // macOS / Windows have no offscreen engine; OffscreenWebView.create
     // returns null there so this is never reached.
     (void)env; (void)cb;
+#endif
+}
+
+// Popup-adoption JNI bridges — Canvas 18.  Must live inside this `extern "C"`
+// block (they are newly-added methods with no generated-header prototype, so
+// C++ name-mangling would otherwise make them unresolvable from the JVM —
+// UnsatisfiedLinkError).  macOS reparents the retained WKWebView; Linux
+// (Canvas 19) and Windows (Canvas 20) land their reparent later, so those
+// return 0 (EmbeddedWebView.adopt turns 0 into a documented
+// IllegalStateException).
+JNIEXPORT jlong JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1adopt_1popup
+  (JNIEnv *env, jclass, jobject parent, jlong popupId, jint debug) {
+#ifdef WEBVIEW_COCOA
+    Engine *e = embed::cocoa_adopt_popup(env, parent, popupId, debug);
+    return (jlong)e;
+#else
+    (void)env; (void)parent; (void)popupId; (void)debug;
+    return 0;
+#endif
+}
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1discard_1popup
+  (JNIEnv *, jclass, jlong /*w*/, jlong popupId) {
+#ifdef WEBVIEW_COCOA
+    embed::cocoa_discard_popup(popupId);
+#else
+    (void)popupId;
 #endif
 }
 

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -2218,8 +2218,20 @@ static void off_engine_on_message(OffEngine *e, const char *msg) {
     if (detach) e->jvm->DetachCurrentThread();
 }
 
+// Canvas 19 (lightweight/offscreen coverage): when `existing_web` is non-null
+// (the offscreen popup-adoption path) the engine REUSES that already-created
+// WebKitWebView instead of allocating a fresh one — preserving its in-flight
+// POST navigation + window.opener linkage — while still building the
+// GtkOffscreenWindow and performing the identical external-message / dialog /
+// popup / IM-disable / focus-synth / container / show wiring.  `existing_web`
+// must carry no GTK parent (the ADOPT branch never adds it to a container);
+// gtk_container_add below adopts it into the offscreen window.  Mirrors
+// gtk_create_engine's existing_web reuse.  The caller (gtk_off_adopt_popup)
+// has already disconnected the child's old PopupEngine-scoped signal handlers
+// so the fresh OffEngine-scoped handlers connected below are the only ones.
 static OffEngine *gtk_off_create_engine(JNIEnv *env,
-                                        int width, int height, jint debug) {
+                                        int width, int height, jint debug,
+                                        GtkWidget *existing_web = nullptr) {
     if (width < 1) width = 1;
     if (height < 1) height = 1;
     auto *e = new OffEngine();
@@ -2231,7 +2243,10 @@ static OffEngine *gtk_off_create_engine(JNIEnv *env,
     bool ok = false;
     GtkPump::instance().run_sync([&] {
         e->window = gtk_offscreen_window_new();
-        e->web = webkit_web_view_new();
+        // Canvas 19: reuse the retained popup child (adoption) or create fresh.
+        // The reused child already carries its opener linkage + in-flight POST
+        // navigation from handle_create_web_view.
+        e->web = existing_web ? existing_web : webkit_web_view_new();
         e->manager =
             webkit_web_view_get_user_content_manager(WEBKIT_WEB_VIEW(e->web));
 
@@ -2457,6 +2472,122 @@ static void gtk_off_set_user_agent(OffEngine *e, const char *ua) {
     if (!e || !e->web) return;
     WebKitSettings *s = webkit_web_view_get_settings(WEBKIT_WEB_VIEW(e->web));
     if (s) webkit_settings_set_user_agent(s, ua);
+}
+
+// ---------------------------------------------------------------------------
+// Canvas 19 (lightweight/offscreen coverage): popup adoption into a
+// caller-supplied lightweight WebViewComponent's offscreen surface.  The
+// offscreen twin of gtk_adopt_popup — same two-phase model, same shared
+// g_gtk_retained_popups registry, same shared gtk_discard_popup reclaim.
+//
+//   Phase 1 (handle_create_web_view ADOPT branch, above): the opener-linked
+//     child WebKitWebView is created windowless, retained under
+//     g_gtk_retained_popups, and onPopupAdoptable is fired.  This is identical
+//     whether the opener was heavyweight (Engine) or lightweight (OffEngine) —
+//     both route `create` through the shared handle_create_web_view.
+//   Phase 2 (here): the application's lightweight WebViewComponent.adoptPopup
+//     peer attach calls webview_offscreen_adopt_popup -> gtk_off_adopt_popup,
+//     which claims the retained child (adopt-once), builds a normal OffEngine
+//     that REUSES the child web view inside a GtkOffscreenWindow (via
+//     gtk_off_create_engine's existing_web parameter), transfers the inherited
+//     callbacks, and frees the PopupEngine shell.
+//
+// ON-DEVICE VALIDATION REQUIRED (no GTK toolchain in the generating sandbox):
+//   * the ownership/reparent handoff — the child, held windowless by
+//     g_object_ref_sink, is gtk_container_add-ed into a fresh
+//     GtkOffscreenWindow (which takes a container ref); the retained ref is
+//     then dropped.  Unlike the heavyweight adopt there is NO XReparentWindow
+//     into a foreign on-screen X11 tree — the child lives in an offscreen
+//     toplevel — but the refcount balance (offscreen window ref + WebKit's own
+//     ref) still needs on-device confirmation (no premature finalization /
+//     use-after-destroy).
+//   * blit of a mid-navigation child — the reused child may be mid-POST
+//     navigation when moved from windowless into the offscreen window; verify
+//     the snapshot/blit pipeline (cairo surface -> BufferedImage at ~30Hz,
+//     driven by the Java component repaint timer) begins producing correct
+//     frames and does not race the reparent.
+//   * the g_signal_handlers_disconnect_by_data handoff (no double `create`
+//     handling, no dangling PopupEngine dereference).
+// ---------------------------------------------------------------------------
+static OffEngine *gtk_off_adopt_popup(JNIEnv *env, jlong popupId,
+                                      jint width, jint height, jint debug) {
+    // Claim the retained child (adopt-once): remove under lock so a second
+    // adopt of the same id finds nothing and returns null (-> JNI 0 -> Java
+    // IllegalStateException).  Shares the SAME registry the heavyweight
+    // gtk_adopt_popup claims from — the opener may have been either engine.
+    PopupEngine *pe = nullptr;
+    {
+        std::lock_guard<std::mutex> lk(g_gtk_retained_popups_mutex);
+        auto it = g_gtk_retained_popups.find(popupId);
+        if (it == g_gtk_retained_popups.end()) return nullptr;
+        pe = it->second;
+        g_gtk_retained_popups.erase(it);
+    }
+    if (!pe || !pe->web) {
+        // Nothing usable to adopt; drop the empty shell if present.
+        if (pe) delete pe;
+        return nullptr;
+    }
+
+    GtkWidget *childw = GTK_WIDGET(pe->web);
+
+    // Disconnect the child's PopupEngine-scoped signal handlers (create /
+    // script-dialog / run-file-chooser / close — ready-to-show was never
+    // connected for an ADOPT child) BEFORE gtk_off_create_engine reconnects
+    // its own OffEngine-scoped handlers, so each signal has exactly one
+    // handler and none dereferences the PopupEngine we are about to free.
+    GtkPump::instance().run_sync([&] {
+        g_signal_handlers_disconnect_by_data(pe->web, pe);
+    });
+
+    // Build the offscreen engine reusing the retained child web view.  This
+    // creates the GtkOffscreenWindow, wires the external-message / dialog /
+    // popup / IM-disable / focus-synth pipeline, and gtk_container_add-s the
+    // child into the offscreen window (taking a container ref) — identical to
+    // a normal offscreen create except the web view is reused rather than
+    // allocated.
+    OffEngine *e =
+        gtk_off_create_engine(env, (int)width, (int)height, debug, childw);
+    if (!e) {
+        // Create failed.  Reconnect the PopupEngine handlers and re-retain so
+        // the child is reclaimable and not lost; report failure to Java
+        // (0 -> IllegalStateException).  Mirrors gtk_adopt_popup's failure
+        // path exactly.
+        GtkPump::instance().run_sync([&] {
+            g_signal_connect(pe->web, "create",
+                             (GCallback)on_create_web_view_popup, pe);
+            g_signal_connect(pe->web, "script-dialog",
+                             (GCallback)on_script_dialog_popup, pe);
+            g_signal_connect(pe->web, "run-file-chooser",
+                             (GCallback)on_run_file_chooser_popup, pe);
+            g_signal_connect(pe->web, "close",
+                             (GCallback)on_close_popup, pe);
+        });
+        std::lock_guard<std::mutex> lk(g_gtk_retained_popups_mutex);
+        g_gtk_retained_popups[popupId] = pe;
+        return nullptr;
+    }
+
+    // Transfer the inherited popup / dialog callbacks from the shell to the
+    // engine so nested popups + dialogs from the adopted view keep working
+    // immediately.  These are strong JNI global refs; ownership moves to the
+    // OffEngine (nulled on pe so delete pe does not double-free, and freed
+    // later by gtk_off_destroy_engine or overwritten by the component's own
+    // gtk_off_set_popup_callback / gtk_off_set_dialog_callback at attach).
+    e->popup_callback = pe->popup_callback;
+    pe->popup_callback = nullptr;
+    e->dialog_callback = pe->dialog_callback;
+    pe->dialog_callback = nullptr;
+
+    // Drop the retained strong reference taken by the ADOPT branch's
+    // g_object_ref_sink — the offscreen window now holds a container ref on
+    // the child.  Runs on the GTK thread for refcount-thread-safety.
+    GtkPump::instance().run_sync([&] {
+        g_object_unref(childw);
+    });
+
+    delete pe;
+    return e;
 }
 
 static void gtk_off_init_script(OffEngine *e, std::string js) {
@@ -5984,6 +6115,36 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
     (void)peer;
 #endif
     if (ua && s) env->ReleaseStringUTFChars(ua, s);
+}
+
+// Offscreen popup-adoption JNI bridges — Canvas 19 (Linux lightweight
+// coverage).  Must live inside this `extern "C"` block (they are newly-added
+// methods with no generated-header prototype, so C++ name-mangling would
+// otherwise make them unresolvable from the JVM — UnsatisfiedLinkError; the
+// exact bug already hit and fixed for the dialog setters and the heavyweight
+// adopt/discard bridges).  Linux reuses the retained WebKitGTK child inside a
+// GtkOffscreenWindow via gtk_off_adopt_popup; the reclaim path reuses the
+// SHARED gtk_discard_popup (the retained child is the same PopupEngine in the
+// same registry).  macOS / Windows offscreen engines are stubs, so adopt
+// returns 0 (OffscreenWebView.adopt turns 0 into an IllegalStateException) and
+// discard is a no-op.
+JNIEXPORT jlong JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1adopt_1popup
+  (JNIEnv *env, jclass, jint width, jint height, jlong popupId, jint debug) {
+#ifdef WEBVIEW_GTK
+    return (jlong)embed::gtk_off_adopt_popup(env, popupId, width, height, debug);
+#else
+    (void)env; (void)width; (void)height; (void)popupId; (void)debug;
+    return 0;
+#endif
+}
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1discard_1popup
+  (JNIEnv *, jclass, jlong /*peer*/, jlong popupId) {
+#ifdef WEBVIEW_GTK
+    embed::gtk_discard_popup(popupId);
+#else
+    (void)popupId;
+#endif
 }
 
 } // extern "C"

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -881,6 +881,20 @@ struct PopupEngine {
     jlong popup_id = 0;
 };
 
+// Canvas 19 (popup adoption — Linux/WebKitGTK coverage of the Canvas 18 Java
+// contract): retained-but-unadopted popup child engines, keyed by popup_id.
+// Populated by handle_create_web_view's ADOPT branch (which creates the
+// opener-linked WebKit child but NO GtkWindow and holds an explicit strong
+// reference on the widget), drained by gtk_adopt_popup (reparent into a
+// caller-supplied WebViewComponent's realized X11 surface) or gtk_discard_popup
+// (reclaim an unadopted child).  Guarded by its own mutex; the GTK counterpart
+// of the macOS g_retained_popups map.  ON-DEVICE VALIDATION REQUIRED: this file
+// has no GTK toolchain in the generating sandbox — the reparent + widget
+// ownership handoff below must be exercised on a real WebKitGTK/X11 stack
+// before release (see Canvas 19 Safeguards).
+static std::mutex g_gtk_retained_popups_mutex;
+static std::map<jlong, PopupEngine *> g_gtk_retained_popups;
+
 // Synchronous allow/deny hop into Java on the GTK main thread.  Returns false
 // on null callback, attach failure, or any exception (block-on-error default).
 static bool fire_popup_requested(JavaVM *jvm, jobject cb,
@@ -922,6 +936,54 @@ static bool fire_popup_requested(JavaVM *jvm, jobject cb,
     return allow;
 }
 
+// Canvas 19: synchronous DISPOSITION hop into Java on the GTK main thread.
+// Calls WebViewPopupCallback.onPopupDisposition and returns the
+// PopupDisposition ordinal (0 = BLOCK, 1 = NATIVE_WINDOW, 2 = ADOPT).  Mirrors
+// the macOS fire_popup_disposition and this file's fire_popup_requested; a null
+// callback / attach failure / thrown decision all yield BLOCK (0).  Runs
+// synchronously on the GTK main thread (the `create` handler must return the
+// child before yielding to WebKit) and MUST NOT be marshalled to the EDT.  The
+// default WebViewPopupCallback.onPopupDisposition derives from onPopupRequested,
+// so legacy Canvas 16 boolean handlers still map to BLOCK / NATIVE_WINDOW.
+static int fire_popup_disposition(JavaVM *jvm, jobject cb,
+                                  const char *url, const char *name,
+                                  bool gesture, int w, int h,
+                                  const char *page) {
+    if (!jvm || !cb) return 0; // BLOCK
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return 0;
+        detach = true;
+    }
+    int disposition = 0; // BLOCK
+    jstring ju = env->NewStringUTF(url ? url : "");
+    jstring jn = env->NewStringUTF(name ? name : "");
+    jstring jp = env->NewStringUTF(page ? page : "");
+    jclass cls = env->GetObjectClass(cb);
+    if (cls) {
+        jmethodID mid = env->GetMethodID(cls, "onPopupDisposition",
+            "(Ljava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)I");
+        if (mid) {
+            jint r = env->CallIntMethod(cb, mid, ju, jn,
+                gesture ? JNI_TRUE : JNI_FALSE, (jint)w, (jint)h, jp);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+                r = 0;
+            }
+            disposition = (int)r;
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (ju) env->DeleteLocalRef(ju);
+    if (jn) env->DeleteLocalRef(jn);
+    if (jp) env->DeleteLocalRef(jp);
+    if (detach) jvm->DetachCurrentThread();
+    return disposition;
+}
+
 // Fire onPopupOpened.  CallVoidMethod (fire-and-forget); the Java dispatcher
 // marshals to the EDT via invokeLater so this does not block the GTK main
 // thread.
@@ -943,6 +1005,49 @@ static void fire_gtk_popup_opened(JavaVM *jvm, jobject cb, jlong popup_id,
     jclass cls = env->GetObjectClass(cb);
     if (cls) {
         jmethodID mid = env->GetMethodID(cls, "onPopupOpened",
+            "(JLjava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)V");
+        if (mid) {
+            env->CallVoidMethod(cb, mid, popup_id, ju, jn,
+                gesture ? JNI_TRUE : JNI_FALSE, (jint)w, (jint)h, jp);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (ju) env->DeleteLocalRef(ju);
+    if (jn) env->DeleteLocalRef(jn);
+    if (jp) env->DeleteLocalRef(jp);
+    if (detach) jvm->DetachCurrentThread();
+}
+
+// Canvas 19: notify Java (WebViewPopupCallback.onPopupAdoptable) that a popup
+// child has been retained (windowless) and is ready to adopt into a
+// WebViewComponent.  Unlike the macOS fire_popup_notify_adoptable — which hops
+// onto a detached worker thread because it is invoked while the AppKit main
+// thread is blocked in the create delegate — the GTK create handler already
+// runs OFF the EDT on the GTK main thread, so a direct CallVoidMethod is safe
+// (the Java PopupDispatcher marshals popupAdoptable to the EDT via invokeLater
+// itself).  Same fire-and-forget shape as fire_gtk_popup_opened.
+static void fire_popup_notify_adoptable(JavaVM *jvm, jobject cb, jlong popup_id,
+                                        const char *url, const char *name,
+                                        bool gesture, int w, int h,
+                                        const char *page) {
+    if (!jvm || !cb) return;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return;
+        detach = true;
+    }
+    jstring ju = env->NewStringUTF(url ? url : "");
+    jstring jn = env->NewStringUTF(name ? name : "");
+    jstring jp = env->NewStringUTF(page ? page : "");
+    jclass cls = env->GetObjectClass(cb);
+    if (cls) {
+        jmethodID mid = env->GetMethodID(cls, "onPopupAdoptable",
             "(JLjava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)V");
         if (mid) {
             env->CallVoidMethod(cb, mid, popup_id, ju, jn,
@@ -1029,29 +1134,58 @@ static GtkWidget *handle_create_web_view(JavaVM *jvm, jobject popup_cb,
     const char *page = opener ? webkit_web_view_get_uri(opener) : nullptr;
     if (!page) page = "";
 
-    // Synchronous allow/deny.  Size is not known until ready-to-show, so pass
-    // -1/-1 here (matching the event contract's "unspecified" sentinel).
-    if (!fire_popup_requested(jvm, popup_cb, uri, "", gesture, -1, -1, page))
-        return NULL;
+    // Canvas 19: synchronous DISPOSITION hop into Java (GTK main -> JNI).
+    // 0 = BLOCK (return NULL), 1 = NATIVE_WINDOW (engine-owned GtkWindow, the
+    // Canvas 16 path), 2 = ADOPT (retain the child windowless, notify Java to
+    // reparent it into a caller-supplied WebViewComponent).  Size is not known
+    // until ready-to-show, so pass -1/-1 (the event contract's "unspecified"
+    // sentinel).  The default WebViewPopupCallback.onPopupDisposition derives
+    // from onPopupRequested, so legacy Canvas 16 boolean handlers still map to
+    // BLOCK / NATIVE_WINDOW.
+    int disposition =
+        fire_popup_disposition(jvm, popup_cb, uri, "", gesture, -1, -1, page);
+    if (disposition == 0)
+        return NULL; // BLOCK
+    const bool adopt = (disposition == 2);
 
     // Create the child LINKED to the opener (window.opener / postMessage).
+    // WebKit drives the ORIGINAL navigation-action request (POST verb + body)
+    // into this child regardless of disposition, preserving POST and
+    // window.opener for both NATIVE_WINDOW and ADOPT.
     GtkWidget *childw = webkit_web_view_new_with_related_view(opener);
     if (!childw) return NULL;
     WebKitWebView *child = WEBKIT_WEB_VIEW(childw);
 
-    // Host it in an engine-owned native top-level window.
-    GtkWidget *win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-    gtk_window_set_title(GTK_WINDOW(win), "Popup");
-    gtk_container_add(GTK_CONTAINER(win), childw);
+    // NATIVE_WINDOW: host the child in an engine-owned native top-level window
+    // (gtk_container_add sinks the widget's floating reference — the window owns
+    // it).  ADOPT: create NO window; instead take an explicit strong reference
+    // so the child survives with no GTK parent until gtk_adopt_popup reparents
+    // it.  g_object_ref_sink clears the floating flag (if WebKit has not already
+    // done so on the value we return from `create`) and gives us an owning ref
+    // held on behalf of g_gtk_retained_popups; it is balanced by the
+    // g_object_unref in gtk_adopt_popup (once the adopting window has taken its
+    // own container ref) or the gtk_widget_destroy + g_object_unref in
+    // gtk_discard_popup.  ON-DEVICE VALIDATION REQUIRED: this dual ownership
+    // (our ref + WebKit's own reference on the returned child) mirrors the
+    // NATIVE_WINDOW container+WebKit refcounting, but the windowless variant is
+    // unexercised in this sandbox.
+    GtkWidget *win = nullptr;
+    if (!adopt) {
+        win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+        gtk_window_set_title(GTK_WINDOW(win), "Popup");
+        gtk_container_add(GTK_CONTAINER(win), childw);
+    } else {
+        g_object_ref_sink(childw);
+    }
 
     PopupEngine *pe = new PopupEngine();
-    pe->window = win;
+    pe->window = win;              // nullptr for ADOPT
     pe->web = child;
     pe->jvm = jvm;
     pe->popup_id = (jlong)(intptr_t)pe;
 
     // Inherit fresh global refs so the popup can raise dialogs / nested popups
-    // and notify onPopupClosed even after the opener is gone.
+    // and notify onPopupClosed / onPopupAdoptable even after the opener is gone.
     JNIEnv *env = nullptr;
     bool detach = false;
     if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
@@ -1064,19 +1198,37 @@ static GtkWidget *handle_create_web_view(JavaVM *jvm, jobject popup_cb,
         if (detach) jvm->DetachCurrentThread();
     }
 
-    // Nested popups + dialogs from inside the popup, and the show/close hooks.
+    // Nested popups + dialogs from inside the popup, and the close hook, wire up
+    // for BOTH dispositions.  ready-to-show (which sizes + shows the GtkWindow
+    // and fires onPopupOpened) is connected ONLY for NATIVE_WINDOW — an ADOPT
+    // child must never create/show a window; it surfaces via onPopupAdoptable
+    // and is shown only once reparented into the adopting component.
     g_signal_connect(child, "create",
                      (GCallback)on_create_web_view_popup, pe);
     g_signal_connect(child, "script-dialog",
                      (GCallback)on_script_dialog_popup, pe);
     g_signal_connect(child, "run-file-chooser",
                      (GCallback)on_run_file_chooser_popup, pe);
-    g_signal_connect(child, "ready-to-show",
-                     (GCallback)on_ready_to_show_popup, pe);
     g_signal_connect(child, "close",
                      (GCallback)on_close_popup, pe);
+    if (!adopt) {
+        g_signal_connect(child, "ready-to-show",
+                         (GCallback)on_ready_to_show_popup, pe);
+    } else {
+        // Retain the windowless child and notify Java it is adoptable.  The
+        // dispatcher marshals popupAdoptable to the EDT; the application then
+        // calls WebViewComponent.adoptPopup(popup_id), whose peer attach calls
+        // webview_embed_adopt_popup -> gtk_adopt_popup with this popup_id.
+        {
+            std::lock_guard<std::mutex> lk(g_gtk_retained_popups_mutex);
+            g_gtk_retained_popups[pe->popup_id] = pe;
+        }
+        fire_popup_notify_adoptable(jvm, popup_cb, pe->popup_id, uri, "",
+                                    gesture, -1, -1, page);
+    }
 
-    // WebKit adopts the floating reference on the returned view.
+    // WebKit adopts (refs) the returned view.  For ADOPT we additionally hold
+    // our own ref (above), so the child is not destroyed while windowless.
     return childw;
 }
 
@@ -1085,6 +1237,12 @@ static GtkWidget *handle_create_web_view(JavaVM *jvm, jobject popup_cb,
 static void on_ready_to_show_popup(WebKitWebView *web, gpointer user_data) {
     PopupEngine *pe = static_cast<PopupEngine *>(user_data);
     if (!pe) return;
+    // Canvas 19: an ADOPT child is windowless (pe->window == nullptr) and must
+    // never show a window or fire onPopupOpened — it surfaces via
+    // onPopupAdoptable instead.  handle_create_web_view does not connect this
+    // handler for ADOPT, but guard here belt-and-suspenders in case WebKit
+    // emits ready-to-show through another path.
+    if (!pe->window) return;
     int W = 500, H = 650;
     WebKitWindowProperties *props = webkit_web_view_get_window_properties(web);
     if (props) {
@@ -1198,7 +1356,15 @@ static void engine_on_message(Engine *e, const char *msg) {
     if (detach) e->jvm->DetachCurrentThread();
 }
 
-static Engine *gtk_create_engine(JNIEnv *env, jobject component, jint debug) {
+// Build a heavyweight engine embedded in `component`'s realized X11 surface.
+// Canvas 19: when `existing_web` is non-null (the popup-adoption path) the
+// engine REUSES that already-created WebKitWebView instead of allocating a
+// fresh one — preserving its in-flight POST navigation + window.opener linkage
+// — while still performing the identical JAWT/XReparent/window/frame-clock/
+// signal wiring.  `existing_web` must carry no GTK parent (the ADOPT branch
+// never adds it to a container); gtk_container_add below adopts it.
+static Engine *gtk_create_engine(JNIEnv *env, jobject component, jint debug,
+                                 GtkWidget *existing_web = nullptr) {
     JawtLock lock(env, component);
     if (!lock.ok || !lock.dsi->platformInfo) return nullptr;
     auto *info = (JAWT_X11DrawingSurfaceInfo *)lock.dsi->platformInfo;
@@ -1279,7 +1445,16 @@ static Engine *gtk_create_engine(JNIEnv *env, jobject component, jint debug) {
         XReparentWindow(gdkd, child, e->parent_xid, 0, 0);
         XSync(gdkd, False);
 
-        e->web = webkit_web_view_new();
+        // Canvas 19: reuse the retained popup child (adoption) or create fresh.
+        // The reused child already carries its opener linkage + in-flight POST
+        // navigation from handle_create_web_view; the caller (gtk_adopt_popup)
+        // has already disconnected the child's old PopupEngine signal handlers
+        // so the fresh engine-scoped handlers connected below are the only ones.
+        if (existing_web) {
+            e->web = existing_web;
+        } else {
+            e->web = webkit_web_view_new();
+        }
         e->manager =
             webkit_web_view_get_user_content_manager(WEBKIT_WEB_VIEW(e->web));
 
@@ -1791,6 +1966,155 @@ static void gtk_set_user_agent(Engine *e, const char *ua) {
     if (!e || !e->web) return;
     WebKitSettings *s = webkit_web_view_get_settings(WEBKIT_WEB_VIEW(e->web));
     if (s) webkit_settings_set_user_agent(s, ua);
+}
+
+// ---------------------------------------------------------------------------
+// Canvas 19: popup adoption — reparent a retained-but-unadopted popup child
+// into a caller-supplied WebViewComponent's realized X11 surface.
+//
+// Two-phase, mirroring the macOS cocoa_adopt_popup / cocoa_discard_popup:
+//   Phase 1 (handle_create_web_view ADOPT branch, above): the opener-linked
+//     child WebKitWebView is created windowless, retained under
+//     g_gtk_retained_popups, and onPopupAdoptable is fired.
+//   Phase 2 (here): the application's WebViewComponent.adoptPopup peer attach
+//     calls webview_embed_adopt_popup -> gtk_adopt_popup, which claims the
+//     retained child (adopt-once), builds a normal heavyweight Engine for the
+//     new parent that REUSES the child web view (via gtk_create_engine's
+//     existing_web parameter), transfers the inherited callbacks, and frees the
+//     PopupEngine shell.  gtk_discard_popup is the reclaim path for a child that
+//     was decided ADOPT but never adopted.
+//
+// ON-DEVICE VALIDATION REQUIRED (no GTK toolchain in the generating sandbox):
+//   * the X11 XReparentWindow of the reused child under the new AWT canvas
+//     window (performed inside gtk_create_engine);
+//   * the widget ownership handoff — our retained g_object_ref_sink ref, the
+//     new window's container ref, and WebKit's own reference on the child;
+//   * whether the child's in-flight POST navigation continues to render after
+//     being reparented from windowless to the adopting surface.
+// ---------------------------------------------------------------------------
+static Engine *gtk_adopt_popup(JNIEnv *env, jobject parent, jlong popupId,
+                               jint debug) {
+    // Claim the retained child (adopt-once): remove under lock so a second
+    // adopt of the same id finds nothing and returns null (-> JNI 0 -> Java
+    // IllegalStateException).
+    PopupEngine *pe = nullptr;
+    {
+        std::lock_guard<std::mutex> lk(g_gtk_retained_popups_mutex);
+        auto it = g_gtk_retained_popups.find(popupId);
+        if (it == g_gtk_retained_popups.end()) return nullptr;
+        pe = it->second;
+        g_gtk_retained_popups.erase(it);
+    }
+    if (!pe || !pe->web) {
+        // Nothing usable to adopt; drop the empty shell if present.
+        if (pe) delete pe;
+        return nullptr;
+    }
+
+    GtkWidget *childw = GTK_WIDGET(pe->web);
+
+    // Disconnect the child's PopupEngine-scoped signal handlers (create /
+    // script-dialog / run-file-chooser / close — ready-to-show was never
+    // connected for an ADOPT child) BEFORE the engine reconnects its own
+    // engine-scoped handlers, so each signal has exactly one handler and none
+    // dereferences the PopupEngine we are about to free.
+    GtkPump::instance().run_sync([&] {
+        g_signal_handlers_disconnect_by_data(pe->web, pe);
+    });
+
+    // Build the heavyweight engine reusing the retained child web view.  This
+    // does the JAWT lock, XReparent, window creation, frame-clock, and fresh
+    // engine-scoped signal wiring — identical to a normal create except the web
+    // view is reused rather than allocated.  gtk_create_engine's epilogue
+    // gtk_container_add takes a container ref on the child.
+    Engine *e = gtk_create_engine(env, parent, debug, childw);
+    if (!e) {
+        // Attach failed (e.g. JAWT lock / non-X11 surface).  Reconnect the
+        // PopupEngine handlers and re-retain so the child is reclaimable and
+        // not lost; report failure to Java (0 -> IllegalStateException).
+        GtkPump::instance().run_sync([&] {
+            g_signal_connect(pe->web, "create",
+                             (GCallback)on_create_web_view_popup, pe);
+            g_signal_connect(pe->web, "script-dialog",
+                             (GCallback)on_script_dialog_popup, pe);
+            g_signal_connect(pe->web, "run-file-chooser",
+                             (GCallback)on_run_file_chooser_popup, pe);
+            g_signal_connect(pe->web, "close",
+                             (GCallback)on_close_popup, pe);
+        });
+        std::lock_guard<std::mutex> lk(g_gtk_retained_popups_mutex);
+        g_gtk_retained_popups[popupId] = pe;
+        return nullptr;
+    }
+
+    // Transfer the inherited popup / dialog callbacks from the shell to the
+    // engine so nested popups + dialogs from the adopted view keep working
+    // immediately.  These are strong JNI global refs; ownership moves to the
+    // engine (nulled on pe so delete pe does not double-free, and freed later
+    // by gtk_destroy_engine or overwritten by the component's own
+    // gtk_set_popup_callback / gtk_set_dialog_callback at attach).
+    e->popup_callback = pe->popup_callback;
+    pe->popup_callback = nullptr;
+    e->dialog_callback = pe->dialog_callback;
+    pe->dialog_callback = nullptr;
+
+    // Drop the retained strong reference taken by the ADOPT branch's
+    // g_object_ref_sink — the engine's window now holds a container ref on the
+    // child.  Runs on the GTK thread for refcount-thread-safety.
+    GtkPump::instance().run_sync([&] {
+        g_object_unref(childw);
+    });
+
+    delete pe;
+    return e;
+}
+
+// Canvas 19: discard a retained-but-unadopted popup child (the ADOPT reclaim
+// path — opener disposed or grace period elapsed).  Tears the child down
+// WITHOUT ever showing a window; silent no-op for an unknown popupId.  Mirrors
+// on_close_popup minus the window: notify onPopupClosed, destroy the widget,
+// drop our retained ref, free the inherited global refs, delete the shell.
+static void gtk_discard_popup(jlong popupId) {
+    PopupEngine *pe = nullptr;
+    {
+        std::lock_guard<std::mutex> lk(g_gtk_retained_popups_mutex);
+        auto it = g_gtk_retained_popups.find(popupId);
+        if (it == g_gtk_retained_popups.end()) return;
+        pe = it->second;
+        g_gtk_retained_popups.erase(it);
+    }
+    if (!pe) return;
+
+    const char *url = pe->web ? webkit_web_view_get_uri(pe->web) : "";
+    fire_gtk_popup_closed(pe->jvm, pe->popup_callback, pe->dialog_callback,
+                          pe->popup_id, url ? url : "", "");
+
+    GtkPump::instance().run_sync([&] {
+        if (pe->web) {
+            // No window owns this child (ADOPT is windowless); disconnect its
+            // handlers, destroy the widget directly, then drop the strong ref
+            // we took via g_object_ref_sink in handle_create_web_view.
+            g_signal_handlers_disconnect_by_data(pe->web, pe);
+            gtk_widget_destroy(GTK_WIDGET(pe->web));
+            g_object_unref(pe->web);
+            pe->web = nullptr;
+        }
+    });
+
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (pe->jvm && pe->jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (pe->jvm->AttachCurrentThread((void **)&env, nullptr) == JNI_OK)
+            detach = true;
+    }
+    if (env) {
+        if (pe->popup_callback) env->DeleteGlobalRef(pe->popup_callback);
+        if (pe->dialog_callback) env->DeleteGlobalRef(pe->dialog_callback);
+        if (detach) pe->jvm->DetachCurrentThread();
+    }
+    pe->popup_callback = nullptr;
+    pe->dialog_callback = nullptr;
+    delete pe;
 }
 
 // ===========================================================================
@@ -5600,16 +5924,21 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
 #endif
 }
 
-// Popup-adoption JNI bridges — Canvas 18.  Must live inside this `extern "C"`
-// block (they are newly-added methods with no generated-header prototype, so
-// C++ name-mangling would otherwise make them unresolvable from the JVM —
-// UnsatisfiedLinkError).  macOS reparents the retained WKWebView; Linux
-// (Canvas 19) and Windows (Canvas 20) land their reparent later, so those
-// return 0 (EmbeddedWebView.adopt turns 0 into a documented
+// Popup-adoption JNI bridges — Canvas 18 (macOS) + Canvas 19 (Linux).  Must
+// live inside this `extern "C"` block (they are newly-added methods with no
+// generated-header prototype, so C++ name-mangling would otherwise make them
+// unresolvable from the JVM — UnsatisfiedLinkError; this exact bug was hit and
+// fixed for the dialog setters).  macOS reparents the retained WKWebView via
+// cocoa_adopt_popup; Linux reparents the retained WebKitGTK child via
+// gtk_adopt_popup (Canvas 19).  Windows (Canvas 20) lands its reparent later,
+// so it still returns 0 (EmbeddedWebView.adopt turns 0 into a documented
 // IllegalStateException).
 JNIEXPORT jlong JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1adopt_1popup
   (JNIEnv *env, jclass, jobject parent, jlong popupId, jint debug) {
-#ifdef WEBVIEW_COCOA
+#ifdef WEBVIEW_GTK
+    Engine *e = embed::gtk_adopt_popup(env, parent, popupId, debug);
+    return (jlong)e;
+#elif defined(WEBVIEW_COCOA)
     Engine *e = embed::cocoa_adopt_popup(env, parent, popupId, debug);
     return (jlong)e;
 #else
@@ -5620,7 +5949,9 @@ JNIEXPORT jlong JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1ad
 
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1discard_1popup
   (JNIEnv *, jclass, jlong /*w*/, jlong popupId) {
-#ifdef WEBVIEW_COCOA
+#ifdef WEBVIEW_GTK
+    embed::gtk_discard_popup(popupId);
+#elif defined(WEBVIEW_COCOA)
     embed::cocoa_discard_popup(popupId);
 #else
     (void)popupId;

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -2640,6 +2640,16 @@ struct Engine {
 static std::mutex g_webview_map_mutex;
 static std::map<id, Engine *> g_webview_map;
 
+// Canvas 18 (popup adoption): retained-but-unadopted popup child engines,
+// keyed by popup_id.  Populated by impl_create_web_view's ADOPT branch (which
+// creates the opener-linked child but NO NSWindow), drained by
+// cocoa_adopt_popup (reparent into a caller surface) or cocoa_discard_popup
+// (reclaim).  Guarded by its own mutex; entries are Engine* also present in
+// g_webview_map.  ON-DEVICE VALIDATION REQUIRED: this file has no native
+// toolchain in the generating sandbox (see Canvas 18 Safeguards).
+static std::mutex g_retained_popups_mutex;
+static std::map<jlong, Engine *> g_retained_popups;
+
 // The EDT↔AppKit-main synchronous bridge has been eliminated.  Per
 // Canvas 6 Norms (the macOS sync EDT→AppKit-main bridge prohibition),
 // every per-engine native operation runs via cocoa_run_on_main_async
@@ -3486,6 +3496,89 @@ static int popup_feature_int(id nsNumber) {
     return (int)msg<int>(nsNumber, sel("intValue"));
 }
 
+// Canvas 18: synchronous disposition gate.  Calls WebViewPopupCallback
+// .onPopupDisposition on the AppKit main thread and returns the
+// PopupDisposition ordinal (0 = BLOCK, 1 = NATIVE_WINDOW, 2 = ADOPT).
+// Mirrors fire_popup_requested; a null callback / attach failure / thrown
+// decision all yield BLOCK (0).  MUST NOT be marshalled to the EDT (the
+// AppKit main thread is blocked awaiting this decision).
+static int fire_popup_disposition(JavaVM *jvm, jobject cb,
+                                  const char *url, const char *name,
+                                  bool gesture, int w, int h,
+                                  const char *page) {
+    if (!jvm || !cb) return 0; // BLOCK
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return 0;
+        detach = true;
+    }
+    int disposition = 0; // BLOCK
+    jstring ju = env->NewStringUTF(url ? url : "");
+    jstring jn = env->NewStringUTF(name ? name : "");
+    jstring jp = env->NewStringUTF(page ? page : "");
+    jclass cls = env->GetObjectClass(cb);
+    if (cls) {
+        jmethodID mid = env->GetMethodID(cls, "onPopupDisposition",
+            "(Ljava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)I");
+        if (mid) {
+            jint r = env->CallIntMethod(cb, mid, ju, jn,
+                gesture ? JNI_TRUE : JNI_FALSE, (jint)w, (jint)h, jp);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+                r = 0;
+            }
+            disposition = (int)r;
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (ju) env->DeleteLocalRef(ju);
+    if (jn) env->DeleteLocalRef(jn);
+    if (jp) env->DeleteLocalRef(jp);
+    if (detach) jvm->DetachCurrentThread();
+    return disposition;
+}
+
+// Canvas 18: async notification that a popup child has been retained and is
+// ready to adopt.  Fire-and-forget on a detached worker thread (the Java
+// dispatcher marshals popupAdoptable to the EDT via invokeLater), mirroring
+// fire_popup_notify_opened.
+static void fire_popup_notify_adoptable(JavaVM *jvm, jobject cb, jlong popup_id,
+                                        std::string url, std::string name,
+                                        bool gesture, int w, int h,
+                                        std::string page) {
+    if (!jvm || !cb) return;
+    std::thread([jvm, cb, popup_id, url, name, gesture, w, h, page]() {
+        JNIEnv *env = nullptr;
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return;
+        jstring ju = env->NewStringUTF(url.c_str());
+        jstring jn = env->NewStringUTF(name.c_str());
+        jstring jp = env->NewStringUTF(page.c_str());
+        jclass cls = env->GetObjectClass(cb);
+        if (cls) {
+            jmethodID mid = env->GetMethodID(cls, "onPopupAdoptable",
+                "(JLjava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)V");
+            if (mid) {
+                env->CallVoidMethod(cb, mid, popup_id, ju, jn,
+                                    gesture ? JNI_TRUE : JNI_FALSE,
+                                    (jint)w, (jint)h, jp);
+                if (env->ExceptionCheck()) {
+                    env->ExceptionDescribe();
+                    env->ExceptionClear();
+                }
+            }
+            env->DeleteLocalRef(cls);
+        }
+        if (ju) env->DeleteLocalRef(ju);
+        if (jn) env->DeleteLocalRef(jn);
+        if (jp) env->DeleteLocalRef(jp);
+        jvm->DetachCurrentThread();
+    }).detach();
+}
+
 // WKUIDelegate createWebViewWithConfiguration:forNavigationAction:windowFeatures:
 // Returns the child WKWebView, or nil to block.
 static id impl_create_web_view(id self, SEL, id webView, id configuration,
@@ -3507,80 +3600,73 @@ static id impl_create_web_view(id self, SEL, id webView, id configuration,
     // window.open in practice requires a user gesture; report true.
     bool gesture = true;
 
-    // Synchronous allow/deny hop into Java (AppKit main -> JNI).
+    // Canvas 18: synchronous DISPOSITION hop into Java (AppKit main -> JNI).
+    // 0 = BLOCK (return nil), 1 = NATIVE_WINDOW (engine-owned window, the
+    // Canvas 15 path), 2 = ADOPT (retain the child, NO window, notify Java to
+    // reparent it into a caller-supplied WebViewComponent).  The default
+    // WebViewPopupCallback.onPopupDisposition derives from onPopupRequested,
+    // so legacy boolean handlers still map to BLOCK / NATIVE_WINDOW.
     JavaVM *jvm = e->jvm;
     jobject cb = e->popup_callback;
-    JNIEnv *env = nullptr;
-    bool attached = false;
-    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
-        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
-            return nullptr;
-        attached = true;
+    int disposition = fire_popup_disposition(
+        jvm, cb, target.c_str(), "", gesture, req_w, req_h, page.c_str());
+    if (disposition == 0) {
+        return nullptr; // BLOCK
     }
-    bool allow = false;
-    {
-        jstring ju = env->NewStringUTF(target.c_str());
-        jstring jn = env->NewStringUTF("");
-        jstring jp = env->NewStringUTF(page.c_str());
-        jclass cls = env->GetObjectClass(cb);
-        if (cls) {
-            jmethodID mid = env->GetMethodID(cls, "onPopupRequested",
-                "(Ljava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)Z");
-            if (mid) {
-                jboolean r = env->CallBooleanMethod(cb, mid, ju, jn,
-                    gesture ? JNI_TRUE : JNI_FALSE, (jint)req_w, (jint)req_h, jp);
-                if (env->ExceptionCheck()) {
-                    env->ExceptionDescribe();
-                    env->ExceptionClear();
-                    r = JNI_FALSE;
-                }
-                allow = (r == JNI_TRUE);
-            }
-            env->DeleteLocalRef(cls);
-        }
-        if (ju) env->DeleteLocalRef(ju);
-        if (jn) env->DeleteLocalRef(jn);
-        if (jp) env->DeleteLocalRef(jp);
-    }
-    // NOTE: keep the thread attached until AFTER the child engine's global
-    // refs are created below — detaching here would invalidate `env`.
-    if (!allow) {
-        if (attached) jvm->DetachCurrentThread();
-        return nullptr;
-    }
+    const bool adopt = (disposition == 2);
 
     // Size the popup: use the requested size, else a typical auth-popup size.
     int W = req_w > 0 ? req_w : 500;
     int H = req_h > 0 ? req_h : 650;
 
     // Create the child WKWebView LINKED to the opener via the passed config.
+    // WebKit drives the ORIGINAL navigation-action request (POST verb + body)
+    // into this child regardless of disposition, which is what preserves POST
+    // and window.opener for both NATIVE_WINDOW and ADOPT.
     id child = msg(objc_cls("WKWebView"), sel("alloc"));
     child = msg<id, CGRect, id>(child, sel("initWithFrame:configuration:"),
                                 CGRectMake(0, 0, W, H), configuration);
     if (!child) {
-        if (attached) jvm->DetachCurrentThread();
         return nullptr;
     }
 
-    // Host it in an engine-owned NSWindow (titled|closable|miniaturizable|
-    // resizable = 1|2|4|8; NSBackingStoreBuffered = 2).
-    id win = msg(objc_cls("NSWindow"), sel("alloc"));
-    win = msg<id, CGRect, unsigned long, unsigned long, BOOL>(
-        win, sel("initWithContentRect:styleMask:backing:defer:"),
-        CGRectMake(0, 0, W, H), (unsigned long)15, (unsigned long)2, NO);
-    msg<void, id>(win, sel("setTitle:"), ns_str("Popup"));
-    msg<void, id>(win, sel("setContentView:"), child);
-    msg<void>(win, sel("center"));
-    msg<void, id>(win, sel("makeKeyAndOrderFront:"), nullptr);
+    // Attach a JNIEnv to create the child engine's inherited global refs.
+    JNIEnv *env = nullptr;
+    bool attached = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env) {
+            msg<void>(child, sel("release"));
+            return nullptr;
+        }
+        attached = true;
+    }
+
+    // NATIVE_WINDOW: host the child in an engine-owned NSWindow (titled|
+    // closable|miniaturizable|resizable = 1|2|4|8; NSBackingStoreBuffered =
+    // 2).  ADOPT: create NO window — the child is retained under
+    // g_retained_popups and reparented later by cocoa_adopt_popup, so nothing
+    // is ever shown until the caller adopts it.
+    id win = nullptr;
+    if (!adopt) {
+        win = msg(objc_cls("NSWindow"), sel("alloc"));
+        win = msg<id, CGRect, unsigned long, unsigned long, BOOL>(
+            win, sel("initWithContentRect:styleMask:backing:defer:"),
+            CGRectMake(0, 0, W, H), (unsigned long)15, (unsigned long)2, NO);
+        msg<void, id>(win, sel("setTitle:"), ns_str("Popup"));
+        msg<void, id>(win, sel("setContentView:"), child);
+        msg<void>(win, sel("center"));
+        msg<void, id>(win, sel("makeKeyAndOrderFront:"), nullptr);
+    }
 
     // Build the child Engine, inheriting the opener's callbacks so the popup
-    // supports dialogs / nested popups and can notify onPopupClosed.
+    // supports dialogs / nested popups and can notify onPopupClosed /
+    // onPopupAdoptable.
     Engine *child_e = new Engine();
     child_e->webview = child;
     child_e->jvm = jvm;
     child_e->config = configuration;
     child_e->manager = msg(configuration, sel("userContentController"));
-    child_e->popup_window = win;
+    child_e->popup_window = win;              // nil for ADOPT
     child_e->popup_id = (jlong)child_e;
     if (env) {
         child_e->popup_callback = env->NewGlobalRef(cb);
@@ -3596,15 +3682,23 @@ static id impl_create_web_view(id self, SEL, id webView, id configuration,
         std::lock_guard<std::mutex> lk(g_webview_map_mutex);
         g_webview_map[child] = child_e;
     }
+    if (adopt) {
+        std::lock_guard<std::mutex> lk(g_retained_popups_mutex);
+        g_retained_popups[child_e->popup_id] = child_e;
+    }
 
     // Global refs are created; safe to detach now if we attached above.
     if (attached) jvm->DetachCurrentThread();
 
-    // Notify the opener's PopupDispatcher (async) that the popup is open.
-    // fire_popup_notify_opened attaches its own worker thread; it does not
-    // use `env`.
-    fire_popup_notify_opened(jvm, cb, child_e->popup_id, target, "",
-                             gesture, W, H, page);
+    // Notify the opener's PopupDispatcher (async).  Both notify helpers attach
+    // their own worker thread and do not use `env`.
+    if (adopt) {
+        fire_popup_notify_adoptable(jvm, cb, child_e->popup_id, target, "",
+                                    gesture, W, H, page);
+    } else {
+        fire_popup_notify_opened(jvm, cb, child_e->popup_id, target, "",
+                                 gesture, W, H, page);
+    }
     return child;
 }
 
@@ -4438,6 +4532,169 @@ static Engine *cocoa_create_engine(JNIEnv *env, jobject parentComponent,
     return e;
 }
 
+// Canvas 18: reparent a retained popup child (created windowless by
+// impl_create_web_view's ADOPT branch) into parentComponent's realized native
+// surface, promoting it to a normal embedded engine.  Returns the child
+// Engine* (as cocoa_create_engine would) or nullptr when popupId is unknown /
+// already adopted, or the JAWT surface cannot be resolved.  Reuses the exact
+// host-view walk + addSubview + KVO + attach-signal from cocoa_create_engine's
+// epilogue; it deliberately does NOT re-create the WKWebView / config / UI
+// delegate — the retained child already carries them (and its in-flight POST
+// navigation) from impl_create_web_view.  The eval / function bridges are
+// installed by the Java EmbeddedWebView.adopt wrapper (webview_embed_init /
+// _bind) after this returns.
+//
+// ON-DEVICE VALIDATION REQUIRED: the reparent retain/release balance and the
+// first-responder handoff are prime zombie/Instruments candidates (Canvas 18
+// Safeguards); this file has no native toolchain in the generating sandbox.
+static Engine *cocoa_adopt_popup(JNIEnv *env, jobject parentComponent,
+                                 jlong popupId, jint /*debug*/) {
+    // Claim the retained child (adopt-once): remove under lock so a second
+    // adopt of the same id finds nothing and returns 0.
+    Engine *e = nullptr;
+    {
+        std::lock_guard<std::mutex> lk(g_retained_popups_mutex);
+        auto it = g_retained_popups.find(popupId);
+        if (it == g_retained_popups.end()) return nullptr;
+        e = it->second;
+        g_retained_popups.erase(it);
+    }
+    if (!e) return nullptr;
+
+    // Resolve the JAWT surface layers for the new parent (mirrors the
+    // cocoa_create_engine prologue), then release the surface lock before the
+    // async main-thread epilogue.
+    {
+        JawtLock lock(env, parentComponent);
+        if (!lock.ok) {
+            // Could not attach; put the child back so it is reclaimable and
+            // not lost.
+            std::lock_guard<std::mutex> lk(g_retained_popups_mutex);
+            g_retained_popups[popupId] = e;
+            return nullptr;
+        }
+        if (e->surface_layers) {
+            msg<void>(e->surface_layers, sel("release"));
+            e->surface_layers = nullptr;
+        }
+        e->surface_layers = (id)lock.dsi->platformInfo;
+        if (e->surface_layers) {
+            msg<void>(e->surface_layers, sel("retain"));
+        }
+    }
+
+    // Async epilogue on the AppKit main thread: reparent the retained child's
+    // WKWebView into the resolved host view and finish attach.  The host-view
+    // walk is identical to cocoa_create_engine's.
+    cocoa_run_on_main_async([e] {
+        if (e->destroyed.load()) {
+            cocoa_attach_signal_complete(e, false,
+                "EmbeddedWebView disposed before adopt completed");
+            return;
+        }
+        id ns_view_cls = objc_cls("NSView");
+        SEL is_kind_of_class = sel("isKindOfClass:");
+        id window_layer = e->surface_layers
+            ? msg(e->surface_layers, sel("windowLayer"))
+            : (id)nullptr;
+        id host = nullptr;
+        bool host_is_awt = false;
+        for (id l = window_layer; l; l = msg(l, sel("superlayer"))) {
+            id ld = msg(l, sel("delegate"));
+            if (!ld) continue;
+            if (!msg<BOOL>(ld, is_kind_of_class, ns_view_cls)) continue;
+            Class cls = object_getClass(ld);
+            const char *cls_name = cls ? class_getName(cls) : "<unknown>";
+            if (std::strstr(cls_name, "AWT") != nullptr) {
+                host = ld;
+                host_is_awt = true;
+                break;
+            }
+            if (host == nullptr) {
+                id window = msg(ld, sel("window"));
+                if (window) {
+                    id cv = msg(window, sel("contentView"));
+                    if (cv) host = cv;
+                }
+            }
+        }
+        if (host != nullptr) {
+            msg<void>(host, sel("retain"));
+            e->host_view = host;
+            e->host_is_awt = host_is_awt;
+            msg<void, BOOL>(host, sel("setWantsLayer:"), YES);
+            // Reparent the existing (retained) child WKWebView into the tab's
+            // host view — this is the crux that hosts the popup in the caller's
+            // surface instead of a native window, preserving the in-flight
+            // POST navigation.
+            msg<void, id>(host, sel("addSubview:"), e->webview);
+            // Hide until the first setBounds positions it (as create does).
+            msg<void, CGRect>(e->webview, sel("setFrame:"),
+                              CGRectMake(0, 0, 0, 0));
+        } else if (e->surface_layers) {
+            msg<void, BOOL>(e->webview, sel("setWantsLayer:"), YES);
+            id layer = msg(e->webview, sel("layer"));
+            msg<void, id>(e->surface_layers, sel("setLayer:"), layer);
+            fprintf(stderr,
+                "[webview-embed] WARNING: adopt could not locate a host "
+                "NSView; layer-only fallback (content may not render).\n");
+        }
+        // The child is no longer a windowless popup: it is now a normal
+        // embedded engine hosted in the caller's surface.  Clear popup_window
+        // (already nil for ADOPT) and register KVO / signal attach so the Java
+        // AttachCallback fires (webViewDidClose: still routes onPopupClosed).
+        e->popup_window = nullptr;
+        cocoa_kvo_install(e);
+        cocoa_attach_signal_complete(e, true, "");
+    });
+    return e;
+}
+
+// Canvas 18: discard a retained-but-unadopted popup child (the ADOPT reclaim
+// path).  Tears the child engine down WITHOUT ever showing a window; silent
+// no-op for an unknown popupId.  Mirrors impl_web_view_did_close teardown
+// (minus the window) and transfers ownership of the inherited global refs to
+// the async close-notify worker.
+static void cocoa_discard_popup(jlong popupId) {
+    Engine *e = nullptr;
+    {
+        std::lock_guard<std::mutex> lk(g_retained_popups_mutex);
+        auto it = g_retained_popups.find(popupId);
+        if (it == g_retained_popups.end()) return;
+        e = it->second;
+        g_retained_popups.erase(it);
+    }
+    if (!e) return;
+    cocoa_run_on_main_async([e] {
+        JavaVM *jvm = e->jvm;
+        jobject popup_cb = e->popup_callback;
+        jobject dialog_cb = e->dialog_callback;
+        jlong pid = e->popup_id;
+        std::string url = page_url_utf8(e->webview);
+        if (e->webview) {
+            msg<void, id>(e->webview, sel("setUIDelegate:"), nullptr);
+        }
+        {
+            std::lock_guard<std::mutex> lk(g_webview_map_mutex);
+            g_webview_map.erase(e->webview);
+        }
+        // Notify Java (onPopupClosed) and transfer ownership of the inherited
+        // refs to the worker, which frees them after the call.
+        fire_popup_notify_closed(jvm, popup_cb, dialog_cb, pid, url, "");
+        e->popup_callback = nullptr;
+        e->dialog_callback = nullptr;
+        if (e->ui_delegate) {
+            msg(e->ui_delegate, sel("release"));
+            e->ui_delegate = nullptr;
+        }
+        if (e->webview) {
+            msg(e->webview, sel("release"));
+            e->webview = nullptr;
+        }
+        delete e;
+    });
+}
+
 // Asynchronous engine destroy.  Returns immediately on the calling
 // thread (typically the EDT) after a small Java-side cleanup; the
 // AppKit teardown, view-hierarchy removal, KVO observer unregister,
@@ -4880,6 +5137,33 @@ JNIEXPORT jlong JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1cr
 #else
     (void)env; (void)component; (void)debug;
     return 0;
+#endif
+}
+
+// Canvas 18: adopt a retained popup child into `parent`'s surface.  macOS
+// reparents the retained WKWebView; Linux (Canvas 19) and Windows (Canvas 20)
+// land their reparent later, so this returns 0 there (EmbeddedWebView.adopt
+// turns 0 into a documented IllegalStateException).
+JNIEXPORT jlong JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1adopt_1popup
+  (JNIEnv *env, jclass, jobject parent, jlong popupId, jint debug) {
+#ifdef WEBVIEW_COCOA
+    Engine *e = embed::cocoa_adopt_popup(env, parent, popupId, debug);
+    return (jlong)e;
+#else
+    (void)env; (void)parent; (void)popupId; (void)debug;
+    return 0;
+#endif
+}
+
+// Canvas 18: discard a retained-but-unadopted popup child (ADOPT reclaim).
+// `w` (any live embed peer from the same process) is unused on macOS because
+// the retained-popup registry is process-global keyed by popupId.
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1discard_1popup
+  (JNIEnv *, jclass, jlong /*w*/, jlong popupId) {
+#ifdef WEBVIEW_COCOA
+    embed::cocoa_discard_popup(popupId);
+#else
+    (void)popupId;
 #endif
 }
 

--- a/test/ca/weblite/webview/PopupDispatcherTest.java
+++ b/test/ca/weblite/webview/PopupDispatcherTest.java
@@ -331,6 +331,197 @@ public class PopupDispatcherTest {
     }
 
     // -----------------------------------------------------------------
+    // Disposition gate (Canvas 18).
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testDispositionDefaultDerivesFromBooleanTrue() {
+        // A legacy handler overriding only popupRequested (true) maps to
+        // NATIVE_WINDOW via the popupDisposition default.
+        dispatcher.setHandler(new WebViewPopupHandler() {
+            @Override public boolean popupRequested(WebViewPopupEvent e) {
+                return true;
+            }
+        });
+        assertEquals(PopupDisposition.NATIVE_WINDOW.ordinal(),
+            dispatcher.dispatchPopupDisposition("u", "n", true, -1, -1, "p"));
+    }
+
+    @Test
+    public void testDispositionDefaultDerivesFromBooleanFalse() {
+        dispatcher.setHandler(new WebViewPopupHandler() {
+            @Override public boolean popupRequested(WebViewPopupEvent e) {
+                return false;
+            }
+        });
+        assertEquals(PopupDisposition.BLOCK.ordinal(),
+            dispatcher.dispatchPopupDisposition("u", "n", true, -1, -1, "p"));
+    }
+
+    @Test
+    public void testDispositionDefaultHandlerIsNativeWindow() {
+        // DEFAULT handler: popupRequested() returns true -> NATIVE_WINDOW.
+        assertEquals(PopupDisposition.NATIVE_WINDOW.ordinal(),
+            dispatcher.dispatchPopupDisposition("u", "n", true, 500, 650, "p"));
+    }
+
+    @Test
+    public void testDispositionDropHandlerBlocks() {
+        dispatcher.setHandler(null); // DROP
+        assertEquals(PopupDisposition.BLOCK.ordinal(),
+            dispatcher.dispatchPopupDisposition("u", "n", true, -1, -1, "p"));
+    }
+
+    @Test
+    public void testDispositionAdoptRunsOffEdtAndReturnsOrdinal() {
+        final AtomicReference<Boolean> onEdt = new AtomicReference<Boolean>();
+        dispatcher.setHandler(new WebViewPopupHandler() {
+            @Override public PopupDisposition popupDisposition(
+                    WebViewPopupEvent e) {
+                onEdt.set(SwingUtilities.isEventDispatchThread());
+                return PopupDisposition.ADOPT;
+            }
+        });
+        int d = dispatcher.dispatchPopupDisposition(
+            "https://e.com/auth", "authwin", true, 520, 640, "https://o.com");
+        assertEquals(PopupDisposition.ADOPT.ordinal(), d);
+        assertEquals("disposition must run off the EDT",
+            Boolean.FALSE, onEdt.get());
+    }
+
+    @Test
+    public void testDispositionNullReturnBlocks() {
+        dispatcher.setHandler(new WebViewPopupHandler() {
+            @Override public PopupDisposition popupDisposition(
+                    WebViewPopupEvent e) {
+                return null;
+            }
+        });
+        assertEquals(PopupDisposition.BLOCK.ordinal(),
+            dispatcher.dispatchPopupDisposition("u", "n", true, -1, -1, "p"));
+    }
+
+    @Test
+    public void testDispositionExceptionBlocksAndIsolated() {
+        dispatcher.setHandler(new WebViewPopupHandler() {
+            @Override public PopupDisposition popupDisposition(
+                    WebViewPopupEvent e) {
+                throw new RuntimeException("boom-disp");
+            }
+        });
+        assertEquals(PopupDisposition.BLOCK.ordinal(),
+            dispatcher.dispatchPopupDisposition("u", "n", true, -1, -1, "p"));
+        waitForUncaught();
+        assertNotNull(uncaught.get());
+        assertEquals("boom-disp", uncaught.get().getMessage());
+    }
+
+    @Test
+    public void testDisposedDispatcherDispositionBlocks() {
+        dispatcher.disposeAll();
+        assertEquals(PopupDisposition.BLOCK.ordinal(),
+            dispatcher.dispatchPopupDisposition("u", "n", true, -1, -1, "p"));
+    }
+
+    // -----------------------------------------------------------------
+    // Adopt notification, claim-once, and reclaim (Canvas 18).
+    // -----------------------------------------------------------------
+
+    @Test
+    public void testAdoptableNotifiedOnEdtAndPending() throws Exception {
+        final AtomicReference<Boolean> onEdt = new AtomicReference<Boolean>();
+        final AtomicReference<Long> gotId = new AtomicReference<Long>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        dispatcher.setHandler(new WebViewPopupHandler() {
+            @Override public void popupAdoptable(WebViewPopupEvent e,
+                                                 long popupId) {
+                onEdt.set(SwingUtilities.isEventDispatchThread());
+                gotId.set(popupId);
+                latch.countDown();
+            }
+        });
+        dispatcher.dispatchPopupAdoptable(
+            77L, "https://e.com", "win", true, 520, 640, "https://o.com");
+        assertTrue("popupAdoptable not delivered",
+            latch.await(2, TimeUnit.SECONDS));
+        assertEquals(Boolean.TRUE, onEdt.get());
+        assertEquals(Long.valueOf(77L), gotId.get());
+        assertEquals(1, dispatcher.pendingAdoptCount());
+    }
+
+    @Test
+    public void testClaimAdoptReturnsStoredEventAndClearsPending() {
+        dispatcher.dispatchPopupAdoptable(
+            5L, "https://e.com", "win", true, 520, 640, "https://o.com");
+        WebViewPopupEvent ev = dispatcher.claimAdopt(5L);
+        assertNotNull(ev);
+        assertSame(source, ev.source());
+        assertEquals("https://e.com", ev.targetUrl());
+        assertEquals(520, ev.width());
+        assertEquals(0, dispatcher.pendingAdoptCount());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testClaimAdoptUnknownIdThrowsIAE() {
+        dispatcher.claimAdopt(123456L);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testClaimAdoptTwiceThrowsISE() {
+        dispatcher.dispatchPopupAdoptable(
+            9L, "u", "n", true, -1, -1, "p");
+        dispatcher.claimAdopt(9L);      // first claim ok
+        dispatcher.claimAdopt(9L);      // second claim -> ISE
+    }
+
+    @Test
+    public void testReclaimAdoptsDiscardsViaSinkOnDispose() {
+        final java.util.List<Long> discarded =
+            new java.util.concurrent.CopyOnWriteArrayList<Long>();
+        dispatcher.setReclaimSink(new PopupDispatcher.ReclaimSink() {
+            @Override public void discard(long popupId) {
+                discarded.add(Long.valueOf(popupId));
+            }
+        });
+        dispatcher.dispatchPopupAdoptable(1L, "u", "n", true, -1, -1, "p");
+        dispatcher.dispatchPopupAdoptable(2L, "u", "n", true, -1, -1, "p");
+        assertEquals(2, dispatcher.pendingAdoptCount());
+        dispatcher.disposeAll();
+        assertEquals(0, dispatcher.pendingAdoptCount());
+        assertTrue(discarded.contains(Long.valueOf(1L)));
+        assertTrue(discarded.contains(Long.valueOf(2L)));
+    }
+
+    @Test
+    public void testClaimedAdoptIsNotReclaimed() {
+        final java.util.List<Long> discarded =
+            new java.util.concurrent.CopyOnWriteArrayList<Long>();
+        dispatcher.setReclaimSink(new PopupDispatcher.ReclaimSink() {
+            @Override public void discard(long popupId) {
+                discarded.add(Long.valueOf(popupId));
+            }
+        });
+        dispatcher.dispatchPopupAdoptable(3L, "u", "n", true, -1, -1, "p");
+        dispatcher.claimAdopt(3L);      // claimed -> removed from pending
+        dispatcher.disposeAll();
+        assertFalse("a claimed adoption must not be reclaimed",
+            discarded.contains(Long.valueOf(3L)));
+    }
+
+    @Test
+    public void testDisposedDispatcherAdoptableIsNoOp() {
+        dispatcher.setHandler(new WebViewPopupHandler() {
+            @Override public void popupAdoptable(WebViewPopupEvent e,
+                                                 long popupId) {
+                throw new AssertionError("handler invoked after dispose");
+            }
+        });
+        dispatcher.disposeAll();
+        dispatcher.dispatchPopupAdoptable(1L, "u", "n", true, -1, -1, "p");
+        assertEquals(0, dispatcher.pendingAdoptCount());
+    }
+
+    // -----------------------------------------------------------------
     // Constructor null-checks.
     // -----------------------------------------------------------------
 

--- a/test/ca/weblite/webview/WebViewComponentUserAgentTest.java
+++ b/test/ca/weblite/webview/WebViewComponentUserAgentTest.java
@@ -1,0 +1,101 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import ca.weblite.webview.swing.WebViewComponent;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Unit tests for the {@code WebViewComponent} custom User-Agent contract
+ * (Canvas 21) — store / reset / get and the live-apply hook — without a
+ * native peer.  On-device verification of the actual HTTP {@code User-Agent}
+ * header is a manual step (per the no-automated-GUI-tests policy).
+ */
+public class WebViewComponentUserAgentTest {
+
+    /** Minimal {@link WebViewComponent} that records {@code applyUserAgentToPeer}
+     *  invocations; never attaches to a native peer. */
+    private static final class StubComponent extends WebViewComponent {
+        final AtomicReference<String> lastApplied = new AtomicReference<String>();
+        final AtomicInteger applyCount = new AtomicInteger(0);
+
+        @Override protected void applyUserAgentToPeer(String ua) {
+            lastApplied.set(ua);
+            applyCount.incrementAndGet();
+        }
+
+        @Override public WebViewComponent setUrl(String url) { return this; }
+        @Override public String getUrl() { return ""; }
+        @Override public WebViewComponent setDebug(boolean debug) { return this; }
+        @Override public WebViewComponent addOnBeforeLoad(String js) { return this; }
+        @Override public WebViewComponent eval(String js) { return this; }
+        @Override public CompletableFuture<String> evalAsync(String js) {
+            CompletableFuture<String> f = new CompletableFuture<String>();
+            f.completeExceptionally(new IllegalStateException("stub"));
+            return f;
+        }
+        @Override public WebViewComponent addJavascriptCallback(
+                String name, WebView.JavascriptCallback cb) { return this; }
+        @Override public WebViewComponent addJavascriptFunction(
+                String name, JavascriptFunction fn) { return this; }
+        @Override public WebViewComponent addJavascriptFunction(
+                String name, AsyncJavascriptFunction fn) { return this; }
+        @Override public WebViewComponent dispatch(Runnable r) { return this; }
+        @Override public void dispose() { }
+    }
+
+    @Test
+    public void testDefaultUserAgentIsNull() {
+        assertNull(new StubComponent().getUserAgent());
+    }
+
+    @Test
+    public void testSetUserAgentStoresAndReturns() {
+        StubComponent c = new StubComponent();
+        String ua = "Mozilla/5.0 … Version/18.3 Safari/605.1.15";
+        assertSame("setUserAgent must chain", c, c.setUserAgent(ua));
+        assertEquals(ua, c.getUserAgent());
+        assertEquals(ua, c.lastApplied.get());
+        assertEquals(1, c.applyCount.get());
+    }
+
+    @Test
+    public void testNullResetsToDefault() {
+        StubComponent c = new StubComponent();
+        c.setUserAgent("x");
+        c.setUserAgent(null);
+        assertNull(c.getUserAgent());
+        assertNull("reset must apply null to the peer", c.lastApplied.get());
+    }
+
+    @Test
+    public void testEmptyStringResetsToDefault() {
+        StubComponent c = new StubComponent();
+        c.setUserAgent("x");
+        c.setUserAgent("");
+        assertNull(c.getUserAgent());
+        assertNull(c.lastApplied.get());
+    }
+
+    @Test
+    public void testApplyHookFiresEveryCall() {
+        StubComponent c = new StubComponent();
+        c.setUserAgent("a");
+        c.setUserAgent("b");
+        c.setUserAgent(null);
+        assertEquals(3, c.applyCount.get());
+        assertNull(c.getUserAgent());
+    }
+}

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -808,12 +808,15 @@ static void fire_popup_closed_win(Engine *e, jlong popup_id, const char *url,
 // adopting component's realized AWT HWND via put_ParentWindow; an unclaimed
 // child is reclaimed by webview_embed_discard_popup.
 //
-// ON-DEVICE-VALIDATION-REQUIRED throughout: this file cannot be compiled in
-// the generating sandbox (no MSVC / WebView2 SDK).  The COM ref-counting on
-// the controller/webview/environment handoffs, the apartment-thread
-// (worker-thread) affinity of every ICoreWebView2* call, and the JNI
-// global-ref lifecycle across retain -> adopt/discard are prime candidates for
-// on-device scrutiny.
+// VALIDATED ON-DEVICE: the core adopt path (retain a POST/opener-linked child,
+// reparent it into a WebViewComponent tab via put_ParentWindow, POST body +
+// window.opener preserved) has been confirmed working on a real WebView2 stack.
+// The remaining ON-DEVICE-VALIDATION markers below flag the teardown / reclaim
+// / race edges that the happy-path confirmation does not fully exercise: the
+// COM ref-counting on the controller/webview/environment handoffs, the
+// apartment-thread (worker-thread) affinity of every ICoreWebView2* call, and
+// the JNI global-ref lifecycle across retain -> adopt/discard remain prime
+// candidates for on-device scrutiny.
 // ---------------------------------------------------------------------------
 
 // Synchronous disposition hop into Java (runs on the JNI worker thread the

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -1507,6 +1507,36 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1nav
     });
 }
 
+// Custom User-Agent — Canvas 21.  ua == null / empty restores the engine
+// default.  Applied on the WebView2 UI thread via ICoreWebView2Settings2;
+// no-op on an old runtime lacking the _2 settings interface.  Takes effect on
+// the next navigation.
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1user_1agent
+  (JNIEnv *env, jclass, jlong wv, jstring ua) {
+    auto *e = (Engine *)wv;
+    if (!e) return;
+    std::wstring w;
+    if (ua) {
+        const char *s = env->GetStringUTFChars(ua, nullptr);
+        w = embed_win::utf8_to_wide(s);
+        env->ReleaseStringUTFChars(ua, s);
+    }
+    embed_win::dispatch_to_thread(e, [e, w] {
+        if (!e->webview) return;
+        ICoreWebView2Settings *settings = nullptr;
+        if (SUCCEEDED(e->webview->get_Settings(&settings)) && settings) {
+            ICoreWebView2Settings2 *settings2 = nullptr;
+            if (SUCCEEDED(settings->QueryInterface(
+                    __uuidof(ICoreWebView2Settings2),
+                    reinterpret_cast<void **>(&settings2))) && settings2) {
+                settings2->put_UserAgent(w.c_str()); // empty -> default
+                settings2->Release();
+            }
+            settings->Release();
+        }
+    });
+}
+
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1init
   (JNIEnv *env, jclass, jlong wv, jstring js) {
     auto *e = (Engine *)wv;

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -159,6 +159,18 @@ struct Engine {
     // environment so the popup is a linked view (window.opener / postMessage
     // work) -- a controller from a different environment is not linked.
     ICoreWebView2Environment *environment = nullptr;
+
+    // Canvas 20 (popup adoption).  An ADOPTED popup engine reuses the OPENER
+    // engine's WebView2 worker thread, because its ICoreWebView2Controller was
+    // created on that thread and WebView2 objects are apartment-bound to their
+    // creating thread (they cannot be moved to a fresh thread).  For such an
+    // engine `thread_id` is the opener's worker thread and this flag is TRUE,
+    // so destroy_engine must NOT post WM_EMBED_QUIT (that would tear down the
+    // opener's message loop and the opener engine with it).  Instead it
+    // synchronously Close()es the controller/webview on that shared thread.
+    // ON-DEVICE-VALIDATION-REQUIRED: shared-worker-thread lifecycle (opener
+    // outliving / being disposed before the adopted child).
+    bool shared_thread = false;
 };
 
 static void fire_focus_callback(Engine *e, bool became) {
@@ -782,6 +794,268 @@ static void fire_popup_closed_win(Engine *e, jlong popup_id, const char *url,
     if (detach) jvm->DetachCurrentThread();
 }
 
+// ---------------------------------------------------------------------------
+// Popup ADOPTION support — Canvas 20 (Windows / WebView2).
+//
+// Mirrors the shipped macOS (Canvas 18) + Linux (Canvas 19) adoption backends
+// against the SAME platform-agnostic Java contract (no Java changes).  On an
+// ADOPT disposition the NewWindowRequested handler builds the linked child
+// controller from the opener's SAME environment against a HIDDEN holder HWND
+// (never shown), returns the child to WebView2 (so it drives the original
+// request -- POST verb+body, window.opener), retains it in
+// g_win_retained_popups keyed by a jlong popupId, and fires onPopupAdoptable.
+// Later webview_embed_adopt_popup reparents the retained controller into the
+// adopting component's realized AWT HWND via put_ParentWindow; an unclaimed
+// child is reclaimed by webview_embed_discard_popup.
+//
+// ON-DEVICE-VALIDATION-REQUIRED throughout: this file cannot be compiled in
+// the generating sandbox (no MSVC / WebView2 SDK).  The COM ref-counting on
+// the controller/webview/environment handoffs, the apartment-thread
+// (worker-thread) affinity of every ICoreWebView2* call, and the JNI
+// global-ref lifecycle across retain -> adopt/discard are prime candidates for
+// on-device scrutiny.
+// ---------------------------------------------------------------------------
+
+// Synchronous disposition hop into Java (runs on the JNI worker thread the
+// NewWindowRequested handler spins up), returning the PopupDisposition ordinal
+// (0=BLOCK, 1=NATIVE_WINDOW, 2=ADOPT).  Returns 0 (BLOCK) on null callback,
+// attach failure, or any exception -- the safe block-on-error default.
+// Mirrors fire_popup_requested_win but calls onPopupDisposition (returns int).
+static jint fire_popup_disposition_win(Engine *e, const char *url, bool gesture,
+                                       int w, int h, const char *page) {
+    if (!e || !e->popup_callback || !e->jvm) return 0;  // BLOCK
+    JavaVM *jvm = e->jvm;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return 0;
+        detach = true;
+    }
+    jint disposition = 0;
+    jstring ju = env->NewStringUTF(url ? url : "");
+    jstring jn = env->NewStringUTF("");
+    jstring jp = env->NewStringUTF(page ? page : "");
+    jclass cls = env->GetObjectClass(e->popup_callback);
+    if (cls) {
+        jmethodID mid = env->GetMethodID(cls, "onPopupDisposition",
+            "(Ljava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)I");
+        if (mid) {
+            jint r = env->CallIntMethod(e->popup_callback, mid, ju, jn,
+                gesture ? JNI_TRUE : JNI_FALSE, (jint)w, (jint)h, jp);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+                r = 0;
+            }
+            disposition = r;
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (ju) env->DeleteLocalRef(ju);
+    if (jn) env->DeleteLocalRef(jn);
+    if (jp) env->DeleteLocalRef(jp);
+    if (detach) jvm->DetachCurrentThread();
+    return disposition;
+}
+
+// Fire onPopupAdoptable (fire-and-forget; the Java dispatcher marshals to the
+// EDT via invokeLater).  Runs on the WebView2 worker thread.  Same signature
+// shape as fire_popup_opened_win, different method name.
+static void fire_popup_adoptable_win(Engine *e, jlong popup_id, const char *url,
+                                     bool gesture, int w, int h,
+                                     const char *page) {
+    if (!e || !e->popup_callback || !e->jvm) return;
+    JavaVM *jvm = e->jvm;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return;
+        detach = true;
+    }
+    jstring ju = env->NewStringUTF(url ? url : "");
+    jstring jn = env->NewStringUTF("");
+    jstring jp = env->NewStringUTF(page ? page : "");
+    jclass cls = env->GetObjectClass(e->popup_callback);
+    if (cls) {
+        jmethodID mid = env->GetMethodID(cls, "onPopupAdoptable",
+            "(JLjava/lang/String;Ljava/lang/String;ZIILjava/lang/String;)V");
+        if (mid) {
+            env->CallVoidMethod(e->popup_callback, mid, popup_id, ju, jn,
+                gesture ? JNI_TRUE : JNI_FALSE, (jint)w, (jint)h, jp);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (ju) env->DeleteLocalRef(ju);
+    if (jn) env->DeleteLocalRef(jn);
+    if (jp) env->DeleteLocalRef(jp);
+    if (detach) jvm->DetachCurrentThread();
+}
+
+// A retained-but-unadopted popup child: a linked child WebView2 hosted in a
+// HIDDEN holder HWND (never shown), held until webview_embed_adopt_popup
+// reparents it or webview_embed_discard_popup reclaims it.  The controller /
+// webview / environment are AddRef'd COM references owned by this struct; the
+// popup/dialog callbacks are inherited JNI global refs owned by this struct.
+struct RetainedPopup {
+    ICoreWebView2Controller *controller = nullptr;  // AddRef'd
+    ICoreWebView2 *webview = nullptr;               // AddRef'd
+    ICoreWebView2Environment *environment = nullptr;// AddRef'd (opener's)
+    HWND holder = nullptr;                           // hidden top-level HWND
+    JavaVM *jvm = nullptr;
+    jlong popup_id = 0;
+    std::string url;
+    std::string page;
+    // Worker thread the controller was created on (== opener engine's
+    // thread_id).  Every ICoreWebView2* call on controller/webview MUST run on
+    // this apartment thread.
+    DWORD worker_thread_id = 0;
+    // Inherited callback global refs (new global refs on the opener's, so the
+    // retained child keeps working for nested popups/dialogs until adoption
+    // transfers ownership to the adopted engine).
+    jobject popup_callback = nullptr;
+    jobject dialog_callback = nullptr;
+    // Retained-phase event handler tokens, removed before the adopted engine
+    // registers its own handlers (analogous to Linux's
+    // g_signal_handlers_disconnect_by_data).
+    EventRegistrationToken new_window_token{};
+    EventRegistrationToken script_dialog_token{};
+    EventRegistrationToken close_token{};
+};
+
+// ON-DEVICE-VALIDATION-REQUIRED: the retained-popup registry is the Windows
+// counterpart of the macOS g_retained_popups / Linux g_gtk_retained_popups.
+static std::mutex g_win_retained_popups_mutex;
+static std::map<jlong, RetainedPopup *> g_win_retained_popups;
+
+// Post a fire-and-forget op onto a specific WebView2 worker thread (the
+// apartment that owns a retained child's COM objects).  Falls back to running
+// inline if the thread id is unknown (best effort; wrong apartment).
+static void post_to_worker_thread(DWORD tid, DispatchFn fn) {
+    if (!tid) { fn(); return; }
+    auto *holder = new DispatchFn(std::move(fn));
+    PostThreadMessage(tid, WM_EMBED_DISPATCH, 0, (LPARAM)holder);
+}
+
+// Hidden holder window class for retained popup children.  A plain
+// DefWindowProc window that is NEVER shown; it exists only to give the child
+// controller a valid parent HWND until adoption reparents it.
+static ATOM ensure_popup_holder_class_registered() {
+    static ATOM atom = 0;
+    if (atom != 0) return atom;
+    WNDCLASSEX wc{};
+    wc.cbSize = sizeof(wc);
+    wc.hInstance = GetModuleHandle(nullptr);
+    wc.lpszClassName = "WebViewEmbedPopupHolder";
+    wc.lpfnWndProc = DefWindowProc;
+    wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
+    atom = RegisterClassEx(&wc);
+    return atom;
+}
+
+// Fire onPopupClosed for a retained (never-shown) child, using the inherited
+// jvm + popup_callback stored on the RetainedPopup.  Mirrors
+// fire_popup_closed_win but sources jvm/callback from the shell rather than an
+// Engine (the retained child has no opener-independent Engine yet).
+static void fire_popup_closed_retained(RetainedPopup *rp) {
+    if (!rp || !rp->popup_callback || !rp->jvm) return;
+    JavaVM *jvm = rp->jvm;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return;
+        detach = true;
+    }
+    jstring ju = env->NewStringUTF(rp->url.c_str());
+    jstring jp = env->NewStringUTF(rp->page.c_str());
+    jclass cls = env->GetObjectClass(rp->popup_callback);
+    if (cls) {
+        jmethodID mid = env->GetMethodID(cls, "onPopupClosed",
+            "(JLjava/lang/String;Ljava/lang/String;)V");
+        if (mid) {
+            env->CallVoidMethod(rp->popup_callback, mid, rp->popup_id, ju, jp);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (ju) env->DeleteLocalRef(ju);
+    if (jp) env->DeleteLocalRef(jp);
+    if (detach) jvm->DetachCurrentThread();
+}
+
+// Tear down a retained-but-unadopted child.  MUST run on rp->worker_thread_id
+// (the COM apartment owning controller/webview) -- callers dispatch it there.
+// ON-DEVICE-VALIDATION-REQUIRED: Close/Release ordering + global-ref frees.
+static void free_inherited_refs(JavaVM *jvm, jobject popup_cb,
+                                jobject dialog_cb) {
+    if (!jvm || (!popup_cb && !dialog_cb)) return;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return;
+        detach = true;
+    }
+    if (env) {
+        if (popup_cb) env->DeleteGlobalRef(popup_cb);
+        if (dialog_cb) env->DeleteGlobalRef(dialog_cb);
+    }
+    if (detach) jvm->DetachCurrentThread();
+}
+
+static void retained_popup_teardown(RetainedPopup *rp, bool fire_closed) {
+    if (!rp) return;
+    if (fire_closed) fire_popup_closed_retained(rp);
+    if (rp->webview) { rp->webview->Release(); rp->webview = nullptr; }
+    if (rp->controller) {
+        rp->controller->Close();
+        rp->controller->Release();
+        rp->controller = nullptr;
+    }
+    if (rp->holder) { DestroyWindow(rp->holder); rp->holder = nullptr; }
+    if (rp->environment) { rp->environment->Release(); rp->environment = nullptr; }
+    free_inherited_refs(rp->jvm, rp->popup_callback, rp->dialog_callback);
+    rp->popup_callback = nullptr;
+    rp->dialog_callback = nullptr;
+    delete rp;
+}
+
+// window.close() raised by a retained child BEFORE it is adopted -> discard it.
+// Runs on the child's WebView2 worker thread (the opener's), so the COM
+// teardown is on the correct apartment.  Claims under the mutex so an adoption
+// racing the close wins-or-loses exactly once (whoever removes from the
+// registry owns the teardown).
+class RetainedPopupCloseHandler : public CallbackBase<
+    ICoreWebView2WindowCloseRequestedEventHandler> {
+public:
+    explicit RetainedPopupCloseHandler(RetainedPopup *rp) : m_rp(rp) {}
+    HRESULT STDMETHODCALLTYPE Invoke(ICoreWebView2 *, IUnknown *) override {
+        if (!m_rp) return S_OK;
+        RetainedPopup *rp = nullptr;
+        {
+            std::lock_guard<std::mutex> lk(g_win_retained_popups_mutex);
+            auto it = g_win_retained_popups.find(m_rp->popup_id);
+            if (it != g_win_retained_popups.end() && it->second == m_rp) {
+                rp = it->second;
+                g_win_retained_popups.erase(it);
+            }
+        }
+        if (rp) retained_popup_teardown(rp, /*fire_closed=*/true);
+        return S_OK;
+    }
+private:
+    RetainedPopup *m_rp;
+};
+
 // window.close() from the popup (or the user closing the native window).
 // Notify onPopupClosed, then DestroyWindow -> PopupWndProc WM_DESTROY frees
 // the controller/webview and deletes the PopupWindow.
@@ -857,17 +1131,186 @@ public:
         Engine *e = m_engine;
         bool gesture = (user_initiated != FALSE);
         std::thread([e, args, deferral, uri, page, gesture, req_w, req_h] {
-            bool allow = fire_popup_requested_win(e, uri.c_str(), gesture,
-                                                  req_w, req_h, page.c_str());
+            // Canvas 20: the disposition switch replaces the Canvas-17 boolean
+            // gate.  0=BLOCK, 1=NATIVE_WINDOW (the unchanged Canvas-17
+            // engine-owned shown-window path), 2=ADOPT (retain a windowless
+            // child for later adoption into a caller-provided component).
+            jint disposition = fire_popup_disposition_win(
+                e, uri.c_str(), gesture, req_w, req_h, page.c_str());
             dispatch_to_thread(e, [e, args, deferral, uri, page, gesture,
-                                   req_w, req_h, allow] {
-                if (!allow) {
+                                   req_w, req_h, disposition] {
+                if (disposition == 0) {   // BLOCK
                     args->put_Handled(TRUE);   // block; window.open -> null
                     deferral->Complete();
                     deferral->Release();
                     args->Release();
                     return;
                 }
+                if (disposition == 2) {   // ADOPT — retain windowless child
+                    // Need the opener's environment to build a LINKED child
+                    // (window.opener / postMessage / POST replay).  Without it
+                    // we cannot honour ADOPT -> block.
+                    if (!e->environment) {
+                        args->put_Handled(TRUE);
+                        deferral->Complete();
+                        deferral->Release();
+                        args->Release();
+                        return;
+                    }
+                    ensure_popup_holder_class_registered();
+                    // Hidden holder top-level window -- NEVER ShowWindow.  The
+                    // child renders offscreen here until adoption reparents it
+                    // via put_ParentWindow.  (WebView2 requires a real parent
+                    // HWND for the controller.)
+                    HWND holder = CreateWindowEx(
+                        0, "WebViewEmbedPopupHolder", "", WS_OVERLAPPEDWINDOW,
+                        CW_USEDEFAULT, CW_USEDEFAULT,
+                        req_w > 0 ? req_w : 500, req_h > 0 ? req_h : 650,
+                        nullptr, nullptr, GetModuleHandle(nullptr), nullptr);
+                    if (!holder) {
+                        args->put_Handled(TRUE);
+                        deferral->Complete();
+                        deferral->Release();
+                        args->Release();
+                        return;
+                    }
+                    // Inherit the opener's popup/dialog callbacks as NEW global
+                    // refs so the retained child keeps working (nested popups +
+                    // dialogs) until adoption transfers them to the adopted
+                    // engine.  ON-DEVICE-VALIDATION-REQUIRED: global-ref
+                    // lifecycle across retain -> adopt/discard.
+                    JavaVM *jvm = e->jvm;
+                    jobject inh_popup = nullptr;
+                    jobject inh_dialog = nullptr;
+                    if (jvm) {
+                        JNIEnv *jenv = nullptr;
+                        bool jdetach = false;
+                        if (jvm->GetEnv((void **)&jenv, JNI_VERSION_1_6)
+                                != JNI_OK) {
+                            jvm->AttachCurrentThread((void **)&jenv, nullptr);
+                            jdetach = true;
+                        }
+                        if (jenv) {
+                            if (e->popup_callback)
+                                inh_popup = jenv->NewGlobalRef(e->popup_callback);
+                            if (e->dialog_callback)
+                                inh_dialog =
+                                    jenv->NewGlobalRef(e->dialog_callback);
+                        }
+                        if (jdetach) jvm->DetachCurrentThread();
+                    }
+
+                    RetainedPopup *rp = new RetainedPopup();
+                    rp->holder = holder;
+                    rp->jvm = jvm;
+                    rp->url = uri;
+                    rp->page = page;
+                    rp->popup_callback = inh_popup;
+                    rp->dialog_callback = inh_dialog;
+                    rp->worker_thread_id = e->thread_id;
+                    rp->environment = e->environment;
+                    rp->environment->AddRef();
+                    rp->popup_id = (jlong)(LONG_PTR)rp;
+
+                    auto *ctrl_handler = new ControllerHandler(
+                        [e, args, deferral, rp, uri, page, gesture,
+                         req_w, req_h]
+                        (HRESULT r2, ICoreWebView2Controller *ctrl) {
+                            if (FAILED(r2) || !ctrl) {
+                                WV_LOG("adopt CreateController completion "
+                                       "failed: 0x%08lx", (unsigned long)r2);
+                                args->put_Handled(TRUE);
+                                deferral->Complete();
+                                deferral->Release();
+                                args->Release();
+                                // rp never entered the registry; tear the
+                                // half-built shell down on THIS (worker) thread.
+                                retained_popup_teardown(rp,
+                                                        /*fire_closed=*/false);
+                                return;
+                            }
+                            ctrl->AddRef();
+                            rp->controller = ctrl;
+                            ICoreWebView2 *child = nullptr;
+                            ctrl->get_CoreWebView2(&child);
+                            if (child) { child->AddRef(); rp->webview = child; }
+
+                            // Return the LINKED child to WebView2 so it drives
+                            // the original request (POST verb+body,
+                            // window.opener) into it.
+                            args->put_NewWindow(child);
+                            args->put_Handled(TRUE);
+                            deferral->Complete();
+
+                            // Keep it HIDDEN: no ShowWindow, controller not
+                            // visible.  It renders offscreen until adoption.
+                            RECT rc;
+                            GetClientRect(rp->holder, &rc);
+                            ctrl->put_Bounds(rc);
+                            ctrl->put_IsVisible(FALSE);
+
+                            if (child) {
+                                // Retained-phase handlers reuse the opener
+                                // engine's callbacks (opener outlives the
+                                // retained child until adoption).  Tokens are
+                                // stored so adoption can remove them before the
+                                // adopted engine wires its own handlers.
+                                auto *nwh = new NewWindowRequestedHandler(e);
+                                child->add_NewWindowRequested(
+                                    nwh, &rp->new_window_token);
+                                nwh->Release();
+
+                                ICoreWebView2Settings *settings = nullptr;
+                                if (SUCCEEDED(child->get_Settings(&settings)) &&
+                                    settings) {
+                                    settings
+                                        ->put_AreDefaultScriptDialogsEnabled(
+                                            FALSE);
+                                    settings->Release();
+                                }
+                                auto *sdh = new ScriptDialogHandler(e);
+                                child->add_ScriptDialogOpening(
+                                    sdh, &rp->script_dialog_token);
+                                sdh->Release();
+
+                                // window.close() before adoption -> discard.
+                                auto *rch = new RetainedPopupCloseHandler(rp);
+                                child->add_WindowCloseRequested(
+                                    rch, &rp->close_token);
+                                rch->Release();
+                            }
+
+                            {
+                                std::lock_guard<std::mutex> lk(
+                                    g_win_retained_popups_mutex);
+                                g_win_retained_popups[rp->popup_id] = rp;
+                            }
+
+                            // Notify Java: child retained + adoptable.  The Java
+                            // dispatcher marshals popupAdoptable to the EDT.
+                            fire_popup_adoptable_win(e, rp->popup_id,
+                                                     uri.c_str(), gesture,
+                                                     req_w, req_h, page.c_str());
+
+                            deferral->Release();
+                            args->Release();
+                        });
+                    HRESULT rc2 = e->environment->CreateCoreWebView2Controller(
+                        rp->holder, ctrl_handler);
+                    ctrl_handler->Release();
+                    if (FAILED(rc2)) {
+                        WV_LOG("adopt CreateCoreWebView2Controller call "
+                               "failed: 0x%08lx", (unsigned long)rc2);
+                        args->put_Handled(TRUE);
+                        deferral->Complete();
+                        deferral->Release();
+                        args->Release();
+                        retained_popup_teardown(rp, /*fire_closed=*/false);
+                    }
+                    return;
+                }
+                // disposition == 1: NATIVE_WINDOW -- the unchanged Canvas-17
+                // engine-owned shown-window path below.
                 int W = req_w > 0 ? req_w : 500;
                 int H = req_h > 0 ? req_h : 650;
                 ensure_popup_class_registered();
@@ -1301,7 +1744,33 @@ static Engine *create_engine(JNIEnv *env, jobject component, int debug) {
 
 static void destroy_engine(Engine *e) {
     if (!e) return;
-    if (e->thread_id) {
+    if (e->shared_thread) {
+        // Canvas 20: an ADOPTED engine shares the opener's WebView2 worker
+        // thread.  Posting WM_EMBED_QUIT here would exit the opener's message
+        // loop and tear the opener down too.  Instead synchronously Close() the
+        // controller/webview and destroy our child HWND on that shared thread,
+        // then fall through to free the global refs + delete e.  The opener's
+        // loop keeps running.  ON-DEVICE-VALIDATION-REQUIRED: apartment-correct
+        // Close/Release on the shared worker thread.
+        std::atomic<bool> done{false};
+        dispatch_to_thread(e, [e, &done] {
+            if (e->controller) {
+                e->controller->Close();
+                e->controller->Release();
+                e->controller = nullptr;
+            }
+            if (e->webview) {
+                e->webview->Release();
+                e->webview = nullptr;
+            }
+            if (e->child) {
+                DestroyWindow(e->child);
+                e->child = nullptr;
+            }
+            done.store(true);
+        });
+        while (!done.load()) Sleep(1);
+    } else if (e->thread_id) {
         PostThreadMessage(e->thread_id, WM_EMBED_QUIT, 0, 0);
     }
     // Release the focus callback global ref BEFORE the WebView2 worker
@@ -1418,6 +1887,120 @@ static std::string wide_to_utf8(LPCWSTR w) {
     return s;
 }
 
+// Build a normal embedded Engine from a claimed RetainedPopup, reusing its
+// child controller/webview (apartment-bound to the opener's worker thread).
+// The retained COM references + inherited global refs are TRANSFERRED into the
+// returned Engine (rp is a plain shell freed by the dispatched op -- its raw
+// pointers are copied, not re-released, so no double-free).  Returns the Engine
+// (never null here; the caller already validated the claim).  The reparent +
+// handler registration happen asynchronously on the shared worker thread; the
+// Engine is returned immediately with a valid controller/webview so Java gets a
+// usable peer handle.  ON-DEVICE-VALIDATION-REQUIRED: put_ParentWindow reparent
+// of a live (mid-navigation) controller, and the retained->adopted handler
+// handoff.
+static Engine *adopt_retained_popup(JNIEnv *env, HWND parent, RetainedPopup *rp,
+                                    int debug) {
+    Engine *e = new Engine();
+    e->parent = parent;
+    e->debug = debug != 0;
+    e->jvm = rp->jvm;
+    e->shared_thread = true;                 // reuse opener's worker thread
+    e->thread_id = rp->worker_thread_id;
+    e->thread = nullptr;
+    e->controller = rp->controller;          // transferred (already AddRef'd)
+    e->webview = rp->webview;                // transferred (already AddRef'd)
+    e->environment = rp->environment;        // transferred (already AddRef'd)
+    e->popup_callback = rp->popup_callback;  // inherited global refs transferred
+    e->dialog_callback = rp->dialog_callback;
+
+    // Everything below touches WebView2 objects, so it MUST run on the
+    // controller's apartment thread (the opener's worker thread).
+    post_to_worker_thread(rp->worker_thread_id, [e, parent, rp] {
+        ICoreWebView2 *child = e->webview;
+        // Remove the retained-phase handlers (bound to the opener engine)
+        // before wiring the adopted engine's own handlers, so exactly one
+        // handler set survives (analogue of Linux disconnect_by_data).
+        if (child) {
+            child->remove_NewWindowRequested(rp->new_window_token);
+            child->remove_ScriptDialogOpening(rp->script_dialog_token);
+            child->remove_WindowCloseRequested(rp->close_token);
+        }
+
+        // Create the standard child HWND under the adopting AWT canvas HWND,
+        // exactly like a freshly-created engine, so WM_SIZE / WM_PARENTNOTIFY
+        // (the click hook) behave identically.
+        ensure_class_registered();
+        RECT pr;
+        GetClientRect(parent, &pr);
+        int cw = pr.right - pr.left;
+        int chh = pr.bottom - pr.top;
+        if (cw <= 0) cw = 1;
+        if (chh <= 0) chh = 1;
+        e->child = CreateWindowEx(0, "WebViewEmbedChild", "",
+                                  WS_CHILD | WS_VISIBLE, 0, 0, cw, chh,
+                                  parent, nullptr, GetModuleHandle(nullptr),
+                                  nullptr);
+        if (e->child) SetWindowLongPtr(e->child, GWLP_USERDATA, (LONG_PTR)e);
+
+        // Reparent the retained controller into the adopting surface and make
+        // it visible.
+        if (e->controller) {
+            e->controller->put_ParentWindow(e->child ? e->child : parent);
+            RECT rc;
+            GetClientRect(e->child ? e->child : parent, &rc);
+            e->controller->put_Bounds(rc);
+            e->controller->put_IsVisible(TRUE);
+
+            auto *gh = new FocusHandler(e, true);
+            e->controller->add_GotFocus(gh, &e->got_focus_token);
+            gh->Release();
+            auto *lh = new FocusHandler(e, false);
+            e->controller->add_LostFocus(lh, &e->lost_focus_token);
+            lh->Release();
+        }
+
+        if (child) {
+            ICoreWebView2Settings *settings = nullptr;
+            if (SUCCEEDED(child->get_Settings(&settings)) && settings) {
+                settings->put_AreDevToolsEnabled(e->debug ? TRUE : FALSE);
+                settings->put_AreDefaultContextMenusEnabled(TRUE);
+                settings->put_AreDefaultScriptDialogsEnabled(FALSE);
+                settings->Release();
+            }
+            child->AddScriptToExecuteOnDocumentCreated(
+                L"window.external = { invoke: s => "
+                L"window.chrome.webview.postMessage(s) };",
+                nullptr);
+
+            auto *mh = new MsgHandler(e);
+            child->add_WebMessageReceived(mh, &e->message_token);
+            mh->Release();
+
+            auto *sdh = new ScriptDialogHandler(e);
+            child->add_ScriptDialogOpening(sdh, &e->script_dialog_token);
+            sdh->Release();
+
+            auto *nwh = new NewWindowRequestedHandler(e);
+            child->add_NewWindowRequested(nwh, &e->new_window_token);
+            nwh->Release();
+        }
+
+        // The hidden holder top-level window is no longer needed once the
+        // controller has been reparented onto the adopting child HWND above.
+        // Destroy it on this (its creating) worker thread to avoid leaking a
+        // top-level HWND per adopted popup.  retained_popup_teardown does the
+        // same on the discard/close paths.
+        if (rp->holder) { DestroyWindow(rp->holder); rp->holder = nullptr; }
+
+        // Free the retained shell.  Its COM references + global refs were
+        // TRANSFERRED to e (copied, not re-AddRef'd), so DO NOT release them
+        // here; just free the struct.
+        delete rp;
+    });
+
+    return e;
+}
+
 } // namespace embed_win
 
 // ---------------------------------------------------------------------------
@@ -1504,36 +2087,6 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1nav
     env->ReleaseStringUTFChars(url, u);
     embed_win::dispatch_to_thread(e, [e, w] {
         if (e->webview) e->webview->Navigate(w.c_str());
-    });
-}
-
-// Custom User-Agent — Canvas 21.  ua == null / empty restores the engine
-// default.  Applied on the WebView2 UI thread via ICoreWebView2Settings2;
-// no-op on an old runtime lacking the _2 settings interface.  Takes effect on
-// the next navigation.
-JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1user_1agent
-  (JNIEnv *env, jclass, jlong wv, jstring ua) {
-    auto *e = (Engine *)wv;
-    if (!e) return;
-    std::wstring w;
-    if (ua) {
-        const char *s = env->GetStringUTFChars(ua, nullptr);
-        w = embed_win::utf8_to_wide(s);
-        env->ReleaseStringUTFChars(ua, s);
-    }
-    embed_win::dispatch_to_thread(e, [e, w] {
-        if (!e->webview) return;
-        ICoreWebView2Settings *settings = nullptr;
-        if (SUCCEEDED(e->webview->get_Settings(&settings)) && settings) {
-            ICoreWebView2Settings2 *settings2 = nullptr;
-            if (SUCCEEDED(settings->QueryInterface(
-                    __uuidof(ICoreWebView2Settings2),
-                    reinterpret_cast<void **>(&settings2))) && settings2) {
-                settings2->put_UserAgent(w.c_str()); // empty -> default
-                settings2->Release();
-            }
-            settings->Release();
-        }
     });
 }
 
@@ -1803,6 +2356,106 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
   (JNIEnv *, jclass, jlong, jobject) {
     // Windows has no offscreen engine; stub for link-symmetry across all
     // three native binaries.
+}
+
+JNIEXPORT jlong JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1adopt_1popup
+  (JNIEnv *, jclass, jint, jint, jlong, jint) {
+    // Windows has no offscreen engine (webview_offscreen_create returns 0), so
+    // adoption into a lightweight component is never triggered here; return 0.
+    // Popup adoption on Windows uses the heavyweight webview_embed_adopt_popup
+    // path (Canvas 20).  Stub for link-symmetry (Canvas 19 offscreen bridge).
+    return 0;
+}
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1discard_1popup
+  (JNIEnv *, jclass, jlong, jlong) {
+    // Windows has no offscreen engine; stub for link-symmetry.
+}
+
+// Custom User-Agent — Canvas 21.  ua == null / empty restores the engine
+// default.  Applied on the WebView2 UI thread via ICoreWebView2Settings2;
+// no-op on an old runtime lacking the _2 settings interface.  Takes effect on
+// the next navigation.
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1user_1agent
+  (JNIEnv *env, jclass, jlong wv, jstring ua) {
+    auto *e = (Engine *)wv;
+    if (!e) return;
+    std::wstring w;
+    if (ua) {
+        const char *s = env->GetStringUTFChars(ua, nullptr);
+        w = embed_win::utf8_to_wide(s);
+        env->ReleaseStringUTFChars(ua, s);
+    }
+    embed_win::dispatch_to_thread(e, [e, w] {
+        if (!e->webview) return;
+        ICoreWebView2Settings *settings = nullptr;
+        if (SUCCEEDED(e->webview->get_Settings(&settings)) && settings) {
+            ICoreWebView2Settings2 *settings2 = nullptr;
+            if (SUCCEEDED(settings->QueryInterface(
+                    __uuidof(ICoreWebView2Settings2),
+                    reinterpret_cast<void **>(&settings2))) && settings2) {
+                settings2->put_UserAgent(w.c_str()); // empty -> default
+                settings2->Release();
+            }
+            settings->Release();
+        }
+    });
+}
+
+// Adopt a retained popup child (Canvas 20) into `parent`'s realized AWT HWND.
+// Resolves the parent HWND via the SAME JAWT path as webview_embed_create,
+// claims the RetainedPopup (adopt-once under the mutex; 0 -> Java throws
+// IllegalStateException), and reuses its controller/webview.
+JNIEXPORT jlong JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1adopt_1popup
+  (JNIEnv *env, jclass, jobject component, jlong popupId, jint debug) {
+    // Resolve the parent AWT HWND (same mechanism as create_engine).
+    HWND parent = nullptr;
+    {
+        JawtLock lock(env, component);
+        if (!lock.ok || !lock.dsi->platformInfo) {
+            WV_LOG("adopt_popup: JAWT lock failed");
+            return 0;
+        }
+        auto *info = (JAWT_Win32DrawingSurfaceInfo *)lock.dsi->platformInfo;
+        parent = info->hwnd;
+    }
+    if (!parent) {
+        WV_LOG("adopt_popup: JAWT platform info had no HWND");
+        return 0;
+    }
+    // Claim the retained popup (adopt-once).  0 for unknown/consumed id ->
+    // EmbeddedWebView.adopt turns it into IllegalStateException.
+    embed_win::RetainedPopup *rp = nullptr;
+    {
+        std::lock_guard<std::mutex> lk(embed_win::g_win_retained_popups_mutex);
+        auto it = embed_win::g_win_retained_popups.find(popupId);
+        if (it == embed_win::g_win_retained_popups.end()) return 0;
+        rp = it->second;
+        embed_win::g_win_retained_popups.erase(it);
+    }
+    Engine *e = embed_win::adopt_retained_popup(env, parent, rp, debug);
+    return (jlong)e;
+}
+
+// Discard a retained-but-unadopted popup child (Canvas 20 reclaim path).  `wv`
+// (any live embed peer) is unused on Windows -- the retained child is located
+// by popupId alone.  Unknown id is a silent no-op.  The COM teardown is
+// dispatched onto the child's owning worker thread.
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1discard_1popup
+  (JNIEnv *, jclass, jlong /*wv*/, jlong popupId) {
+    embed_win::RetainedPopup *rp = nullptr;
+    {
+        std::lock_guard<std::mutex> lk(embed_win::g_win_retained_popups_mutex);
+        auto it = embed_win::g_win_retained_popups.find(popupId);
+        if (it == embed_win::g_win_retained_popups.end()) return;
+        rp = it->second;
+        embed_win::g_win_retained_popups.erase(it);
+    }
+    // Tear down on the apartment thread that owns the controller/webview.
+    DWORD tid = rp->worker_thread_id;
+    embed_win::post_to_worker_thread(tid, [rp] {
+        embed_win::retained_popup_teardown(rp, /*fire_closed=*/true);
+    });
 }
 
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1release_1native_1focus


### PR DESCRIPTION
Two related capabilities for making real third-party web apps work in an embedded WebView, developed on the same branch.

---

## 1. Popup adoption into a caller-provided WebViewComponent (Canvas 18)

Lets an app host a browser-initiated popup — the opener-linked child the engine raises for `window.open` / `<a target="_blank">` / `<form method="post" target="…">` — inside a `WebViewComponent` it supplies (a tab) instead of the native window the engine owns. Reusing the engine's own child preserves the in-flight request (POST verb + body) and `window.opener` linkage, which the block-and-GET-reopen workaround cannot.

- `PopupDisposition {BLOCK, NATIVE_WINDOW, ADOPT}`; `WebViewPopupHandler.popupDisposition` (default derives from `popupRequested` → fully backward compatible) + `popupAdoptable`.
- `PopupDispatcher`: disposition routing, `claimAdopt` (adopt-once), reclaim + grace backstop.
- `WebViewComponent.adoptPopup(...)`; `EmbeddedWebView.adopt` / `discardRetainedPopup`.
- Two-phase model: sync ADOPT decision on the native thread; async reparent on the EDT.

### Native backends — all three platforms
- **macOS (WKWebView)** — reference backend: retain child, no `NSWindow`, reparent via `addSubview:`.
- **Linux (WebKitGTK, Canvas 19)** — heavyweight (`XReparentWindow`) **and** lightweight/offscreen (`GtkOffscreenWindow` + cairo→`BufferedImage` blit). Lightweight is the Linux default (heavyweight has unreliable text-input feedback), so adoption works in the default mode.
- **Windows (WebView2, Canvas 20)** — heavyweight: retain an opener-linked windowless child against a hidden holder HWND, reparent via `ICoreWebView2Controller::put_ParentWindow` on the opener's shared worker thread. Windows has no offscreen engine, so it is heavyweight-only.

## 2. Custom User-Agent (Canvas 21)

`WebViewComponent.setUserAgent(String)` / `getUserAgent()` — overrides the engine UA. Unlike a JS `navigator.userAgent` shim, this changes the actual **HTTP `User-Agent` request header**, so it fixes server-side UA gating (e.g. sites rejecting WKWebView's default UA, which lacks the `Version/…Safari/…` tokens).

- `null`/empty restores the engine default; applied before the first navigate at attach, live afterward (next navigation).
- Native: macOS `WKWebView.customUserAgent`, Linux `webkit_settings_set_user_agent`, Windows `ICoreWebView2Settings2::UserAgent`.

---

## Testing
- `javac` clean on all main sources (Java 8 target).
- `PopupDispatcherTest` + `WebViewComponentUserAgentTest`: **37/37 pass** headless.
- **Native: on-device validation required.** macOS and Linux (heavyweight + lightweight) adoption have been exercised on-device via the adopt-popup demos. Windows native code is **unbuilt in the sandbox** (no MSVC/WebView2 toolchain) — it is pattern-faithful to the macOS/Linux backends and compiles under Windows CI, but still needs on-device validation via `run-windows-adopt-popup-demo.bat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)