### PR TITLE
feat: popups inherit the opener's custom User-Agent (Canvas 21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,11 @@ wv.setUrl("https://example.com/");   // first request carries the custom UA
 * **Timing.** Called before display, it applies to the first request. Called
   after display, it applies to the **next** navigation (engines don't rewrite
   the in-flight request for the current page).
+* **Popups inherit it.** A browser-initiated popup (`window.open`,
+  `target="_blank"`, or a POST that targets a new window) — whether adopted
+  into a `WebViewComponent` tab or opened in a native window — carries the
+  opener's custom UA on its **first** request. When the opener has no override,
+  the popup uses the engine default.
 * **Platform coverage.** macOS `WKWebView.customUserAgent`, Linux WebKitGTK
   `webkit_settings_set_user_agent`, Windows WebView2
   `ICoreWebView2Settings2::UserAgent`. The native setters ship

--- a/demos/WebViewAdoptPopupDemo/src/ca/weblite/webview/demos/WebViewAdoptPopupDemo.java
+++ b/demos/WebViewAdoptPopupDemo/src/ca/weblite/webview/demos/WebViewAdoptPopupDemo.java
@@ -43,6 +43,14 @@ import javax.swing.ToolTipManager;
  *       WebViewComponent#setUserAgent(String)} on the opener and reloads, so
  *       both the JS-visible UA and the HTTP header (visible in the httpbin
  *       echo) change.</li>
+ *   <li><b>Popup UA inheritance</b> (Canvas 21) — after Set UA, click
+ *       {@code window.open &rarr; popup} (or submit the POST form): the popup
+ *       opens {@code https://httpbin.org/user-agent}, which echoes the UA the
+ *       popup's <em>first</em> request carried.  With the fix the popup echoes
+ *       the opener's custom UA (not the engine default) in both Adopt and
+ *       Native-window modes; with Reset UA it echoes the engine default.  This
+ *       verifies the opener's override is applied to the popup child before its
+ *       in-flight initial navigation.</li>
  * </ul>
  *
  * <p>The POST/echo checks hit {@code https://httpbin.org/post}, so they need

--- a/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
+++ b/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
@@ -36,6 +36,27 @@ generated_at: 2026-08-06T14:00:00-07:00
   and the engine's default UA is used — byte-for-byte today's
   behaviour.
 
+- **Popup inheritance.** A browser-initiated popup
+  (`window.open` / `target="_blank"` / POST-to-new-window),
+  whether **adopted** into a caller-supplied `WebViewComponent` tab
+  (ADOPT) or hosted in an **engine-owned window** (NATIVE_WINDOW),
+  inherits the opener's custom User-Agent. The override is applied
+  to the newly created popup child **before its initial (in-flight)
+  navigation**, so the popup's **first** request carries the opener's
+  UA — not the engine default. When the opener has no override, the
+  child keeps the engine default. This holds on macOS, Linux, and
+  Windows. **Why.** `customUserAgent` (and its per-engine analogues)
+  is a per-view **instance** property, not part of the
+  `WKWebViewConfiguration` / related-view linkage the child inherits
+  from the opener, so without explicit propagation the popup's first
+  request goes out with the engine default UA — on macOS that lacks
+  the `Safari` token, so UA-gating sites (e.g. Cloudbeds `/connect/…`,
+  which 301s any non-Safari UA to `/browsererror`) block the popup
+  even though the opener tab loads fine. Cross-references the popup
+  canvases that own the child-creation sites: Canvas 15 (`window.open`
+  / macOS), Canvas 16/17 (native-window Linux/Windows), and Canvas
+  18/19/20 (popup adoption macOS/Linux/Windows).
+
 - Definition of Done:
   - `wv.setUserAgent("…Safari…")` before display makes the first and
     subsequent navigations send that `User-Agent` header on all three
@@ -50,6 +71,12 @@ generated_at: 2026-08-06T14:00:00-07:00
     User-Agent field + Set/Reset so the real HTTP header change is
     verifiable via an httpbin echo; run with
     `./run-mac-adopt-popup-demo.sh`.
+  - A popup opened from an opener that has a custom UA sends that UA on
+    its **first** (and subsequent) request on all three engines, for
+    both the ADOPT and NATIVE_WINDOW dispositions; an opener at the
+    engine default yields a popup at the engine default. Verifiable in
+    `WebViewAdoptPopupDemo`: the `window.open → popup` button opens
+    `https://httpbin.org/user-agent`, which echoes the popup's UA.
 
 - Out of scope: per-request UA switching; UA-Client-Hints
   (`Sec-CH-UA`) customisation; spoofing `navigator.userAgent` from
@@ -83,6 +110,31 @@ generated_at: 2026-08-06T14:00:00-07:00
 - **`src_c/webview_embed.cpp`** (modified — macOS + Linux),
   **`windows/webview_embed.cc`** (modified — Windows): per-engine
   setters + JNI bridges.
+- **Popup-child creation sites** (modified — the propagation points
+  for popup inheritance):
+  - macOS `impl_create_web_view` (the `WKUIDelegate`
+    `createWebViewWithConfiguration:` handler) in
+    `src_c/webview_embed.cpp`: right after the child `WKWebView` is
+    created from the shared configuration, and **before** the window
+    setup so it covers BOTH dispositions, reads the opener engine's
+    `customUserAgent` (`e->webview`) and, when non-nil, calls
+    `setCustomUserAgent:` on the child.
+  - Linux `handle_create_web_view` (the shared `create`-signal inner)
+    in `src_c/webview_embed.cpp`: right after
+    `webkit_web_view_new_with_related_view(opener)` creates the child,
+    copies the opener view's user-agent onto the child's
+    `WebKitSettings`.
+  - Windows `NewWindowRequestedHandler` in `windows/webview_embed.cc`:
+    in both the ADOPT (retained) and NATIVE_WINDOW controller-ready
+    completions, sets the child's UA via
+    `ICoreWebView2Settings2::put_UserAgent` from the opener engine's
+    tracked override, before completing the deferral.
+- **Windows `Engine`** (modified). Gains a tracked custom-UA field
+  (the last non-empty UA passed to the embed setter; empty ⇒ engine
+  default) so the `NewWindowRequested` handler — which runs on the
+  WebView2 worker thread and cannot distinguish an override from the
+  default via `get_UserAgent` — can propagate the opener's override to
+  the child.
 - **WebViewComponentUserAgentTest** (new), **README.md** (modified).
 
 ```mermaid
@@ -134,6 +186,35 @@ OffscreenWebView ..> WebViewNative : JNI
    exception-free (never throw across JNI). A `null` jstring maps to
    the clear path.
 
+5. **Popup inheritance at creation.** The custom-UA override is
+   per-view instance state, not part of the shared configuration /
+   related-view linkage a popup child inherits from its opener, so the
+   child must be given the opener's override explicitly — at the
+   child-creation site, **before** WebKit/WebView2 drives the original
+   in-flight navigation-action request into it. Prefer reading the
+   opener's effective override back from the **live opener view** where
+   the engine exposes a getter that distinguishes an override from the
+   default; otherwise track the last override on the opener engine.
+   Per engine:
+   - macOS reads `customUserAgent` off the opener `WKWebView`, which
+     returns `nil` when unset — a clean override/default distinction,
+     so an engine-default opener leaves the child untouched (child
+     keeps the engine default).
+   - Linux reads the opener view's `WebKitSettings` user-agent and
+     copies it onto the child's settings. The GTK getter returns the
+     effective UA (it cannot signal "no override"), but copying the
+     opener's effective UA is harmless: an unset opener's UA is the
+     engine default, and copying it onto a same-engine child is
+     byte-identical to the child's own default. This also composes for
+     nested popups — a popup's child reads the popup view's already
+     propagated UA.
+   - Windows reads a tracked override on the opener `Engine` (recorded
+     alongside `put_UserAgent`; empty ⇒ default), because
+     `ICoreWebView2Settings2::get_UserAgent` likewise cannot signal
+     "no override". An empty tracked value leaves the child untouched.
+     Nested popups reuse the opener engine, so they inherit the same
+     override.
+
 ## S · Structure
 
 ### Inheritance Relationships
@@ -146,6 +227,10 @@ OffscreenWebView ..> WebViewNative : JNI
    (`EmbeddedWebView`/`OffscreenWebView`).
 2. Engine wrappers → `WebViewNative` natives → per-engine setter.
 3. `createPeer()` / `addNotify()` → apply pending UA before navigate.
+4. Popup-child creation site → opener's effective override (read from
+   the opener view on macOS/Linux, from the opener `Engine`'s tracked
+   value on Windows) → child view's UA, before the child's in-flight
+   initial navigation.
 
 ### Layered Architecture
 1. Native engine layer (`src_c/webview_embed.cpp`,
@@ -235,6 +320,45 @@ File: `windows/webview_embed.cc`
    semantics, the "changes the HTTP header (unlike a JS shim)" note,
    and the next-navigation timing.
 
+### 9. Popup inherits the opener's custom UA
+Propagate the opener's effective custom User-Agent to a newly created
+popup child **before its initial navigation**, for BOTH the ADOPT and
+NATIVE_WINDOW dispositions, on all three engines.
+1. macOS — `src_c/webview_embed.cpp`, `impl_create_web_view`:
+   immediately after the child `WKWebView` is created via
+   `initWithFrame:configuration:` (and **before** the `if (!adopt)`
+   window setup, so it applies to both dispositions), read the opener
+   engine's `customUserAgent` from `e->webview`; when non-nil, call
+   `setCustomUserAgent:` on the child with that value. When the opener
+   has no override, `customUserAgent` is `nil` and the child is left at
+   the engine default. Guard for `e` being null.
+2. Linux — `src_c/webview_embed.cpp`, `handle_create_web_view`:
+   immediately after `webkit_web_view_new_with_related_view(opener)`
+   returns the child (and before the window / ref setup), read the
+   opener view's user-agent via
+   `webkit_settings_get_user_agent(webkit_web_view_get_settings(opener))`
+   and, when non-null, set it on the child's settings via
+   `webkit_settings_set_user_agent(webkit_web_view_get_settings(child),
+   …)`. Guard for `opener` and both settings being non-null. This also
+   composes for nested popups (a popup's child reads the popup view's
+   already propagated UA).
+3. Windows — `windows/webview_embed.cc`:
+   a. `Engine` gains a tracked custom-UA field holding the last
+      non-empty UA passed to the embed setter (empty ⇒ default). The
+      embed UA setter records it on the WebView2 worker thread,
+      alongside its existing `put_UserAgent` call, so reads from the
+      `NewWindowRequested` completion (same worker thread) see a
+      consistent value.
+   b. In `NewWindowRequestedHandler`'s controller-ready completion,
+      for BOTH the ADOPT (retained) and NATIVE_WINDOW child branches,
+      after the child `ICoreWebView2` is obtained and **before**
+      `deferral->Complete()`, when the opener engine's tracked override
+      is non-empty, query `ICoreWebView2Settings2` from the child's
+      settings and `put_UserAgent(tracked)`. No-op on an old runtime
+      lacking the `_2` interface (mirrors the embed setter's tolerance).
+      Nested popups reuse the opener engine, so they inherit the same
+      override.
+
 ## N · Norms
 
 - **Mirror `pendingUrl`** lifecycle: store on the component, apply at
@@ -247,6 +371,13 @@ File: `windows/webview_embed.cc`
 - **Java 8 target**; get-style accessors (`setUserAgent`/
   `getUserAgent`) matching `setUrl`/`getUrl`.
 - **No new dependency; no JS shim; no reserved binding.**
+- **Popup inheritance runs at the child-creation site, before the
+  child's in-flight navigation**, covers both dispositions on all three
+  engines, and never propagates an empty override: an opener at the
+  engine default leaves the child at the engine default (macOS `nil`
+  `customUserAgent` / Windows empty tracked value ⇒ child untouched;
+  Linux copies the effective UA, which equals the child's own default
+  when the opener is unset).
 
 ## S · Safeguards
 
@@ -263,7 +394,18 @@ File: `windows/webview_embed.cc`
   exists only touch the `pendingUserAgent` field; no
   `HeadlessException`.
 - **WebView2 old-runtime tolerance:** absent `ICoreWebView2Settings2`
-  → silent no-op, not a crash.
+  → silent no-op, not a crash (applies to the popup-inheritance
+  propagation too).
+- **Popup UA inheritance (both dispositions, all engines):** applied to
+  the child **before** its first request; opener-default ⇒
+  child-default (macOS `nil` `customUserAgent`, Windows empty tracked
+  value ⇒ child untouched; Linux copies the effective UA, which equals
+  the child's own default when unset). Must not affect the opener's own
+  UA, and must not depend on the caller having set a UA (unset ⇒ no
+  propagation). On-device validation required (no native toolchain in
+  the sandbox): confirm the popup's first request carries the opener's
+  UA via an echo endpoint (`WebViewAdoptPopupDemo` `window.open` →
+  `https://httpbin.org/user-agent`), for both ADOPT and NATIVE_WINDOW.
 - **Native coverage status (mirrors Canvas 15/18):** the Java
   contract (Ops 1–5, 8) plus the macOS + Linux native setters (Op 6)
   and the Windows setter (Op 7) are this canvas's deliverable. The

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -1156,6 +1156,25 @@ static GtkWidget *handle_create_web_view(JavaVM *jvm, jobject popup_cb,
     if (!childw) return NULL;
     WebKitWebView *child = WEBKIT_WEB_VIEW(childw);
 
+    // Canvas 21: propagate the opener's User-Agent to the popup child BEFORE
+    // its in-flight initial navigation.  A child from
+    // webkit_web_view_new_with_related_view gets fresh default settings, so
+    // copy the opener view's user-agent onto the child's WebKitSettings.  The
+    // GTK getter returns the effective UA (it cannot signal "no override"), but
+    // copying an unset opener's default UA onto a same-engine child is byte-
+    // identical to the child's own default, so the no-override case still
+    // yields the engine default.  Composes for nested popups: a popup's child
+    // reads the popup view's already-propagated UA.  Covers BOTH the ADOPT and
+    // NATIVE_WINDOW dispositions.
+    if (opener) {
+        WebKitSettings *os = webkit_web_view_get_settings(opener);
+        WebKitSettings *cs = webkit_web_view_get_settings(child);
+        if (os && cs) {
+            const char *oua = webkit_settings_get_user_agent(os);
+            if (oua) webkit_settings_set_user_agent(cs, oua);
+        }
+    }
+
     // NATIVE_WINDOW: host the child in an engine-owned native top-level window
     // (gtk_container_add sinks the widget's floating reference — the window owns
     // it).  ADOPT: create NO window; instead take an explicit strong reference
@@ -4115,6 +4134,19 @@ static id impl_create_web_view(id self, SEL, id webView, id configuration,
                                 CGRectMake(0, 0, W, H), configuration);
     if (!child) {
         return nullptr;
+    }
+
+    // Canvas 21: propagate the opener's custom User-Agent to the popup child
+    // BEFORE its in-flight initial navigation.  customUserAgent is a per-
+    // WKWebView INSTANCE property (NOT part of WKWebViewConfiguration), so the
+    // child does not inherit it from the shared config.  Reading it back from
+    // the opener returns nil when no override is set, so an engine-default
+    // opener correctly leaves the child at the engine default.  Applied here
+    // (before the `if (!adopt)` window setup) so it covers BOTH the ADOPT and
+    // NATIVE_WINDOW dispositions.
+    id openerUA = e ? msg(e->webview, sel("customUserAgent")) : nullptr;
+    if (openerUA) {
+        msg<void, id>(child, sel("setCustomUserAgent:"), openerUA);
     }
 
     // Attach a JNIEnv to create the child engine's inherited global refs.

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -171,6 +171,15 @@ struct Engine {
     // ON-DEVICE-VALIDATION-REQUIRED: shared-worker-thread lifecycle (opener
     // outliving / being disposed before the adopted child).
     bool shared_thread = false;
+
+    // Canvas 21 (popup UA inheritance).  The last NON-empty custom User-Agent
+    // passed to webview_embed_set_user_agent, tracked so the
+    // NewWindowRequested handler can propagate the opener's override to a
+    // popup child before its in-flight initial navigation.  Empty means "no
+    // override" (engine default) — ICoreWebView2Settings2::get_UserAgent
+    // cannot distinguish an override from the default, so we cache it here.
+    // Written / read on this engine's WebView2 worker thread only.
+    std::wstring user_agent;
 };
 
 static void fire_focus_callback(Engine *e, bool became) {
@@ -1089,6 +1098,28 @@ private:
     PopupWindow *m_pw;
 };
 
+// Canvas 21: propagate the opener's tracked custom User-Agent to a popup child
+// BEFORE its in-flight initial navigation (i.e. before deferral->Complete()).
+// No-op when the opener has no override (empty tracked value -> child keeps the
+// engine default) or on an old runtime lacking the ICoreWebView2Settings2
+// interface (mirrors the embed setter's tolerance).  Nested popups reuse the
+// opener engine, so they inherit the same override.  Covers BOTH the ADOPT and
+// NATIVE_WINDOW dispositions.
+static void propagate_popup_user_agent(Engine *opener, ICoreWebView2 *child) {
+    if (!opener || !child || opener->user_agent.empty()) return;
+    ICoreWebView2Settings *settings = nullptr;
+    if (SUCCEEDED(child->get_Settings(&settings)) && settings) {
+        ICoreWebView2Settings2 *settings2 = nullptr;
+        if (SUCCEEDED(settings->QueryInterface(
+                __uuidof(ICoreWebView2Settings2),
+                reinterpret_cast<void **>(&settings2))) && settings2) {
+            settings2->put_UserAgent(opener->user_agent.c_str());
+            settings2->Release();
+        }
+        settings->Release();
+    }
+}
+
 // NewWindowRequested -> allow/deny via Java, then create the linked child in an
 // engine-owned top-level window.  Deferral pattern; see the block comment.
 class NewWindowRequestedHandler : public CallbackBase<
@@ -1250,6 +1281,10 @@ public:
                             ctrl->get_CoreWebView2(&child);
                             if (child) { child->AddRef(); rp->webview = child; }
 
+                            // Canvas 21: inherit the opener's custom UA before
+                            // the child's in-flight initial navigation.
+                            propagate_popup_user_agent(e, child);
+
                             // Return the LINKED child to WebView2 so it drives
                             // the original request (POST verb+body,
                             // window.opener) into it.
@@ -1366,6 +1401,10 @@ public:
                         ICoreWebView2 *child = nullptr;
                         ctrl->get_CoreWebView2(&child);
                         if (child) { child->AddRef(); pw->webview = child; }
+
+                        // Canvas 21: inherit the opener's custom UA before the
+                        // child's in-flight initial navigation.
+                        propagate_popup_user_agent(e, child);
 
                         args->put_NewWindow(child);   // LINKED to opener
                         args->put_Handled(TRUE);
@@ -2402,6 +2441,10 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set
         env->ReleaseStringUTFChars(ua, s);
     }
     embed_win::dispatch_to_thread(e, [e, w] {
+        // Canvas 21: track the override so the NewWindowRequested handler can
+        // propagate it to popup children (empty == engine default).  Recorded
+        // on the worker thread, where the popup handler also reads it.
+        e->user_agent = w;
         if (!e->webview) return;
         ICoreWebView2Settings *settings = nullptr;
         if (SUCCEEDED(e->webview->get_Settings(&settings)) && settings) {


### PR DESCRIPTION
## Problem

A browser-initiated popup (`window.open` / `target="_blank"` / POST-to-new-window) did **not** inherit the opener's custom User-Agent. The popup's **first** (and often only) request went out with the engine **default** UA instead of the opener's `setUserAgent(...)` override.

The custom UA is a **per-view instance** property (macOS `customUserAgent`, WebKitGTK `WebKitSettings`, WebView2 `ICoreWebView2Settings2::UserAgent`) — it is **not** part of the `WKWebViewConfiguration` / related-view linkage the child inherits from its opener. WebKit/WebView2 then drives the original navigation-action request into the child immediately, so the popup's first request already carries the default UA.

On macOS the default WKWebView UA lacks the `Safari` token, so UA-gating sites (e.g. Cloudbeds `/connect/...`, which 301s any non-Safari UA to `/browsererror`) blocked the popup even though the opener tab loaded fine. Affected both **ADOPT** (popup-as-tab) and **NATIVE_WINDOW** dispositions.

## Fix

Propagate the opener's effective custom UA to the newly created popup child **before its in-flight initial navigation**, for **both** dispositions, on all three engines:

| Engine | Site | How |
|--------|------|-----|
| macOS | `impl_create_web_view` (`src_c/webview_embed.cpp`) | Read the opener `WKWebView`'s `customUserAgent` (nil when unset) and `setCustomUserAgent:` on the child, right after creation and **before** the `if (!adopt)` window setup |
| Linux | `handle_create_web_view` (`src_c/webview_embed.cpp`) | Copy the opener view's `WebKitSettings` user-agent onto the child's settings, right after `webkit_web_view_new_with_related_view(opener)` |
| Windows | `NewWindowRequestedHandler` (`windows/webview_embed.cc`) | Track the last non-empty UA on the opener `Engine` (since `get_UserAgent` can't distinguish an override from the default) and apply it to the child via `ICoreWebView2Settings2::put_UserAgent` before `deferral->Complete()`, in both child branches |

**No-override case:** when the opener has no custom UA, the child keeps the engine default — macOS `customUserAgent` is nil ⇒ child untouched; Windows tracked value is empty ⇒ child untouched; Linux copies the opener's effective UA, which is byte-identical to the child's own default on the same engine. Nested popups inherit the same override (Linux/macOS read the popup view back; Windows nested handlers reuse the opener engine).

## SPDD

This is a behavior change, so the change went through the workflow:

- **Canvas 21** (`spdd/prompt/21-…-Custom-User-Agent.md`) updated via `/spdd-prompt-update`: new **Popup inheritance** requirement in R, propagation entities in E, approach in A, dependency in S, **Operation 9** in O, plus Norms + Safeguards. Cross-references the popup creation/adoption canvases (15/16/17/18/19/20).
- Code generated via `/spdd-generate` (Op 9 only — Ops 1–8 already implemented, unchanged).

## Verification

- Headless `WebViewComponentUserAgentTest`: **5/5 pass** (Java contract unchanged — this fix is native-only).
- `WebViewAdoptPopupDemo` already opens `https://httpbin.org/user-agent` from its `window.open` button, which echoes the popup's UA; demo Javadoc + README now document the expected inheritance. After the fix the popup echoes the opener's UA (not the default) for both ADOPT and NATIVE_WINDOW.
- ⚠️ **No native toolchain in the sandbox** (WebKitGTK dev headers absent), so the three per-engine propagations are pattern-faithful but **must be built and exercised on-device** before release — confirm the popup's first request carries the opener's UA via the httpbin echo on macOS, Linux, and Windows.

## Follow-up

- **Cut a 1.3.1 release** after merge (release versioning is managed outside this `pom.xml`, which is `1.0-SNAPSHOT`) so the agentic-app-framework can bump its `webview-run.version` / `ca.weblite:webview` dependency and pick up the fix.
- Out of scope (noted in the task): a separate quit-time `SIGSEGV in objc_msgSend` inside `embed::cocoa_destroy_engine(...)` during `-[NSApplication terminate:]` — worth its own canvas/fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C82aKTwNiM2P1URk5NADiz

---
_Generated by [Claude Code](https://claude.ai/code/session_01C82aKTwNiM2P1URk5NADiz)_