### PR TITLE
Fix SIGSEGV on app quit during engine/popup teardown (macOS + Linux)

### DIFF
--- a/spdd/prompt/15-20260802-1000-[Feat]-Browser-Initiated-Popups-Window-Open.md
+++ b/spdd/prompt/15-20260802-1000-[Feat]-Browser-Initiated-Popups-Window-Open.md
@@ -698,7 +698,22 @@ File: `src_c/webview_embed.cpp` (Cocoa)
    `onPopupRequested` inline on AppKit main. Every path either returns
    a valid child or `nil`; a child engine's `dialog_callback` and
    `popup_callback` are inherited so the popup itself supports dialogs
-   and nested popups.
+   and nested popups. `impl_web_view_did_close` recovers the engine
+   from the delegate's `"eng"` associated object and, before any
+   release, clears that association (`objc_setAssociatedObject(self,
+   "eng", nil, OBJC_ASSOCIATION_ASSIGN)`), calls
+   `setUIDelegate:nil`, and removes the child from **both**
+   `g_webview_map` and (if present) `g_retained_popups` under their
+   mutexes — so a close arriving before adoption cannot leave a
+   dangling registry entry. It then frees the engine (`delete e`)
+   **only when the engine is not `java_owned`** (an engine-owned
+   native-window popup, or a retained-but-unadopted child): a
+   `java_owned` engine — a normal embedded engine, or a popup already
+   promoted by `cocoa_adopt_popup` — is owned by the Java
+   `EmbeddedWebView` and is freed exactly once by
+   `cocoa_destroy_engine`, so `impl_web_view_did_close` fires
+   `onPopupClosed` (when `popup_id != 0`) and returns without
+   deleting it, leaving the single free to the Java-driven destroy.
 5. JNI bridges `Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1popup_1callback`
    and `…_webview_1offscreen_1set_1popup_1callback` in the existing
    `extern "C"` block (`:4544`), `#ifdef`-dispatching to
@@ -858,10 +873,22 @@ File: `test/ca/weblite/webview/PopupDispatcherTest.java`
   Never return a half-constructed child web view.
 - **Child-engine teardown ordering.** `webViewDidClose:` /
   `close` / `WindowCloseRequested` MUST clear the child's UI delegate
-  (`setUIDelegate:nil` etc.) before releasing the delegate and
-  window, and remove the child from `g_webview_map`, so no in-flight
-  selector dereferences a freed engine. Delete the inherited
-  `popup_callback` / `dialog_callback` global refs on teardown.
+  (`setUIDelegate:nil` etc.) and remove the delegate's `"eng"`
+  associated-object back-pointer before releasing the delegate and
+  window, and remove the child from `g_webview_map` (and, on macOS,
+  from `g_retained_popups` when a close races an unadopted child), so
+  no in-flight selector dereferences a freed engine. Delete the
+  inherited `popup_callback` / `dialog_callback` global refs on
+  teardown.
+- **A browser `window.close()` never frees a Java-owned engine.**
+  `impl_web_view_did_close` MUST NOT `delete` an engine flagged
+  `java_owned` (a normal embedded engine, or a popup already promoted
+  by `cocoa_adopt_popup`); that engine's single free is the
+  Java-driven `cocoa_destroy_engine`. Deleting from both the close
+  path and the dispose path is a double-free (observed as an
+  `objc_msgSend` crash on app quit). Only an engine-owned
+  native-window popup or a retained-but-unadopted child — neither of
+  which Java wraps — is freed by its close/discard path.
 - **`popupId` correlation is best-effort.** `dispatchPopupClosed`
   tolerates a missing map entry (builds a minimal event); a close
   without a prior open never NPEs.

--- a/spdd/prompt/18-20260806-1200-[Feat]-Popup-Adoption-Into-Webviewcomponent-Tab.md
+++ b/spdd/prompt/18-20260806-1200-[Feat]-Popup-Adoption-Into-Webviewcomponent-Tab.md
@@ -585,6 +585,10 @@ File: `src_c/webview_embed.cpp` (Cocoa)
    parent bounds; promote `child_e` to a normal embedded engine keyed
    by `parentEngine`'s peer (re-point `popup_callback`/`dialog_callback`
    to the parent's, register in `g_webview_map`, keep the UI delegate);
+   set `child_e->java_owned = true` (Canvas 6) so the promoted engine
+   is now owned by the adopting `EmbeddedWebView` and is freed exactly
+   once by `cocoa_destroy_engine` — a later `window.close()`
+   (`webViewDidClose:`) on the adopted child MUST NOT free it;
    remove from `g_retained_popups`; return the child engine handle.
 4. `cocoa_discard_popup(jlong popupId)`: look up + remove from
    `g_retained_popups`; `setUIDelegate:nil`; delete inherited global
@@ -710,12 +714,30 @@ Files: `README.md`, `test/ca/weblite/webview/PopupDispatcherTest.java`
   sweep per pending id, cancelled on claim) elapses — whichever comes
   first — with a logged diagnostic. No busy-wait; no silent drop.
 - **Child-engine teardown ordering.** `cocoa_adopt_popup` and
-  `cocoa_discard_popup` MUST clear the UI delegate and update
+  `cocoa_discard_popup` MUST clear the UI delegate (and remove the
+  delegate's `"eng"` associated-object back-pointer) and update
   `g_webview_map` / `g_retained_popups` before releasing native
   objects, and manage the inherited `popup_callback`/`dialog_callback`
   global refs with the delete-old / new-global-ref lifecycle — no
   double-free, no dereference of a freed engine (mirrors
   `impl_web_view_did_close`).
+- **An adopted child is freed exactly once (crash-safe on quit).**
+  Adoption transfers lifecycle ownership to the Java
+  `EmbeddedWebView`: `cocoa_adopt_popup` sets `java_owned = true`
+  (Canvas 6). From that point the child is torn down **only** by
+  `cocoa_destroy_engine` (Java `dispose()`), which is idempotent
+  (`peer` nulled before the native call). A browser-initiated
+  `window.close()` on the adopted child routes through
+  `webViewDidClose:`, which — seeing `java_owned` — fires
+  `onPopupClosed` and returns WITHOUT `delete e`. This closes the
+  observed use-after-free where an adopted-then-closed popup was
+  freed by `webViewDidClose:` and then messaged again by the
+  `cocoa_destroy_engine` main-queue block during
+  `-[NSApplication terminate:]` (`objc_msgSend` SIGSEGV on quit).
+  Symmetrically, `cocoa_destroy_engine` clears the delegate and its
+  `"eng"` association before freeing, so a `window.close()` that
+  drains after the engine is gone recovers `nil` and no-ops. The
+  two paths are mutually exclusive on `delete`, never racing it.
 - **Opener linkage + POST are mandatory (AC1/AC2).** The adopted child
   MUST be the WebKit-created child from the passed configuration;
   creating a fresh view or re-navigating from Java is a defect.

--- a/spdd/prompt/19-20260806-1600-[Feat]-Popup-Adoption-Linux-Coverage.md
+++ b/spdd/prompt/19-20260806-1600-[Feat]-Popup-Adoption-Linux-Coverage.md
@@ -515,6 +515,18 @@ File: `src_c/webview_embed.cpp` (GTK)
    run-file-chooser/close (NOT ready-to-show); register in
    `g_gtk_retained_popups`; `fire_popup_notify_adoptable`.
 4. `on_ready_to_show_popup`: early-return when `pe->window == nullptr`.
+5. `on_close_popup` MUST be crash-safe when a `window.close()` races an
+   unadopted ADOPT child (a windowless `pe` still in the registry): it
+   first claims `pe` from `g_gtk_retained_popups` under
+   `g_gtk_retained_popups_mutex` (remove-if-present), so no later
+   `gtk_adopt_popup` / `gtk_discard_popup` can find and re-tear-down the
+   same shell. For a windowless child (`pe->window == nullptr` but
+   `pe->web != nullptr`) it disconnects the child's handlers,
+   `gtk_widget_destroy`s the child, and drops the `g_object_ref_sink`
+   reference (`g_object_unref`) — mirroring `gtk_discard_popup`'s
+   windowless teardown — instead of leaking the child and its ref. The
+   NATIVE_WINDOW path (`pe->window != nullptr`) is unchanged. `delete
+   pe` happens exactly once, after the notify + teardown.
 
 ### 4. `gtk_create_engine` reuse parameter
 File: `src_c/webview_embed.cpp` (GTK)
@@ -690,6 +702,19 @@ File: `src/ca/weblite/webview/swing/WebViewLightweightComponent.java`
   the child down, frees the inherited refs, and deletes the shell — the
   Linux end of the Canvas 18 reclaim contract (opener dispose +
   grace-period backstop, both driven from the unchanged Java side).
+- **Close-before-adopt is claim-guarded (no dangling registry entry,
+  no leak).** A `window.close()` on an ADOPT child that has not yet been
+  adopted invokes `on_close_popup` while the shell is still registered
+  in `g_gtk_retained_popups`. `on_close_popup` MUST claim (remove) the
+  shell from the registry under `g_gtk_retained_popups_mutex` before
+  freeing it, so a subsequent `gtk_adopt_popup` / `gtk_discard_popup`
+  cannot dereference a freed `PopupEngine`; and for the windowless
+  child it MUST destroy the widget and drop the `g_object_ref_sink`
+  reference (parity with `gtk_discard_popup`) rather than skipping the
+  `pe->window`-gated teardown and leaking. Whoever removes the id from
+  the registry owns the single teardown (mirrors the macOS
+  `g_retained_popups` claim rule and the Windows
+  `RetainedPopupCloseHandler`).
 - **JNI bridges inside `extern "C"`.** The GTK-branch edit does not move
   the heavyweight bridges; keeping them inside `extern "C"` is mandatory
   (UnsatisfiedLinkError otherwise — the documented, previously-fixed

--- a/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
+++ b/spdd/prompt/6-20260516-0719-[Feat]-Swing-Heavyweight-Webview-Embedding.md
@@ -487,6 +487,18 @@ generated_at: 2026-05-16T07:19:13-07:00
     against. Used by destroy / window-change to call
     `removeObserver:forKeyPath:` against the right target;
     never `release`d (it's an unowned back-pointer).
+  - `java_owned: bool` — default `false`. Set `true` for any
+    engine whose lifecycle is owned by a Java `EmbeddedWebView`
+    wrapper (i.e. Java will call `webview_embed_destroy` →
+    `cocoa_destroy_engine` exactly once for it): every engine
+    created via `cocoa_create_engine`, and any popup child
+    promoted to a real embedded engine by `cocoa_adopt_popup`
+    (Canvas 18). A browser-initiated `window.close()`
+    (`webViewDidClose:`) MUST NOT free a `java_owned` engine —
+    doing so would double-free it against the Java-driven
+    destroy. Left `false` for engine-owned popup windows and
+    retained-but-unadopted popup children, whose sole owner is
+    their native close / discard path.
 
 ## A · Approach
 - **Heavyweight peer hosts the native view.** AWT/JAWT exposes a
@@ -2261,14 +2273,22 @@ Files:
      KVO firstResponder observer from
      `e->observed_window` (if any) and the
      `window`-keypath observer from `e->webview`; clear
-     `e->kvo_observer` / `e->observed_window`; call
+     `e->kvo_observer` / `e->observed_window`; clear
+     `e->webview`'s `uiDelegate` (`setUIDelegate:nil`)
+     and remove the `"eng"` associated-object
+     back-pointer from `e->ui_delegate` (set it to `nil`
+     with `OBJC_ASSOCIATION_ASSIGN`) BEFORE the delegate
+     or the WKWebView is released — so a `webViewDidClose:`
+     that the main queue drains during
+     `NSApplication terminate:` recovers a `nil` engine
+     and returns without messaging any freed object; call
      `[e->webview removeFromSuperview]`; release
-     `e->host_view` / `e->surface_layers` /
-     `e->webview` / `e->config`; walk `e->bindings`
-     releasing each Java global ref (the JNI attach /
-     detach pattern existing destroy uses); `delete e`.
-     The JNI entry returns immediately after enqueueing
-     the lambda.
+     `e->ui_delegate` / `e->host_view` /
+     `e->surface_layers` / `e->webview` / `e->config`;
+     walk `e->bindings` releasing each Java global ref
+     (the JNI attach / detach pattern existing destroy
+     uses); `delete e`. The JNI entry returns immediately
+     after enqueueing the lambda.
    - Every other async-on-main lambda
      (`cocoa_navigate` / `cocoa_eval` /
      `cocoa_init_script` / `cocoa_set_bounds` /
@@ -2720,6 +2740,20 @@ Files:
   window, registered against the new window) if the
   WKWebView's `window` property changes at runtime; the atomic
   cache MUST be recomputed immediately after the move.
+- **Both unretained `"eng"` back-pointers MUST be neutralised
+  before the engine is freed.** The engine is reachable from
+  two `OBJC_ASSOCIATION_ASSIGN` associations: the WKUIDelegate's
+  `"eng"` (used by the dialog / popup selectors and
+  `webViewDidClose:`) and the external-message
+  `WKScriptMessageHandler`'s `"eng"`. The destroy lambda MUST
+  clear the delegate association (set `"eng"` to `nil`) and MUST
+  drop the script-message handler
+  (`removeScriptMessageHandlerForName:` for the `external` name
+  on `e->manager`) before releasing the delegate / config /
+  WKWebView — so neither a `webViewDidClose:` nor a late
+  `didReceiveScriptMessage:` draining during
+  `-[NSApplication terminate:]` can recover and message a freed
+  `Engine`.
 - The `Engine.destroyed: std::atomic<bool>` MUST be set to
   `true` as the FIRST action inside the destroy lambda,
   before any AppKit teardown runs. Every other
@@ -2734,6 +2768,32 @@ Files:
   (b) future code changes that violate the
   EDT-only-enqueue invariant, and (c) the `cocoa_eval`
   late-completion path that needs a clean signalling channel.
+- **Termination-time teardown is crash-safe (no message to a
+  freed object).** The destroy lambda MUST clear the WKWebView's
+  `uiDelegate` (`setUIDelegate:nil`) and MUST remove the
+  `"eng"` associated-object back-pointer from `e->ui_delegate`
+  (`objc_setAssociatedObject(ui, "eng", nil,
+  OBJC_ASSOCIATION_ASSIGN)`) BEFORE releasing the delegate or
+  the WKWebView. The `"eng"` back-pointer is unretained
+  (`OBJC_ASSOCIATION_ASSIGN`), so a `webViewDidClose:` (or any
+  WKUIDelegate selector) that the main dispatch queue drains
+  during `-[NSApplication terminate:]` — after the engine is
+  freed — MUST recover a `nil` engine and return without
+  dereferencing or messaging freed memory. Clearing the
+  association and the delegate is the enforcement point; the
+  `objc_msgSend` crash this prevents is a real observed
+  use-after-free on app quit.
+- **`java_owned` engines are freed exactly once, by the
+  Java-driven destroy.** An engine flagged `java_owned` (every
+  `cocoa_create_engine` engine; any `cocoa_adopt_popup`-promoted
+  child) is destroyed only through `EmbeddedWebView.dispose()` →
+  `webview_embed_destroy` → `cocoa_destroy_engine`, which the
+  Java side already makes idempotent (`peer` is nulled before
+  the native call). A browser-initiated `window.close()`
+  (`webViewDidClose:`) MUST NOT `delete` a `java_owned` engine;
+  it may fire the close notification and neutralise state, but
+  the single `delete e` belongs to `cocoa_destroy_engine`.
+  Freeing from both paths is the double-free this rule forbids.
 - `EmbeddedWebView.dispose()` ordering (Java-side) MUST be
   preserved under async destroy: drain the `EvalDispatcher`
   first, clear focus / click callbacks (try/catch),

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -1287,12 +1287,36 @@ static void on_ready_to_show_popup(WebKitWebView *web, gpointer user_data) {
 static void on_close_popup(WebKitWebView *web, gpointer user_data) {
     PopupEngine *pe = static_cast<PopupEngine *>(user_data);
     if (!pe) return;
+    // If this child is still registered as a retained-but-unadopted ADOPT
+    // popup (window.close() raced adoption), claim it from the registry
+    // under the mutex so a later gtk_adopt_popup / gtk_discard_popup cannot
+    // find and re-tear-down the same freed shell.  Whoever removes the id
+    // owns the single teardown (mirrors the macOS g_retained_popups claim
+    // rule and the Windows RetainedPopupCloseHandler).
+    {
+        std::lock_guard<std::mutex> lk(g_gtk_retained_popups_mutex);
+        auto it = g_gtk_retained_popups.find(pe->popup_id);
+        if (it != g_gtk_retained_popups.end() && it->second == pe) {
+            g_gtk_retained_popups.erase(it);
+        }
+    }
     const char *url = webkit_web_view_get_uri(web);
     fire_gtk_popup_closed(pe->jvm, pe->popup_callback, pe->dialog_callback,
                           pe->popup_id, url ? url : "", "");
     if (pe->window) {
+        // NATIVE_WINDOW popup: destroying the window destroys its child.
         gtk_widget_destroy(pe->window);
         pe->window = nullptr;
+        pe->web = nullptr;
+    } else if (pe->web) {
+        // Windowless ADOPT child closed BEFORE adoption: no window owns it,
+        // so disconnect its handlers, destroy the widget directly, and drop
+        // the g_object_ref_sink reference taken in handle_create_web_view
+        // (parity with gtk_discard_popup) instead of leaking the child and
+        // its ref.
+        g_signal_handlers_disconnect_by_data(pe->web, pe);
+        gtk_widget_destroy(GTK_WIDGET(pe->web));
+        g_object_unref(pe->web);
         pe->web = nullptr;
     }
     JNIEnv *env = nullptr;
@@ -3136,6 +3160,18 @@ struct Engine {
     // onPopupOpened / onPopupClosed pair.  nullptr / 0 on a normal engine.
     id popup_window = nullptr;
     jlong popup_id = 0;
+
+    // True when a Java EmbeddedWebView owns this engine's lifecycle -- i.e.
+    // Java calls webview_embed_destroy -> cocoa_destroy_engine exactly once
+    // for it.  Set for every cocoa_create_engine engine and for any popup
+    // child promoted to a real embedded engine by cocoa_adopt_popup.  A
+    // browser-initiated window.close() (impl_web_view_did_close) MUST NOT
+    // free a java_owned engine -- doing so double-frees it against the
+    // Java-driven destroy (the objc_msgSend use-after-free observed on app
+    // quit).  Left false for engine-owned native-window popups and
+    // retained-but-unadopted popup children, whose sole owner is their
+    // native close / discard path.
+    bool java_owned = false;
 };
 
 // Process-global map from WKWebView (id) to its owning Engine*.  Populated
@@ -4232,16 +4268,57 @@ static void impl_web_view_did_close(id self, SEL, id webView) {
     if (!e) return;
     std::string url = page_url_utf8(webView);
     JavaVM *jvm = e->jvm;
-    jobject popup_cb = e->popup_callback;
-    jobject dialog_cb = e->dialog_callback;
     jlong pid = e->popup_id;
 
-    // Detach the delegate and drop from the map BEFORE releasing so no
-    // in-flight selector dereferences a freed engine.
+    // A browser-initiated window.close() must NEVER free an engine whose
+    // lifecycle Java owns (a normal embedded engine, or a popup already
+    // promoted by cocoa_adopt_popup).  That engine is freed exactly once by
+    // cocoa_destroy_engine (EmbeddedWebView.dispose(), which is idempotent);
+    // deleting it here too double-frees it -- the objc_msgSend
+    // use-after-free observed on app quit when the destroy main-queue block
+    // messaged the already-freed objects during -[NSApplication terminate:].
+    // Fire onPopupClosed (for a real popup) using COPIES of the inherited
+    // global refs so the async worker never frees the engine's own refs,
+    // then return without touching native objects or the engine.
+    if (e->java_owned) {
+        if (pid != 0 && e->popup_callback) {
+            JNIEnv *env = nullptr;
+            bool detach = false;
+            if (jvm && jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+                jvm->AttachCurrentThread((void **)&env, nullptr);
+                detach = true;
+            }
+            jobject pc = nullptr, dc = nullptr;
+            if (env) {
+                pc = env->NewGlobalRef(e->popup_callback);
+                if (e->dialog_callback) dc = env->NewGlobalRef(e->dialog_callback);
+            }
+            if (detach && jvm) jvm->DetachCurrentThread();
+            fire_popup_notify_closed(jvm, pc, dc, pid, url, "");
+        }
+        return;
+    }
+
+    // Non-Java-owned: an engine-owned native-window popup, or a
+    // retained-but-unadopted child.  We are its sole owner; tear it down.
+    jobject popup_cb = e->popup_callback;
+    jobject dialog_cb = e->dialog_callback;
+
+    // Detach the delegate, drop its unretained "eng" back-pointer, and drop
+    // from BOTH registries BEFORE releasing so no in-flight selector -- and
+    // no later cocoa_adopt_popup / cocoa_discard_popup lookup -- can recover
+    // and dereference a freed engine.  Erasing g_retained_popups closes the
+    // close-before-adopt race (a windowless ADOPT child whose page closes
+    // before the app adopts it would otherwise leave a dangling entry).
+    objc_setAssociatedObject(self, "eng", (id)nullptr, OBJC_ASSOCIATION_ASSIGN);
     msg<void, id>(webView, sel("setUIDelegate:"), nullptr);
     {
         std::lock_guard<std::mutex> lk(g_webview_map_mutex);
         g_webview_map.erase(webView);
+    }
+    if (pid != 0) {
+        std::lock_guard<std::mutex> lk(g_retained_popups_mutex);
+        g_retained_popups.erase(pid);
     }
     if (e->popup_window) {
         msg<void>(e->popup_window, sel("close"));
@@ -4817,6 +4894,10 @@ static void cocoa_set_click_callback(Engine *e, JNIEnv *env, jobject cb) {
 static Engine *cocoa_create_engine(JNIEnv *env, jobject parentComponent,
                                    jlong /*display*/, jint debug) {
     auto *e = new Engine();
+    // Java owns this engine's lifecycle: EmbeddedWebView.dispose() ->
+    // webview_embed_destroy -> cocoa_destroy_engine frees it exactly once.
+    // A page-initiated window.close() must never free it out from under Java.
+    e->java_owned = true;
     env->GetJavaVM(&e->jvm);
     e->debug = debug != 0;
 
@@ -5080,6 +5161,12 @@ static Engine *cocoa_adopt_popup(JNIEnv *env, jobject parentComponent,
     }
     if (!e) return nullptr;
 
+    // Adoption transfers lifecycle ownership to the adopting Java
+    // EmbeddedWebView: from here the child is freed exactly once, by
+    // cocoa_destroy_engine (dispose()).  A later window.close() on the
+    // adopted child (impl_web_view_did_close) MUST NOT free it.
+    e->java_owned = true;
+
     // Resolve the JAWT surface layers for the new parent (mirrors the
     // cocoa_create_engine prologue), then release the surface lock before the
     // async main-thread epilogue.
@@ -5203,6 +5290,11 @@ static void cocoa_discard_popup(jlong popupId) {
         e->popup_callback = nullptr;
         e->dialog_callback = nullptr;
         if (e->ui_delegate) {
+            // Drop the delegate's unretained "eng" back-pointer before
+            // releasing it, so a late WKUIDelegate selector cannot recover
+            // and message this freed engine (mirrors cocoa_destroy_engine).
+            objc_setAssociatedObject(e->ui_delegate, "eng", (id)nullptr,
+                                     OBJC_ASSOCIATION_ASSIGN);
             msg(e->ui_delegate, sel("release"));
             e->ui_delegate = nullptr;
         }
@@ -5361,6 +5453,18 @@ static void cocoa_destroy_engine(Engine *e) {
         cocoa_kvo_teardown(e);
 
 
+        // Neutralise the external-message WKScriptMessageHandler BEFORE
+        // releasing config/webview.  That handler carries an unretained
+        // "eng" back-pointer (OBJC_ASSOCIATION_ASSIGN) to this engine; if
+        // a didReceiveScriptMessage: drained during
+        // -[NSApplication terminate:] after the engine is freed it would
+        // dereference freed memory.  Removing the handler drops the
+        // userContentController's strong ref so it deallocates (taking its
+        // association with it).
+        if (e->manager) {
+            msg<void, id>(e->manager, sel("removeScriptMessageHandlerForName:"),
+                          ns_str("external"));
+        }
         if (e->webview) {
             // Clear the WKWebView's uiDelegate BEFORE releasing the
             // WKWebView so any in-flight delegate selector observes
@@ -5372,6 +5476,15 @@ static void cocoa_destroy_engine(Engine *e) {
             msg<void>(e->webview, sel("removeFromSuperview"));
         }
         if (e->ui_delegate) {
+            // Drop the delegate's unretained "eng" back-pointer BEFORE
+            // releasing it.  The WKUIDelegate selectors (webViewDidClose:,
+            // the dialog panels) recover the engine from this association;
+            // clearing it means a selector that the main dispatch queue
+            // drains during -[NSApplication terminate:], after this engine
+            // is freed, recovers nil and returns without messaging freed
+            // memory -- the objc_msgSend use-after-free this fix closes.
+            objc_setAssociatedObject(e->ui_delegate, "eng", (id)nullptr,
+                                     OBJC_ASSOCIATION_ASSIGN);
             msg<void>(e->ui_delegate, sel("release"));
             e->ui_delegate = nullptr;
         }


### PR DESCRIPTION
## Summary

Fixes a native use-after-free that crashes on app quit with a `SIGSEGV` in
`objc_msgSend`, inside the `cocoa_destroy_engine` main-queue block, while
`-[NSApplication terminate:]` drains the main dispatch queue. It reproduces
after a per-session browser has opened, adopted, and closed popups.

### Root cause

An **adopted popup** has its lifecycle owned by the Java `EmbeddedWebView`
that adopted it — Java calls `webview_embed_destroy` → `cocoa_destroy_engine`
for it. But a browser-initiated `window.close()` routed through
`webViewDidClose:` (`impl_web_view_did_close`) **also** did `delete e` on the
same `Engine`. So an adopted-then-closed popup was freed by `webViewDidClose:`
and then freed/messaged again by `cocoa_destroy_engine` at quit → double-free
→ `objc_msgSend` on freed memory.

Secondary issues in the same class:
- The WKUIDelegate's `"eng"` associated object (unretained,
  `OBJC_ASSOCIATION_ASSIGN`) was never cleared on teardown, so a
  `webViewDidClose:` draining **after** the engine was freed could recover a
  dangling pointer.
- `impl_web_view_did_close` never removed a still-retained child from
  `g_retained_popups`, leaving a dangling entry when a `window.close()` raced
  adoption.
- Linux `on_close_popup` had the same close-before-adopt hazard: a windowless
  ADOPT child that closed before adoption left a dangling
  `g_gtk_retained_popups` entry and leaked the widget + its ref.

## Changes

**macOS — `src_c/webview_embed.cpp`**
- New `Engine.java_owned`, set in `cocoa_create_engine` and
  `cocoa_adopt_popup`. `impl_web_view_did_close` now fires `onPopupClosed`
  (via **copied** global refs, so the async worker never frees the engine's
  own refs) and returns **without** `delete` for a `java_owned` engine — the
  single free belongs to the idempotent Java-driven `cocoa_destroy_engine`.
  Only engine-owned native-window and retained-but-unadopted popups are freed
  by the close path.
- `cocoa_destroy_engine` and `cocoa_discard_popup` now clear the delegate's
  `"eng"` association before releasing it; `cocoa_destroy_engine` also drops
  the external `WKScriptMessageHandler` (its own `"eng"` back-pointer). A late
  `webViewDidClose:` / `didReceiveScriptMessage:` after free recovers `nil`
  and messages nothing.
- The non-owned close path now also erases from `g_retained_popups`.

**Linux — `src_c/webview_embed.cpp`**
- `on_close_popup` claims the shell from `g_gtk_retained_popups` under its
  mutex and tears down a windowless ADOPT child (disconnect + destroy +
  `g_object_unref`) when `window.close()` races adoption.

**Windows** — audited, no change needed: `RetainedPopupCloseHandler` already
uses the claim-under-mutex "whoever removes owns teardown" rule, and adopted
engines get no re-armed `WindowCloseRequested` handler, so `window.close()`
never frees a Java-owned engine (the shared-thread `destroy_engine` is the
sole owner).

## SPDD

Behavior change, so the Canvases were updated first and the code regenerated
to match (committed together):
- Canvas 6 (heavyweight destroy): `Engine.java_owned`; destroy clears both
  unretained `"eng"` back-pointers; exactly-once-free + terminate-time
  crash-safety Safeguards.
- Canvas 15 (macOS popup close): `impl_web_view_did_close` `java_owned` gate,
  association clear, both-map removal.
- Canvas 18 (macOS adoption): adopt sets `java_owned`; exactly-once-free
  Safeguard.
- Canvas 19 (Linux adoption): `on_close_popup` claim-guarded windowless
  teardown.

## Validation

⚠️ The native teardown paths **cannot be compiled in this environment** (no
WebKit/Cocoa/GTK toolchain), matching the Canvases' existing
ON-DEVICE-VALIDATION-REQUIRED notes. Brace-balance and idiom review only.

Before tagging a release, please build and exercise on macOS:
1. Run the adopt-popup demo (`run-mac-adopt-popup-demo.sh`), open → adopt →
   close a popup, then quit — confirm no `SIGSEGV`.
2. Ideally run under AddressSanitizer to confirm no use-after-free.

## Release

The published `ca.weblite:webview` version is injected from a `v*` git tag at
CI time (`mvn versions:set` in `maven-release.yml`); the pom stays at
`1.0-SNAPSHOT`, so no pom edit is needed. Cutting **v1.3.2** = pushing the
`v1.3.2` tag, which triggers an irreversible Maven Central publish — do that
**after** this PR merges and the on-device validation above passes, not from
this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXQoFqetkkrSqRyPSruHzH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXQoFqetkkrSqRyPSruHzH)_