### PR TITLE
Fix adopted macOS popup sharing the opener's user-content controller (Canvas 18)

### DIFF
--- a/spdd/prompt/18-20260806-1200-[Feat]-Popup-Adoption-Into-Webviewcomponent-Tab.md
+++ b/spdd/prompt/18-20260806-1200-[Feat]-Popup-Adoption-Into-Webviewcomponent-Tab.md
@@ -573,11 +573,22 @@ File: `src_c/webview_embed.cpp` (Cocoa)
    - `NATIVE_WINDOW` (1): exactly today's window path (create child,
      `NSWindow`, `makeKeyAndOrderFront:`, register child engine, fire
      `onPopupOpened`).
-   - `ADOPT` (2): create child from `configuration`; build a child
-     `Engine` with `popup_window = nil`; `popup_id = (jlong)child_e`;
-     inherit callbacks as global refs; put in `g_retained_popups`;
-     fire `onPopupAdoptable(popup_id, …)` async; **do not** create an
-     `NSWindow`; return `child`.
+   - `ADOPT` (2): **isolate the child's script world first** — before
+     `initWithFrame:configuration:`, replace the passed
+     `configuration`'s `userContentController` with a **fresh, empty
+     `WKUserContentController`** so the child does not share the
+     opener's controller (see the "Adopted child owns its script world"
+     safeguard). Then create the child from `configuration`; build a
+     child `Engine` with `popup_window = nil`; `popup_id =
+     (jlong)child_e`; inherit callbacks as global refs; **install the
+     child's own `"external"` script-message handler (bound to the child
+     `Engine`) plus the `external.invoke` shim user script on the fresh
+     controller**, exactly as `cocoa_create_engine` does for a normal
+     engine, so the child's bridge messages route to the child engine's
+     bindings and never the opener's; put in `g_retained_popups`; fire
+     `onPopupAdoptable(popup_id, …)` async; **do not** create an
+     `NSWindow`; return `child`. (`NATIVE_WINDOW` is engine-owned and
+     unbridged, so its controller is left as WebKit provided it.)
 3. `cocoa_adopt_popup(Engine* parentEngine, jlong popupId)`: look up
    the retained child `Engine`; `id childView = child_e->webview`;
    `id parentView = <parentEngine's content NSView>`;
@@ -741,6 +752,26 @@ Files: `README.md`, `test/ca/weblite/webview/PopupDispatcherTest.java`
 - **Opener linkage + POST are mandatory (AC1/AC2).** The adopted child
   MUST be the WebKit-created child from the passed configuration;
   creating a fresh view or re-navigating from Java is a defect.
+- **Adopted child owns its script world (no opener cross-talk).** The
+  `configuration` WebKit hands the popup-create delegate shares the
+  **opener's `WKUserContentController`**, so without intervention the
+  opener's injected user scripts and its single `"external"`
+  script-message handler are shared with the child. An adopted child
+  cannot register its own `"external"` handler on that shared
+  controller (`addScriptMessageHandler:` throws on a duplicate name),
+  so its bound-function/eval bridge traffic was delivered to the
+  **opener** engine's handler — cross-wiring the two views (observed as
+  an adopted browser tab and its opener tab swapping/stealing each
+  other's address-bar URL). The `ADOPT` branch therefore swaps in a
+  **fresh `WKUserContentController`** before `initWithFrame:
+  configuration:` and installs the child's own `"external"` bridge +
+  shim on it. This isolates only the **script world**: `processPool`
+  and `websiteDataStore` remain on the rest of the configuration, so
+  `window.opener` and the in-flight POST (the AC1/AC2 guarantee above)
+  are preserved. macOS-only and scoped to `ADOPT`. **On-device build +
+  validation required** (the Linux CI sandbox has no macOS toolchain):
+  confirm `window.opener` and the POST still reach the adopted child
+  after the controller swap.
 - **`popupId` correlation is best-effort on close.** `popupClosed`
   tolerates a missing map entry; a close racing adoption never NPEs.
 - **Disposed dispatcher is inert.** After `disposeAll()`, the

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -4161,6 +4161,34 @@ static id impl_create_web_view(id self, SEL, id webView, id configuration,
     int W = req_w > 0 ? req_w : 500;
     int H = req_h > 0 ? req_h : 650;
 
+    // Isolate an ADOPT child's script world from the opener's.  The
+    // configuration WebKit hands us for a browser-initiated popup shares the
+    // opener's WKUserContentController, so the opener's injected user scripts
+    // and its single "external" script-message handler are shared with the
+    // child.  An adopted child never installs its own "external" handler
+    // (addScriptMessageHandler: with a name already present on the SAME
+    // controller throws), so its aaf* bridge messages -- including the address
+    // bar's location reporter -- were delivered to the OPENER engine's handler
+    // instead: the observed bug where an adopted tab (e.g. an Okta-launched
+    // Slack tab) drove the opener tab's URL field and vice-versa.  Swap in a
+    // fresh, empty controller BEFORE init so the child gets its own script
+    // world; the shared processPool / websiteDataStore (and therefore
+    // window.opener and the in-flight POST) live on the rest of the
+    // configuration and are untouched.  Scoped to ADOPT: a NATIVE_WINDOW popup
+    // is engine-owned and unbridged, so its controller is left as-is.
+    //
+    // ON-DEVICE VALIDATION REQUIRED (macOS): confirm window.opener + the
+    // in-flight POST still reach the adopted child after the controller swap.
+    if (adopt) {
+        id freshUCC = msg(objc_cls("WKUserContentController"), sel("alloc"));
+        freshUCC = msg(freshUCC, sel("init"));
+        if (freshUCC) {
+            msg<void, id>(configuration, sel("setUserContentController:"),
+                          freshUCC);
+            msg<void>(freshUCC, sel("release")); // configuration now owns it
+        }
+    }
+
     // Create the child WKWebView LINKED to the opener via the passed config.
     // WebKit drives the ORIGINAL navigation-action request (POST verb + body)
     // into this child regardless of disposition, which is what preserves POST
@@ -4237,6 +4265,33 @@ static id impl_create_web_view(id self, SEL, id webView, id configuration,
         std::lock_guard<std::mutex> lk(g_webview_map_mutex);
         g_webview_map[child] = child_e;
     }
+
+    // An ADOPT child was given its own (empty) WKUserContentController above,
+    // so install the child's OWN "external" script-message bridge + invoke
+    // shim on it -- bound to the CHILD engine -- exactly as cocoa_create_engine
+    // does for a normal engine.  Without this the isolated child would have no
+    // "external" handler at all and its aaf* bridge traffic would go nowhere;
+    // with it, the child's messages route to child_e's bindings (registered by
+    // the adopting Java EmbeddedWebView), never the opener's.  engine_on_message
+    // safely drops any message that arrives before those bindings exist.
+    if (adopt) {
+        Class mh_cls = get_webview_embed_delegate_cls();
+        id mh = msg((id)mh_cls, sel("new"));
+        objc_setAssociatedObject(mh, "eng", (id)child_e,
+                                 OBJC_ASSOCIATION_ASSIGN);
+        msg<void, id, id>(child_e->manager,
+                          sel("addScriptMessageHandler:name:"), mh,
+                          ns_str("external"));
+        id shim = msg(objc_cls("WKUserScript"), sel("alloc"));
+        shim = msg<id, id, long, BOOL>(
+            shim, sel("initWithSource:injectionTime:forMainFrameOnly:"),
+            ns_str("window.external={invoke:function(s){"
+                   "window.webkit.messageHandlers.external.postMessage(s);}};"),
+            (long)0 /* WKUserScriptInjectionTimeAtDocumentStart */,
+            YES);
+        msg<void, id>(child_e->manager, sel("addUserScript:"), shim);
+    }
+
     if (adopt) {
         std::lock_guard<std::mutex> lk(g_retained_popups_mutex);
         g_retained_popups[child_e->popup_id] = child_e;


### PR DESCRIPTION
## Summary

Fixes the "wires crossed" bug where an **adopted popup tab and its opener tab swap/steal each other's address-bar URL** (reported against the consuming app: an Okta app-launcher opening Slack in a new tab via the `TAB`/`ADOPT` popup strategy — the Okta tab shows Slack's URL, the Slack tab shows Okta's, and navigating Slack updates Okta's URL field).

## Root cause (macOS / WKWebView)

When a page calls `window.open`, WebKit invokes `createWebViewWithConfiguration:` with a configuration that **shares the opener's `WKUserContentController`** (this is what makes `window.opener` + the in-flight POST work). The adopted child engine (`impl_create_web_view`, `ADOPT` branch) is built from that configuration but **never registers its own `external` script-message handler** — `addScriptMessageHandler:` throws on a name already present on the *same* controller, and the opener already registered `external`.

So every message the child's page posts through the bridge (the per-view bound functions / eval channel — including the consumer's location reporter that drives the address bar) is delivered to the **opener** engine's single `external` handler. The two views' JS bridges cross-wire.

The macOS message handler routes purely by the delegate's stashed `eng` pointer (`userContentController:didReceiveScriptMessage:` → `objc_getAssociatedObject(self,"eng")`), so with one shared handler bound to the opener, the child's traffic lands on the opener.

## Fix

Scoped to the `ADOPT` disposition, in `impl_create_web_view`:

1. **Before `initWithFrame:configuration:`**, replace the configuration's `userContentController` with a fresh, empty `WKUserContentController` — giving the child its own isolated script world.
2. **After building the child `Engine`**, install the child's **own** `external` script-message handler (bound to the child engine) plus the `external.invoke` shim user script on that fresh controller — exactly as `cocoa_create_engine` does for a normal engine.

`processPool` and `websiteDataStore` remain on the rest of the configuration, so **`window.opener` and the in-flight POST are preserved** (the AC1/AC2 guarantee). `engine_on_message` safely drops any message that arrives before the adopting Java `EmbeddedWebView` registers its bindings. `NATIVE_WINDOW` popups are engine-owned and unbridged, so their controller is left as WebKit provided it.

No framework-side change is needed in the consuming app — the cross-talk was entirely at the native message-handler level.

## Changes

- `src_c/webview_embed.cpp` — the two `if (adopt)` blocks described above (macOS Cocoa path only).
- `spdd/prompt/18-…-Popup-Adoption-Into-Webviewcomponent-Tab.md` — records the decision (amended `ADOPT` operation) and a new **"Adopted child owns its script world"** safeguard, per SPDD.

## Validation

⚠️ **On-device build + validation required (macOS).** This is native Cocoa code and the CI sandbox has no macOS toolchain, so it could not be compiled or exercised here. Please verify on macOS that, after the controller swap:

- an adopted tab and its opener no longer cross their address bars, and each tab's bridge (URL reporter, WebMCP indicator, `browser_execute_js`) targets the right view;
- `window.opener` still resolves and a `<form method="post" target="…">` popup keeps its POST body in the adopted tab (OAuth "sign in with popup" still works).

Linux (Canvas 19) and Windows (Canvas 20) adoption paths are unaffected by this change and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0136Ei2wa6cjNJafcfqTC5jJ)_