### PR TITLE
Built-in password manager for the embedded WebView

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,11 @@ wv.setPasswordManagerEnabled(false);
 // Programmatic access (works regardless of the enabled flag):
 wv.saveCredential(new WebViewCredential("https://example.com", "alice", "s3cret"));
 Optional<WebViewCredential> c = wv.getCredential("https://example.com");
+List<WebViewCredential> everything = wv.getAllCredentials(); // all origins
 wv.deleteCredential("https://example.com", "alice");
+
+// Require a confirmation (or an OS biometric check) before autofill:
+wv.setFillPasswordHandler(WebViewFillPasswordHandler.CONFIRM);
 ```
 
 Key points:
@@ -508,6 +512,25 @@ Key points:
   "Save password?" policy (return a disposition programmatically for
   headless use).  Passing `null` to either restores the default.  Both
   getters never return `null`.
+* **Autofill consent.**  By default a stored credential is filled
+  silently on page load.  `setFillPasswordHandler(WebViewFillPasswordHandler)`
+  gates that: install `WebViewFillPasswordHandler.CONFIRM` for a
+  browser-style "Use the saved password for `<origin>`?" prompt, or your
+  own handler that performs an OS biometric / re-authentication check
+  (Touch ID, Windows Hello) and returns `DONT_FILL` to decline.  The
+  event handed to the handler carries only the origin and username —
+  never the password.  Passing `null` restores the silent-autofill
+  default; the getter never returns `null`.  The consent handler gates
+  the automatic page-load autofill only — the programmatic
+  `getCredential` / `getCredentials` / `getAllCredentials` reads are
+  trusted host calls and are never gated.
+* **Managing saved passwords.**  `getAllCredentials()` enumerates every
+  stored credential across all origins (most-recently-saved first) — the
+  primitive you need to build a Chrome-style "manage saved passwords"
+  screen on top of the OS-native store, combined with `saveCredential`
+  (add/edit) and `deleteCredential` (remove).  Like the origin-scoped
+  reads it returns credentials to host code only; page JavaScript has no
+  path to any stored credential.
 * **Security note.**  Once a credential is auto-filled it lives in the
   page DOM and is readable by any script running on that page — exactly
   the same exposure as a browser's autofill.  The library only ever fills

--- a/README.md
+++ b/README.md
@@ -495,11 +495,13 @@ Key points:
   origin is never offered on another (`http` vs `https`, a different
   port, or a different host are all distinct).
 * **OS-native storage.**  Passwords live only in the OS secret store —
-  macOS **Keychain** (this release); Linux **libsecret** / Secret Service
-  and Windows **Credential Manager** are wired in the follow-up releases.
-  On Windows the library uses its *own* Credential-Manager namespace, not
-  the Edge profile.  The library never writes a plaintext credential file
-  and never logs a password.
+  macOS **Keychain** and Windows **Credential Manager** are wired; Linux
+  **libsecret** / Secret Service is the remaining follow-up.  On Windows
+  the credentials are stored in the library's *own* Credential-Manager
+  namespace (per-user, DPAPI-protected), not the Edge profile, and Edge's
+  built-in password autosave is disabled so it does not compete with this
+  manager.  The library never writes a plaintext credential file and never
+  logs a password.
 * **Overridable seams.**  `setCredentialStore(WebViewCredentialStore)`
   swaps the backing store (e.g. `InMemoryCredentialStore` for tests);
   `setSavePasswordHandler(WebViewSavePasswordHandler)` replaces the
@@ -510,10 +512,11 @@ Key points:
   page DOM and is readable by any script running on that page — exactly
   the same exposure as a browser's autofill.  The library only ever fills
   the single origin-matched credential it chose to send.
-* **Coverage this release: macOS.**  On Linux and Windows the API is
-  present and the programmatic store degrades gracefully, but the
-  automatic capture / autofill activate once the per-platform native
-  channel and secret store land (Canvases 27 / 28).
+* **Coverage this release: macOS and Windows.**  Automatic capture /
+  autofill and the native secret store are wired on macOS (Keychain) and
+  Windows (Credential Manager).  On Linux the API is present and the
+  programmatic store degrades gracefully, but automatic capture / autofill
+  activate once the libsecret channel and store land (Canvas 27).
 
 Known limitation: multi-step / identifier-first login flows (username and
 password on separate pages, e.g. some Okta configurations) are captured

--- a/README.md
+++ b/README.md
@@ -553,6 +553,10 @@ best-effort per page; cross-page correlation is not guaranteed.
 See [`demos/WebViewPasswordDemo/`](demos/WebViewPasswordDemo/README.md)
 for a runnable example exercising capture, autofill, and the programmatic
 API in both the Keychain-backed and in-memory store modes.
+[`demos/WebViewPasswordOptInDemo/`](demos/WebViewPasswordOptInDemo/README.md)
+shows a **Chrome-style opt-in fill** — silent autofill suppressed, an
+account chooser under the focused login field, and a simulated unlock
+before the password is filled.
 
 ## Browser-initiated popups (`window.open`)
 

--- a/README.md
+++ b/README.md
@@ -499,12 +499,15 @@ Key points:
   origin is never offered on another (`http` vs `https`, a different
   port, or a different host are all distinct).
 * **OS-native storage.**  Passwords live only in the OS secret store —
-  macOS **Keychain** and Windows **Credential Manager** are wired; Linux
-  **libsecret** / Secret Service is the remaining follow-up.  On Windows
-  the credentials are stored in the library's *own* Credential-Manager
+  macOS **Keychain**, Windows **Credential Manager**, and Linux
+  **libsecret** / Secret Service (GNOME Keyring, KWallet, or any
+  freedesktop Secret Service provider) are all wired.  On Windows the
+  credentials are stored in the library's *own* Credential-Manager
   namespace (per-user, DPAPI-protected), not the Edge profile, and Edge's
   built-in password autosave is disabled so it does not compete with this
-  manager.  The library never writes a plaintext credential file and never
+  manager.  On Linux libsecret is loaded at runtime (`libsecret-1.so.0`);
+  where no Secret Service provider is available the store degrades to a
+  no-op.  The library never writes a plaintext credential file and never
   logs a password.
 * **Overridable seams.**  `setCredentialStore(WebViewCredentialStore)`
   swaps the backing store (e.g. `InMemoryCredentialStore` for tests);
@@ -535,11 +538,13 @@ Key points:
   page DOM and is readable by any script running on that page — exactly
   the same exposure as a browser's autofill.  The library only ever fills
   the single origin-matched credential it chose to send.
-* **Coverage this release: macOS and Windows.**  Automatic capture /
-  autofill and the native secret store are wired on macOS (Keychain) and
-  Windows (Credential Manager).  On Linux the API is present and the
-  programmatic store degrades gracefully, but automatic capture / autofill
-  activate once the libsecret channel and store land (Canvas 27).
+* **Coverage: all three platforms.**  Automatic capture / autofill and the
+  native secret store are wired on macOS (Keychain), Windows (Credential
+  Manager), and Linux (libsecret, both heavyweight and lightweight).  Where
+  a platform has no available secret store — notably a headless or
+  keyring-less Linux session — the store degrades to a graceful no-op:
+  page load and form submission still work, and the programmatic API
+  simply reports nothing stored.
 
 Known limitation: multi-step / identifier-first login flows (username and
 password on separate pages, e.g. some Okta configurations) are captured

--- a/README.md
+++ b/README.md
@@ -464,6 +464,65 @@ See [`demos/WebViewDownloadDemo/`](demos/WebViewDownloadDemo/README.md)
 for a runnable example that serves five download shapes from a loopback
 server and exercises all three handler modes.
 
+## Password manager
+
+The embedded engines (`WKWebView`, `WebKitGTK`, `WebView2`) do **not**
+give an embedding app the browser "offer to save this password / autofill
+it next time" experience — that is a browser-privileged feature the raw
+engine withholds.  `WebViewComponent` provides its own password manager
+instead: an injected script detects login-form submissions and the library
+shows a Swing "Save password?" prompt; on approval the credential is
+written to the **OS-native secret store**; on a later page load a stored
+credential for the same origin is auto-filled.
+
+```java
+WebViewComponent wv = WebViewComponent.create();
+// Enabled by default.  Turn it off with:
+wv.setPasswordManagerEnabled(false);
+
+// Programmatic access (works regardless of the enabled flag):
+wv.saveCredential(new WebViewCredential("https://example.com", "alice", "s3cret"));
+Optional<WebViewCredential> c = wv.getCredential("https://example.com");
+wv.deleteCredential("https://example.com", "alice");
+```
+
+Key points:
+
+* **Origin keying.** Credentials are keyed by page **origin** =
+  scheme + host + port (the default port is implied by the scheme, so
+  `https://example.com` and `https://example.com:443` are the same
+  origin).  Autofill is **exact-origin only** — a credential for one
+  origin is never offered on another (`http` vs `https`, a different
+  port, or a different host are all distinct).
+* **OS-native storage.**  Passwords live only in the OS secret store —
+  macOS **Keychain** (this release); Linux **libsecret** / Secret Service
+  and Windows **Credential Manager** are wired in the follow-up releases.
+  On Windows the library uses its *own* Credential-Manager namespace, not
+  the Edge profile.  The library never writes a plaintext credential file
+  and never logs a password.
+* **Overridable seams.**  `setCredentialStore(WebViewCredentialStore)`
+  swaps the backing store (e.g. `InMemoryCredentialStore` for tests);
+  `setSavePasswordHandler(WebViewSavePasswordHandler)` replaces the
+  "Save password?" policy (return a disposition programmatically for
+  headless use).  Passing `null` to either restores the default.  Both
+  getters never return `null`.
+* **Security note.**  Once a credential is auto-filled it lives in the
+  page DOM and is readable by any script running on that page — exactly
+  the same exposure as a browser's autofill.  The library only ever fills
+  the single origin-matched credential it chose to send.
+* **Coverage this release: macOS.**  On Linux and Windows the API is
+  present and the programmatic store degrades gracefully, but the
+  automatic capture / autofill activate once the per-platform native
+  channel and secret store land (Canvases 24 / 25).
+
+Known limitation: multi-step / identifier-first login flows (username and
+password on separate pages, e.g. some Okta configurations) are captured
+best-effort per page; cross-page correlation is not guaranteed.
+
+See [`demos/WebViewPasswordDemo/`](demos/WebViewPasswordDemo/README.md)
+for a runnable example exercising capture, autofill, and the programmatic
+API in both the Keychain-backed and in-memory store modes.
+
 ## Browser-initiated popups (`window.open`)
 
 Pages can call `window.open(url, name, features)` or click a link / form
@@ -708,6 +767,11 @@ Additional demos:
   (`alert` / `confirm` / `prompt` / file picker), a custom handler
   returning programmatic answers, and the
   `setDialogHandler(null)` drop mode for headless tests.
+* `demos/WebViewPasswordDemo/` — exercises the built-in password
+  manager: login-submission capture + "Save password?" prompt,
+  autofill on reload, and the programmatic
+  `saveCredential` / `getCredential` / `deleteCredential` API, in both
+  the OS-Keychain and in-memory store modes.
 
 ## Building from source
 

--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ Key points:
 * **Coverage this release: macOS.**  On Linux and Windows the API is
   present and the programmatic store degrades gracefully, but the
   automatic capture / autofill activate once the per-platform native
-  channel and secret store land (Canvases 24 / 25).
+  channel and secret store land (Canvases 27 / 28).
 
 Known limitation: multi-step / identifier-first login flows (username and
 password on separate pages, e.g. some Okta configurations) are captured

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -22,6 +22,10 @@ g++ -I"${JAVA_HOME}/include" -I"${JAVA_HOME}/include/linux" -fPIC -std=c++11 -Wa
 # NOTE: WebKitGTK/JavaScriptCore are intentionally NOT linked (only --cflags
 # for the headers). They are dlopen'd at runtime (4.1 preferred, 4.0 fallback)
 # by src_c/webkit_loader.cpp, so this single libwebview.so runs on both.
+# The password-manager credential store (Canvas 27) likewise dlopen's
+# libsecret-1.so.0 at first use rather than linking -lsecret -- matching the
+# same runtime-load convention. Absence of a Secret Service provider degrades
+# gracefully (the store becomes a no-op); it never blocks library load.
 mkdir -p natives/linux_64
 mv libwebview.so natives/linux_64/
 mvn -DskipTests package

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -21,5 +21,5 @@ c++ -I"${JAVA_HOME}/include" -I"${JAVA_HOME}/include/darwin" -dynamiclib \
     src_c/webview_embed.cpp \
     -o "natives/$NATIVE_DIR/libwebview.dylib" \
     -DWEBVIEW_COCOA=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=1 -std=c++11 \
-    -framework WebKit -framework Cocoa -framework QuartzCore \
+    -framework WebKit -framework Cocoa -framework QuartzCore -framework Security \
     -Wl,-undefined,dynamic_lookup

--- a/demos/WebViewPasswordDemo/README.md
+++ b/demos/WebViewPasswordDemo/README.md
@@ -1,0 +1,46 @@
+# WebViewPasswordDemo
+
+A runnable Swing app that exercises the built-in **password manager** on
+`WebViewComponent` (see the "Password manager" section of the project
+[`README.md`](../../README.md)).
+
+The demo starts a tiny embedded HTTP server on `127.0.0.1` and serves a
+login form there, so the manager sees a **real origin**
+(`http://127.0.0.1:<port>`) — a `data:` / `about:blank` page has no origin
+and would be skipped by the origin-keyed manager.
+
+## What it demonstrates
+
+- **Capture + save prompt** — type a username + password and submit the
+  form; the framework's Swing "Save password?" prompt appears. Approving
+  stores the credential in the active store.
+- **Autofill on load** — click **Reload** after saving; the username and
+  password fields auto-fill for the page's origin.
+- **Programmatic API** — the **Save (demo/demo)**, **Get**, and
+  **Delete demo** buttons call `saveCredential` / `getCredential` /
+  `getCredentials` / `deleteCredential` directly.
+- **Enable/disable gating** — the **Enabled** checkbox toggles
+  `setPasswordManagerEnabled`; when off, no prompt/autofill fires but the
+  programmatic buttons still work.
+- **Store swap** — the **Store** combo switches between the OS-native
+  `NativeCredentialStore` (Keychain on macOS) and an
+  `InMemoryCredentialStore`.
+
+Passwords are never printed to the log pane (only the username and a
+redacted marker).
+
+## Coverage
+
+macOS is wired in this release (Keychain). On Linux and Windows the
+programmatic API works and the store degrades gracefully, but automatic
+capture / autofill activate once the per-platform native channel and
+secret store land (Canvases 24 / 25).
+
+## Running
+
+Build `dist/WebView.jar` once from the project root (e.g. run any
+`run-<platform>-demo.sh` / `.bat`), then from this directory:
+
+```
+ant run
+```

--- a/demos/WebViewPasswordDemo/README.md
+++ b/demos/WebViewPasswordDemo/README.md
@@ -31,10 +31,10 @@ redacted marker).
 
 ## Coverage
 
-macOS is wired in this release (Keychain). On Linux and Windows the
-programmatic API works and the store degrades gracefully, but automatic
-capture / autofill activate once the per-platform native channel and
-secret store land (Canvases 27 / 28).
+macOS (Keychain) and Windows (Credential Manager) are wired: automatic
+capture, the save prompt, and autofill all work. On Linux the programmatic
+API works and the store degrades gracefully, but automatic capture /
+autofill activate once the libsecret channel and store land (Canvas 27).
 
 ## Running
 

--- a/demos/WebViewPasswordDemo/README.md
+++ b/demos/WebViewPasswordDemo/README.md
@@ -31,10 +31,11 @@ redacted marker).
 
 ## Coverage
 
-macOS (Keychain) and Windows (Credential Manager) are wired: automatic
-capture, the save prompt, and autofill all work. On Linux the programmatic
-API works and the store degrades gracefully, but automatic capture /
-autofill activate once the libsecret channel and store land (Canvas 27).
+All three platforms are wired: automatic capture, the save prompt, and
+autofill work on macOS (Keychain), Windows (Credential Manager), and Linux
+(libsecret / freedesktop Secret Service, both heavyweight and lightweight).
+On a Linux session with no Secret Service provider the store degrades
+gracefully (submit and reload still work; nothing persists).
 
 ## Running
 

--- a/demos/WebViewPasswordDemo/README.md
+++ b/demos/WebViewPasswordDemo/README.md
@@ -34,7 +34,7 @@ redacted marker).
 macOS is wired in this release (Keychain). On Linux and Windows the
 programmatic API works and the store degrades gracefully, but automatic
 capture / autofill activate once the per-platform native channel and
-secret store land (Canvases 24 / 25).
+secret store land (Canvases 27 / 28).
 
 ## Running
 

--- a/demos/WebViewPasswordDemo/build.xml
+++ b/demos/WebViewPasswordDemo/build.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="WebViewPasswordDemo" default="run" basedir=".">
+    <description>Build and run the built-in password manager demo.</description>
+
+    <property name="src.dir" value="src"/>
+    <property name="build.dir" value="build"/>
+    <property name="classes.dir" value="${build.dir}/classes"/>
+    <property name="webview.jar" value="../../dist/WebView.jar"/>
+    <property name="main.class" value="ca.weblite.webview.demos.WebViewPasswordDemo"/>
+
+    <target name="check-webview-jar">
+        <available file="${webview.jar}" property="webview.jar.exists"/>
+        <fail unless="webview.jar.exists">
+WebView.jar not found at ${webview.jar}.
+Build it first from the project root, e.g. ./run-linux-demo.sh once to
+produce dist/WebView.jar, or invoke a platform run-*-demo.sh / .bat at
+the repo root.
+        </fail>
+    </target>
+
+    <target name="compile" depends="check-webview-jar">
+        <mkdir dir="${classes.dir}"/>
+        <javac srcdir="${src.dir}" destdir="${classes.dir}"
+               includeantruntime="false" source="1.8" target="1.8">
+            <classpath>
+                <pathelement location="${webview.jar}"/>
+            </classpath>
+        </javac>
+    </target>
+
+    <target name="run" depends="compile">
+        <java classname="${main.class}" fork="true">
+            <classpath>
+                <pathelement location="${classes.dir}"/>
+                <pathelement location="${webview.jar}"/>
+            </classpath>
+        </java>
+    </target>
+
+    <target name="clean">
+        <delete dir="${build.dir}"/>
+    </target>
+</project>

--- a/demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDemo.java
+++ b/demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDemo.java
@@ -1,0 +1,202 @@
+/*
+ * MIT License
+ *
+ * Exercises the built-in password manager on WebViewComponent.  Designed
+ * for manual verification against the acceptance criteria in
+ *   requirements/[User-story-6]webview-native-password-manager.md
+ *
+ * A tiny embedded HTTP server serves a login form at a real origin
+ * (http://127.0.0.1:<port>) so the manager's origin-keyed capture and
+ * autofill actually fire — a data:/about:blank page has no origin and
+ * would be skipped.
+ *
+ *   1. Type a username + password and submit  -> "Save password?" prompt.
+ *   2. Reload (the "Reload" button)            -> fields auto-fill.
+ *   3. Use the Save / Get / Delete buttons     -> programmatic API.
+ *   4. Toggle "Enabled" and the store combo    -> gating + store swap.
+ *
+ * Coverage this release: macOS (Keychain).  On Linux / Windows the
+ * programmatic API works but automatic capture/fill activate once the
+ * per-platform native channel + store land (Canvases 24 / 25).
+ */
+package ca.weblite.webview.demos;
+
+import ca.weblite.webview.ConsoleListener;
+import ca.weblite.webview.ConsoleMessage;
+import ca.weblite.webview.InMemoryCredentialStore;
+import ca.weblite.webview.WebViewCredential;
+import ca.weblite.webview.swing.WebViewComponent;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import javax.swing.ToolTipManager;
+
+public class WebViewPasswordDemo {
+
+    private static final String STORE_NATIVE = "Native (OS Keychain)";
+    private static final String STORE_MEMORY = "In-memory (test store)";
+
+    private static WebViewComponent wv;
+    private static JTextArea log;
+    private static String origin; // http://127.0.0.1:<port>
+
+    public static void main(String[] args) throws Exception {
+        // Heavyweight popups so the "Save password?" JOptionPane renders
+        // above the WebView region on macOS / Windows heavyweight.
+        JPopupMenu.setDefaultLightWeightPopupEnabled(false);
+        ToolTipManager.sharedInstance().setLightWeightPopupEnabled(false);
+
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", new LoginHandler());
+        server.setExecutor(null);
+        server.start();
+        int port = server.getAddress().getPort();
+        origin = "http://127.0.0.1:" + port;
+
+        EventQueue.invokeLater(() -> run(port));
+    }
+
+    private static void run(int port) {
+        JFrame frame = new JFrame("WebView Password Manager Demo");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+        wv = WebViewComponent.create();
+        wv.setPreferredSize(new Dimension(760, 420));
+        wv.addConsoleListener(new ConsoleListener() {
+            @Override public void onMessage(ConsoleMessage m) {
+                append("[console] " + m.getText());
+            }
+        });
+
+        log = new JTextArea();
+        log.setEditable(false);
+        JScrollPane logScroll = new JScrollPane(log);
+        logScroll.setPreferredSize(new Dimension(760, 160));
+
+        JComboBox<String> storeCombo =
+            new JComboBox<>(new String[] { STORE_NATIVE, STORE_MEMORY });
+        storeCombo.addActionListener(e -> {
+            Object sel = storeCombo.getSelectedItem();
+            if (STORE_MEMORY.equals(sel)) {
+                wv.setCredentialStore(new InMemoryCredentialStore());
+                append("store -> in-memory");
+            } else {
+                wv.setCredentialStore(null); // restore default NativeCredentialStore
+                append("store -> native (OS Keychain)");
+            }
+        });
+
+        JCheckBox enabled = new JCheckBox("Enabled", true);
+        enabled.addActionListener(e -> {
+            wv.setPasswordManagerEnabled(enabled.isSelected());
+            append("manager enabled = " + enabled.isSelected());
+        });
+
+        JButton reload = new JButton("Reload");
+        reload.addActionListener(e -> wv.setUrl(origin + "/"));
+
+        JButton save = new JButton("Save (demo/demo)");
+        save.addActionListener(e -> {
+            wv.saveCredential(new WebViewCredential(origin, "demo", "demo-pass"));
+            append("saveCredential(demo) -> stored");
+        });
+
+        JButton get = new JButton("Get");
+        get.addActionListener(e -> {
+            Optional<WebViewCredential> c = wv.getCredential(origin);
+            append("getCredential(" + origin + ") -> "
+                + (c.isPresent() ? "username=" + c.get().username()
+                                   + " (password redacted)" : "<none>"));
+            List<WebViewCredential> all = wv.getCredentials(origin);
+            append("  getCredentials count = " + all.size());
+        });
+
+        JButton delete = new JButton("Delete demo");
+        delete.addActionListener(e ->
+            append("deleteCredential(demo) -> " + wv.deleteCredential(origin, "demo")));
+
+        JPanel controls = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        controls.add(new JLabel("Store:"));
+        controls.add(storeCombo);
+        controls.add(enabled);
+        controls.add(reload);
+        controls.add(save);
+        controls.add(get);
+        controls.add(delete);
+
+        JSplitPane split = new JSplitPane(JSplitPane.VERTICAL_SPLIT, wv, logScroll);
+        split.setResizeWeight(0.72);
+
+        frame.add(controls, BorderLayout.NORTH);
+        frame.add(split, BorderLayout.CENTER);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+
+        append("Serving login form at " + origin + "/");
+        append("Submit the form to trigger the Save prompt; Reload to autofill.");
+        wv.setUrl(origin + "/");
+    }
+
+    private static void append(String s) {
+        SwingUtilities.invokeLater(() -> {
+            log.append(s + "\n");
+            log.setCaretPosition(log.getDocument().getLength());
+        });
+    }
+
+    /** Serves a login form on GET and a confirmation page on POST. */
+    private static final class LoginHandler implements HttpHandler {
+        @Override public void handle(HttpExchange ex) throws IOException {
+            String html;
+            if ("POST".equalsIgnoreCase(ex.getRequestMethod())) {
+                // Drain the body; the demo does not validate credentials.
+                ex.getRequestBody().read(new byte[4096]);
+                html = "<!doctype html><meta charset=utf-8><title>Logged in</title>"
+                    + "<body style='font-family:sans-serif;padding:2rem'>"
+                    + "<h2>Logged in.</h2><p><a href='/'>Back to login</a></p>"
+                    + "<script>console.log('submitted (password captured by the manager)');</script>";
+            } else {
+                html = "<!doctype html><meta charset=utf-8><title>Login</title>"
+                    + "<body style='font-family:sans-serif;padding:2rem'>"
+                    + "<h2>Sign in</h2>"
+                    + "<form method='post' action='/login'>"
+                    + "<p><label>Username<br><input name='username' autocomplete='username'></label></p>"
+                    + "<p><label>Password<br><input type='password' name='password' autocomplete='current-password'></label></p>"
+                    + "<p><button type='submit'>Sign in</button></p>"
+                    + "</form>"
+                    + "<script>document.querySelector('input[type=password]')"
+                    + ".addEventListener('input',function(){console.log('password field input event');});</script>";
+            }
+            byte[] body = html.getBytes(StandardCharsets.UTF_8);
+            ex.getResponseHeaders().add("Content-Type", "text/html; charset=utf-8");
+            ex.sendResponseHeaders(200, body.length);
+            try (OutputStream os = ex.getResponseBody()) {
+                os.write(body);
+            }
+        }
+    }
+}

--- a/demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDemo.java
+++ b/demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDemo.java
@@ -15,9 +15,10 @@
  *   3. Use the Save / Get / Delete buttons     -> programmatic API.
  *   4. Toggle "Enabled" and the store combo    -> gating + store swap.
  *
- * Coverage this release: macOS (Keychain).  On Linux / Windows the
- * programmatic API works but automatic capture/fill activate once the
- * per-platform native channel + store land (Canvases 27 / 28).
+ * Coverage: macOS (Keychain) and Windows (Credential Manager) are wired
+ * for automatic capture/fill.  On Linux the programmatic API works but
+ * automatic capture/fill activate once the libsecret channel + store land
+ * (Canvas 27).
  */
 package ca.weblite.webview.demos;
 

--- a/demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDemo.java
+++ b/demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDemo.java
@@ -17,7 +17,7 @@
  *
  * Coverage this release: macOS (Keychain).  On Linux / Windows the
  * programmatic API works but automatic capture/fill activate once the
- * per-platform native channel + store land (Canvases 24 / 25).
+ * per-platform native channel + store land (Canvases 27 / 28).
  */
 package ca.weblite.webview.demos;
 

--- a/demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDemo.java
+++ b/demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDemo.java
@@ -14,6 +14,10 @@
  *   2. Reload (the "Reload" button)            -> fields auto-fill.
  *   3. Use the Save / Get / Delete buttons     -> programmatic API.
  *   4. Toggle "Enabled" and the store combo    -> gating + store swap.
+ *   5. "Get All"                               -> enumerate every stored
+ *                                                 credential (006-005).
+ *   6. "Confirm before autofill"               -> browser-style consent
+ *                                                 prompt before fill (006-004).
  *
  * Coverage: macOS (Keychain) and Windows (Credential Manager) are wired
  * for automatic capture/fill.  On Linux the programmatic API works but
@@ -26,6 +30,7 @@ import ca.weblite.webview.ConsoleListener;
 import ca.weblite.webview.ConsoleMessage;
 import ca.weblite.webview.InMemoryCredentialStore;
 import ca.weblite.webview.WebViewCredential;
+import ca.weblite.webview.WebViewFillPasswordHandler;
 import ca.weblite.webview.swing.WebViewComponent;
 
 import com.sun.net.httpserver.HttpExchange;
@@ -139,13 +144,35 @@ public class WebViewPasswordDemo {
         delete.addActionListener(e ->
             append("deleteCredential(demo) -> " + wv.deleteCredential(origin, "demo")));
 
+        // STORY-006-005: enumerate every stored credential across all origins.
+        JButton getAll = new JButton("Get All");
+        getAll.addActionListener(e -> {
+            List<WebViewCredential> all = wv.getAllCredentials();
+            append("getAllCredentials() -> " + all.size() + " credential(s):");
+            for (WebViewCredential c : all) {
+                // origin + username only — never the password.
+                append("  " + c.origin() + "  (username=" + c.username() + ")");
+            }
+        });
+
+        // STORY-006-004: opt into a browser-style confirm before autofill.
+        JCheckBox confirmFill = new JCheckBox("Confirm before autofill", false);
+        confirmFill.addActionListener(e -> {
+            wv.setFillPasswordHandler(confirmFill.isSelected()
+                ? WebViewFillPasswordHandler.CONFIRM : null);
+            append("autofill consent = "
+                + (confirmFill.isSelected() ? "CONFIRM" : "DEFAULT (silent)"));
+        });
+
         JPanel controls = new JPanel(new FlowLayout(FlowLayout.LEFT));
         controls.add(new JLabel("Store:"));
         controls.add(storeCombo);
         controls.add(enabled);
+        controls.add(confirmFill);
         controls.add(reload);
         controls.add(save);
         controls.add(get);
+        controls.add(getAll);
         controls.add(delete);
 
         JSplitPane split = new JSplitPane(JSplitPane.VERTICAL_SPLIT, wv, logScroll);

--- a/demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDemo.java
+++ b/demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDemo.java
@@ -19,10 +19,10 @@
  *   6. "Confirm before autofill"               -> browser-style consent
  *                                                 prompt before fill (006-004).
  *
- * Coverage: macOS (Keychain) and Windows (Credential Manager) are wired
- * for automatic capture/fill.  On Linux the programmatic API works but
- * automatic capture/fill activate once the libsecret channel + store land
- * (Canvas 27).
+ * Coverage: macOS (Keychain), Windows (Credential Manager), and Linux
+ * (libsecret / freedesktop Secret Service) are all wired for automatic
+ * capture/fill.  On a Linux session with no Secret Service provider the
+ * store degrades gracefully (nothing persists).
  */
 package ca.weblite.webview.demos;
 

--- a/demos/WebViewPasswordOptInDemo/README.md
+++ b/demos/WebViewPasswordOptInDemo/README.md
@@ -1,0 +1,57 @@
+# WebViewPasswordOptInDemo — Chrome-style opt-in autofill
+
+A demo of a **user-opt-in** password fill, the way a browser like Chrome
+does it: the login fields stay empty on load, and the saved password is
+filled only after the user focuses a field, picks an account from a
+chooser, and passes a re-authentication step.
+
+## The flow
+
+1. **Nothing fills automatically.** The demo installs a fill-consent
+   handler that returns `DONT_FILL`, so the library's built-in silent
+   autofill never fires.
+2. **Focus a login field** (username or password) → a dropdown chooser
+   appears anchored under the field, listing the saved account(s) for the
+   page's origin (username + a masked password — never the real secret).
+3. **Pick an account** → a simulated "Unlock passwords" dialog stands in
+   for the OS re-auth (Touch ID / Windows Hello / login password) that
+   Chrome performs before revealing a saved password.
+4. **On approval**, the username and password are filled in; Cancel fills
+   nothing.
+
+## How it works (public API only)
+
+This is a **host-driven** pattern built entirely on `WebViewComponent`'s
+public API — no library changes:
+
+- `setFillPasswordHandler(e -> FillPasswordDisposition.DONT_FILL)` disables
+  the automatic autofill so the flow is genuinely opt-in.
+- `addOnBeforeLoad(...)` injects a document-start focus detector that
+  reports a focused login field's rectangle over a bound callback
+  registered with `addJavascriptCallback(...)`.
+- `getCredentials(origin)` populates the chooser.
+- After the simulated unlock, the demo fills by evaluating the library's
+  write-only entrypoint `window.__webview_pw_fill__('<b64url user>',
+  '<b64url pass>')` via `eval(...)`, reusing the library's own field
+  detection and `input`/`change` event dispatch.
+
+Saved accounts are seeded into an `InMemoryCredentialStore`, so the demo
+touches no real OS Keychain and is repeatable. Passwords are never printed.
+
+## Run it
+
+```sh
+./run-mac-password-optin-demo.sh
+```
+
+(The launcher builds the macOS native lib, `dist/WebView.jar`, then
+compiles and runs the demo. On Linux/Windows the same
+`WebViewPasswordOptInDemo` class runs against a built jar; the flow is
+identical since it uses only the cross-platform public API.)
+
+## Relationship to `WebViewPasswordDemo`
+
+`WebViewPasswordDemo` shows the built-in behaviour: silent autofill plus an
+optional **load-time** `WebViewFillPasswordHandler.CONFIRM` prompt. This
+demo shows the **field-click** opt-in a browser uses — a chooser under the
+field and a re-auth before fill.

--- a/demos/WebViewPasswordOptInDemo/README.md
+++ b/demos/WebViewPasswordOptInDemo/README.md
@@ -53,6 +53,14 @@ Runtime ships with Windows 11):
 run-windows-password-optin-demo.bat
 ```
 
+Linux (JDK 8+, `g++`/`pkg-config`, GTK3 + WebKitGTK 4.0/4.1 dev packages;
+defaults to lightweight, pass `heavyweight` to force the other mode):
+
+```sh
+./run-linux-password-optin-demo.sh            # lightweight (default)
+./run-linux-password-optin-demo.sh heavyweight
+```
+
 Each launcher builds the platform native library and `dist/WebView.jar`,
 then compiles and runs the demo. The `WebViewPasswordOptInDemo` class is
 the same on every platform — it uses only the cross-platform public API,

--- a/demos/WebViewPasswordOptInDemo/README.md
+++ b/demos/WebViewPasswordOptInDemo/README.md
@@ -40,14 +40,23 @@ touches no real OS Keychain and is repeatable. Passwords are never printed.
 
 ## Run it
 
+macOS:
+
 ```sh
 ./run-mac-password-optin-demo.sh
 ```
 
-(The launcher builds the macOS native lib, `dist/WebView.jar`, then
-compiles and runs the demo. On Linux/Windows the same
-`WebViewPasswordOptInDemo` class runs against a built jar; the flow is
-identical since it uses only the cross-platform public API.)
+Windows (JDK 8+ and Visual Studio with the C++ workload; a WebView2
+Runtime ships with Windows 11):
+
+```bat
+run-windows-password-optin-demo.bat
+```
+
+Each launcher builds the platform native library and `dist/WebView.jar`,
+then compiles and runs the demo. The `WebViewPasswordOptInDemo` class is
+the same on every platform — it uses only the cross-platform public API,
+so the opt-in flow is identical.
 
 ## Relationship to `WebViewPasswordDemo`
 

--- a/demos/WebViewPasswordOptInDemo/src/ca/weblite/webview/demos/WebViewPasswordOptInDemo.java
+++ b/demos/WebViewPasswordOptInDemo/src/ca/weblite/webview/demos/WebViewPasswordOptInDemo.java
@@ -1,0 +1,310 @@
+/*
+ * MIT License
+ *
+ * Chrome-style, user-opt-in autofill demo for WebViewComponent's password
+ * manager.
+ *
+ * Unlike WebViewPasswordDemo (which shows the built-in silent autofill and
+ * an optional load-time "Use saved password?" CONFIRM prompt), this demo
+ * reproduces the flow a browser like Chrome uses:
+ *
+ *   1. Nothing is filled automatically on load — the login fields stay
+ *      empty (silent autofill is suppressed with a DONT_FILL fill-handler).
+ *   2. When the user focuses the username or password field, a dropdown
+ *      chooser appears anchored under the field, listing the saved
+ *      account(s) for the page's origin (username + a masked password).
+ *   3. Picking an account runs a simulated re-authentication ("Unlock
+ *      passwords — Touch ID / your login password"), mirroring the OS
+ *      re-auth Chrome does before revealing a saved password.
+ *   4. Only on approval are the username + password filled in.
+ *
+ * The whole flow is host-driven and uses the library's PUBLIC API only:
+ *   - setFillPasswordHandler(... DONT_FILL) to disable silent autofill,
+ *   - addOnBeforeLoad(...) to inject a focus detector,
+ *   - addJavascriptCallback(...) to hear about field focus,
+ *   - getCredentials(origin) to populate the chooser,
+ *   - eval("window.__webview_pw_fill__(b64user, b64pass)") to fill,
+ *     reusing the library's own field detection + input/change dispatch.
+ *
+ * The saved credentials live in an in-memory store seeded at startup, so
+ * the demo touches no real OS Keychain and is repeatable.  Passwords are
+ * never printed.
+ */
+package ca.weblite.webview.demos;
+
+import ca.weblite.webview.InMemoryCredentialStore;
+import ca.weblite.webview.FillPasswordDisposition;
+import ca.weblite.webview.WebViewCredential;
+import ca.weblite.webview.WebViewFillPasswordEvent;
+import ca.weblite.webview.WebViewFillPasswordHandler;
+import ca.weblite.webview.WebView;
+import ca.weblite.webview.swing.WebViewComponent;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import javax.swing.JFrame;
+import javax.swing.JMenuItem;
+import javax.swing.JOptionPane;
+import javax.swing.JPopupMenu;
+import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.JTextArea;
+import javax.swing.JPopupMenu.Separator;
+import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
+import javax.swing.ToolTipManager;
+
+public class WebViewPasswordOptInDemo {
+
+    /** Bound JS callback name the injected focus detector calls. */
+    private static final String FOCUS_CB = "__optin_focus__";
+
+    private static WebViewComponent wv;
+    private static JTextArea log;
+    private static String origin;                 // http://127.0.0.1:<port>
+    private static InMemoryCredentialStore store; // seeded, no real Keychain
+
+    public static void main(String[] args) throws Exception {
+        // Heavyweight popups so the chooser + unlock render above the
+        // WebView region on macOS / Windows heavyweight.
+        JPopupMenu.setDefaultLightWeightPopupEnabled(false);
+        ToolTipManager.sharedInstance().setLightWeightPopupEnabled(false);
+
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", new LoginHandler());
+        server.setExecutor(null);
+        server.start();
+        origin = "http://127.0.0.1:" + server.getAddress().getPort();
+
+        EventQueue.invokeLater(WebViewPasswordOptInDemo::run);
+    }
+
+    private static void run() {
+        JFrame frame = new JFrame("WebView Password Manager — Chrome-style opt-in fill");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+        wv = WebViewComponent.create();
+        wv.setPreferredSize(new Dimension(760, 440));
+
+        // Seed a couple of saved accounts for this origin in an in-memory
+        // store (no real Keychain), so the chooser has a multi-account list.
+        store = new InMemoryCredentialStore();
+        store.save(new WebViewCredential(origin, "alice", "s3cret"));
+        store.save(new WebViewCredential(origin, "demo",  "demo-pass"));
+        wv.setCredentialStore(store);
+
+        // Opt-in flow: suppress the built-in silent autofill entirely.  The
+        // demo drives the fill itself, only after the user picks an account.
+        wv.setFillPasswordHandler(new WebViewFillPasswordHandler() {
+            @Override public FillPasswordDisposition onAutofillRequested(
+                    WebViewFillPasswordEvent e) {
+                return FillPasswordDisposition.DONT_FILL;
+            }
+        });
+
+        // Hear about login-field focus from the page.
+        wv.addJavascriptCallback(FOCUS_CB, new WebView.JavascriptCallback() {
+            @Override public void run(String wrapped) {
+                final String payload = decodeArg(wrapped);
+                if (payload.isEmpty()) return;
+                SwingUtilities.invokeLater(() -> onFieldFocused(payload));
+            }
+        });
+        // Inject the focus detector at document-start on every load.
+        wv.addOnBeforeLoad(FOCUS_JS);
+
+        log = new JTextArea();
+        log.setEditable(false);
+        JScrollPane logScroll = new JScrollPane(log);
+        logScroll.setPreferredSize(new Dimension(760, 150));
+
+        JSplitPane split = new JSplitPane(JSplitPane.VERTICAL_SPLIT, wv, logScroll);
+        split.setResizeWeight(0.75);
+        frame.add(split, BorderLayout.CENTER);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+
+        append("Saved accounts for " + origin + ": alice, demo (in-memory).");
+        append("Click the username or password field — a chooser appears; "
+            + "pick an account and unlock to fill. Nothing fills on its own.");
+        wv.setUrl(origin + "/");
+    }
+
+    /** A login field was focused; show the account chooser under it. */
+    private static void onFieldFocused(String payload) {
+        // payload = "left|top|width|height|type"
+        String[] p = payload.split("\\|");
+        if (p.length < 4) return;
+        int left, top, height;
+        try {
+            left = Integer.parseInt(p[0]);
+            top = Integer.parseInt(p[1]);
+            height = Integer.parseInt(p[3]);
+        } catch (NumberFormatException nfe) {
+            return;
+        }
+        List<WebViewCredential> accounts = wv.getCredentials(origin);
+        if (accounts.isEmpty()) {
+            append("field focused — no saved accounts for this origin.");
+            return;
+        }
+        append("field focused — showing chooser (" + accounts.size()
+            + " account(s)).");
+
+        JPopupMenu chooser = new JPopupMenu();
+        JLabel header = new JLabel("  Saved passwords for " + origin + "  ");
+        header.setEnabled(false);
+        chooser.add(header);
+        chooser.add(new Separator());
+        for (final WebViewCredential c : accounts) {
+            // Username + a masked password — never the real secret.
+            JMenuItem item = new JMenuItem(
+                c.username() + "    " + mask(c.password().length()));
+            item.addActionListener(e -> chooseAccount(c));
+            chooser.add(item);
+        }
+        // Anchor the chooser just under the focused field.  The rect is in
+        // CSS px relative to the web viewport, which is the WebView
+        // component's content area, so the WebView is the popup invoker.
+        if (wv.isShowing()) {
+            chooser.show(wv, left, top + height);
+        }
+    }
+
+    /** The user picked an account; re-authenticate, then fill. */
+    private static void chooseAccount(WebViewCredential c) {
+        append("selected account: " + c.username());
+        // Simulated OS re-auth, mirroring Chrome's Touch ID / password gate.
+        int r = JOptionPane.showConfirmDialog(
+            SwingUtilities.getWindowAncestor(wv),
+            "Unlock passwords to fill the saved password for\n" + origin
+                + "\n\n(Simulated Touch ID / login-password check.)",
+            "Unlock passwords",
+            JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
+        if (r != JOptionPane.OK_OPTION) {
+            append("unlock declined — nothing filled.");
+            return;
+        }
+        // Fill via the library's write-only entrypoint (reuses its field
+        // detection + input/change dispatch).  Passwords go over as
+        // base64url and are never logged.
+        String js = "window.__webview_pw_fill__('"
+            + b64url(c.username()) + "','" + b64url(c.password()) + "')";
+        wv.eval(js);
+        append("unlocked — filled " + c.username() + " (password redacted).");
+    }
+
+    // ---- helpers ------------------------------------------------------
+
+    private static String mask(int n) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < Math.max(6, Math.min(n, 12)); i++) sb.append('•');
+        return sb.toString();
+    }
+
+    private static String b64url(String s) {
+        return Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Extract and base64url-decode the first argument from a bind-shim
+     * JSON wrapper of the form {@code {"name":..,"seq":..,"args":["<b64>"]}}.
+     * The payload is base64url so it contains no JSON-special characters,
+     * making the naive extraction safe.
+     */
+    private static String decodeArg(String json) {
+        if (json == null) return "";
+        int i = json.indexOf("\"args\":[");
+        String b64;
+        if (i < 0) {
+            b64 = json.trim(); // some backends deliver the raw arg
+        } else {
+            int q = json.indexOf('"', i + 8);
+            if (q < 0) return "";
+            int e = json.indexOf('"', q + 1);
+            if (e < 0) return "";
+            b64 = json.substring(q + 1, e);
+        }
+        try {
+            return new String(Base64.getUrlDecoder().decode(b64),
+                StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException ex) {
+            return "";
+        }
+    }
+
+    private static void append(String s) {
+        SwingUtilities.invokeLater(() -> {
+            log.append(s + "\n");
+            log.setCaretPosition(log.getDocument().getLength());
+        });
+    }
+
+    /** Document-start focus detector: reports login-field focus rects. */
+    private static final String FOCUS_JS =
+        "(function(){\n"
+      + "try{\n"
+      + "if(window.__optin_installed__)return; window.__optin_installed__=true;\n"
+      + "function b64e(s){try{var u=unescape(encodeURIComponent(s));"
+      + "return btoa(u).replace(/\\+/g,'-').replace(/\\//g,'_').replace(/=+$/,'');}"
+      + "catch(e){return '';}}\n"
+      + "function isLogin(el){if(!el||el.tagName!=='INPUT')return false;"
+      + "var t=(el.type||'text').toLowerCase();"
+      + "return t==='password'||t==='text'||t==='email';}\n"
+      + "document.addEventListener('focusin',function(e){try{var el=e.target;"
+      + "if(!isLogin(el))return;var r=el.getBoundingClientRect();"
+      + "var payload=[Math.round(r.left),Math.round(r.top),Math.round(r.width),"
+      + "Math.round(r.height),(el.type||'text')].join('|');"
+      + "if(window." + FOCUS_CB + ")window." + FOCUS_CB + "(b64e(payload));}"
+      + "catch(e){}},true);\n"
+      + "}catch(e){}\n"
+      + "})();";
+
+    /** Serves a login form on GET, a landing page on POST. */
+    private static final class LoginHandler implements HttpHandler {
+        @Override public void handle(HttpExchange ex) throws IOException {
+            String html;
+            if ("POST".equalsIgnoreCase(ex.getRequestMethod())) {
+                ex.getRequestBody().read(new byte[4096]);
+                html = "<!doctype html><meta charset=utf-8><title>Signed in</title>"
+                    + "<body style='font-family:sans-serif;padding:2rem'>"
+                    + "<h2>Signed in.</h2><p><a href='/'>Back to login</a></p>";
+            } else {
+                html = "<!doctype html><meta charset=utf-8><title>Sign in</title>"
+                    + "<body style='font-family:sans-serif;padding:2rem;max-width:22rem'>"
+                    + "<h2>Sign in</h2>"
+                    + "<form method='post' action='/login'>"
+                    + "<p><label>Username<br>"
+                    + "<input name='username' autocomplete='username' "
+                    + "style='width:100%;padding:.4rem'></label></p>"
+                    + "<p><label>Password<br>"
+                    + "<input type='password' name='password' "
+                    + "autocomplete='current-password' "
+                    + "style='width:100%;padding:.4rem'></label></p>"
+                    + "<p><button type='submit'>Sign in</button></p>"
+                    + "</form>"
+                    + "<p style='color:#666;font-size:.85rem'>Click a field to "
+                    + "choose a saved password.</p>";
+            }
+            byte[] body = html.getBytes(StandardCharsets.UTF_8);
+            ex.getResponseHeaders().add("Content-Type", "text/html; charset=utf-8");
+            ex.sendResponseHeaders(200, body.length);
+            try (OutputStream os = ex.getResponseBody()) {
+                os.write(body);
+            }
+        }
+    }
+}

--- a/demos/WebViewPasswordOptInDemo/src/ca/weblite/webview/demos/WebViewPasswordOptInDemo.java
+++ b/demos/WebViewPasswordOptInDemo/src/ca/weblite/webview/demos/WebViewPasswordOptInDemo.java
@@ -8,13 +8,13 @@
  * an optional load-time "Use saved password?" CONFIRM prompt), this demo
  * reproduces the flow a browser like Chrome uses:
  *
- *   1. Nothing is filled automatically on load — the login fields stay
+ *   1. Nothing is filled automatically on load - the login fields stay
  *      empty (silent autofill is suppressed with a DONT_FILL fill-handler).
  *   2. When the user focuses the username or password field, a dropdown
  *      chooser appears anchored under the field, listing the saved
  *      account(s) for the page's origin (username + a masked password).
  *   3. Picking an account runs a simulated re-authentication ("Unlock
- *      passwords — Touch ID / your login password"), mirroring the OS
+ *      passwords - Touch ID / your login password"), mirroring the OS
  *      re-auth Chrome does before revealing a saved password.
  *   4. Only on approval are the username + password filled in.
  *
@@ -91,7 +91,7 @@ public class WebViewPasswordOptInDemo {
     }
 
     private static void run() {
-        JFrame frame = new JFrame("WebView Password Manager — Chrome-style opt-in fill");
+        JFrame frame = new JFrame("WebView Password Manager - Chrome-style opt-in fill");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
         wv = WebViewComponent.create();
@@ -137,7 +137,7 @@ public class WebViewPasswordOptInDemo {
         frame.setVisible(true);
 
         append("Saved accounts for " + origin + ": alice, demo (in-memory).");
-        append("Click the username or password field — a chooser appears; "
+        append("Click the username or password field - a chooser appears; "
             + "pick an account and unlock to fill. Nothing fills on its own.");
         wv.setUrl(origin + "/");
     }
@@ -157,10 +157,10 @@ public class WebViewPasswordOptInDemo {
         }
         List<WebViewCredential> accounts = wv.getCredentials(origin);
         if (accounts.isEmpty()) {
-            append("field focused — no saved accounts for this origin.");
+            append("field focused - no saved accounts for this origin.");
             return;
         }
-        append("field focused — showing chooser (" + accounts.size()
+        append("field focused - showing chooser (" + accounts.size()
             + " account(s)).");
 
         JPopupMenu chooser = new JPopupMenu();
@@ -169,7 +169,7 @@ public class WebViewPasswordOptInDemo {
         chooser.add(header);
         chooser.add(new Separator());
         for (final WebViewCredential c : accounts) {
-            // Username + a masked password — never the real secret.
+            // Username + a masked password - never the real secret.
             JMenuItem item = new JMenuItem(
                 c.username() + "    " + mask(c.password().length()));
             item.addActionListener(e -> chooseAccount(c));
@@ -194,7 +194,7 @@ public class WebViewPasswordOptInDemo {
             "Unlock passwords",
             JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
         if (r != JOptionPane.OK_OPTION) {
-            append("unlock declined — nothing filled.");
+            append("unlock declined - nothing filled.");
             return;
         }
         // Fill via the library's write-only entrypoint (reuses its field
@@ -203,14 +203,14 @@ public class WebViewPasswordOptInDemo {
         String js = "window.__webview_pw_fill__('"
             + b64url(c.username()) + "','" + b64url(c.password()) + "')";
         wv.eval(js);
-        append("unlocked — filled " + c.username() + " (password redacted).");
+        append("unlocked - filled " + c.username() + " (password redacted).");
     }
 
     // ---- helpers ------------------------------------------------------
 
     private static String mask(int n) {
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < Math.max(6, Math.min(n, 12)); i++) sb.append('•');
+        for (int i = 0; i < Math.max(6, Math.min(n, 12)); i++) sb.append('\u2022');
         return sb.toString();
     }
 

--- a/requirements/[User-story-6]webview-native-password-manager.md
+++ b/requirements/[User-story-6]webview-native-password-manager.md
@@ -1,0 +1,549 @@
+# Story Decomposition: Built-in Password Manager for the Embedded WebView
+
+## INVEST Analysis
+
+### Abstract Task: "Give `WebViewComponent` a browser-grade password manager — auto-detect login submissions and offer to save them, auto-fill saved credentials on page load, back everything with the OS-native secret store — with a deterministic Java API for hosts and tests, uniform across macOS, Linux, and Windows"
+
+**Analysis Dimensions**:
+- **Core Responsibility**: A page running inside `WebViewComponent` presents login forms. Today the embedded engines (`WKWebView`, `WebKitGTK`, `WebView2`) do **not** give the embedding app the "offer to save this password / autofill it next time" experience that Safari, Chrome, and Edge give their own users — that behaviour is a browser-privileged feature the raw engine withholds. This task builds that experience into the library itself:
+  - **Save**: injected JavaScript watches the page for login-form submissions, extracts the username + password + page origin, and the library shows a browser-style Swing "Save password?" prompt. On confirm, the credential is written to the **OS-native secret store** (macOS Keychain, Linux libsecret / Secret Service, Windows Credential Manager) so it is encrypted at rest and unlocked by the user's OS login — the library never rolls its own crypto.
+  - **Fill**: on page load, if a credential exists for the page's origin, the library injects the username + password into the detected login fields automatically, reproducing "save once, autofill forever".
+  - **Programmatic control**: a public Java API on `WebViewComponent` lets a host enable/disable the manager, and get / save / delete credentials directly, so applications can drive it deterministically and unit tests can exercise it headlessly.
+- **Primary Operations**:
+  1. Inject a credential-detection + credential-fill script into every document at document-start on each backend, and receive the captured submission back over a message channel.
+  2. On a captured submission, marshal to the Swing EDT, ask the active save-password policy (default: a Swing "Save password?" prompt) whether to store it, and on approval write it to the credential store keyed by origin.
+  3. On document load, look up the store by origin and, if a credential is present and the manager is enabled, inject it into the page's login fields.
+  4. Read / write / delete credentials in the OS-native secret store via a per-platform native backend, behind a single Java `WebViewCredentialStore` seam.
+  5. Expose a public Java API on `WebViewComponent` (enable/disable, get/save/delete, store override, save-policy override, credential + event POJOs) shared by all backends.
+- **Key Constraints**:
+  - Passwords are secret material. They must be stored **only** in the OS-native secret store (encrypted at rest by the OS), never in plaintext files, logs, or the page's persisted DOM. In-memory exposure on the JVM heap must be minimised and never written to disk by the library.
+  - Credentials are keyed by **page origin** = scheme + host + port (e.g. `https://example.okta.com` implies port 443). Autofill for one origin must never fire on a different origin (anti-phishing baseline).
+  - The save prompt and the autofill must be **overridable / disableable**: a host may turn the whole manager off, supply its own credential store (e.g. in-memory for tests), or supply its own save-policy (return SAVE/DON'T-SAVE programmatically without showing UI) so headless tests stay viable.
+  - The detection JavaScript must reuse the **reserved-binding / message-channel** infrastructure each backend already has (the same channel used for console capture, DOM mouse events, and dialog dispatch) — no new public JS binding is exposed to page authors.
+  - Autofill must run at a lifecycle point where the login fields exist but the library's write does not fight the page's own scripts unnecessarily; a best-effort model (fill on `DOMContentLoaded`, re-attempt on late-inserted forms within a bounded window) is acceptable and must be specified.
+  - The native secret-store calls must not block the engine's UI thread for an unbounded time; store I/O is marshaled off the UI thread where the platform requires it.
+- **Technical Complexity**: High overall, split across a shared core (Java API + detection/fill JavaScript + the store seam) and three platform-shaped native pieces:
+  - macOS: inject a `WKUserScript` at document-start, receive captures via a `WKScriptMessageHandler`, and implement the credential store against **Security.framework** Keychain (`SecItemAdd` / `SecItemCopyMatching` / `SecItemDelete`, generic-password items keyed by origin).
+  - Linux: inject via `webkit_user_content_manager_add_script` + a script-message handler, and implement the store against **libsecret** (`secret_password_store_sync` / `secret_password_lookup_sync` / `secret_password_clear_sync`) with a stable schema keyed by origin.
+  - Windows: inject via `AddScriptToExecuteOnDocumentCreated` + `WebMessageReceived`, and implement the store against the **Windows Credential Manager** (`CredWrite` / `CredRead` / `CredDelete`, `CRED_TYPE_GENERIC`, target name derived from origin; the blob is DPAPI-protected by the OS).
+- **Business Complexity**: Medium — the user-visible semantics (offer to save, autofill on return) are familiar from every browser, but the login-form heuristics (which field is username, which is password, when a "submission" happened in a SPA) carry real ambiguity that the ACs must pin down.
+
+### INVEST Evaluation (whole feature)
+
+- ✅ **Independent**: Builds only on the existing per-backend message-channel plumbing (canvases 2 / 6 / 7 and the dialog/console dispatch precedent). No dependency on unshipped work.
+- ✅ **Negotiable**: Defaults agreed with the user — OS-native store, auto-detect + Swing save prompt, auto-fill on load, origin = scheme+host+port. The save-policy and store are override seams, so teams can renegotiate UX without touching the contract.
+- ✅ **Valuable**: Without this, users of any app embedding the WebView must retype passwords on every login (the concrete Okta pain that motivated the feature). With it, the embedded WebView behaves like a real browser.
+- ✅ **Estimable**: Each backend has a well-documented secret-store API and script-injection API. The Java side is one store interface + one save-policy interface + two POJOs + the component methods.
+- ⚠️ **Small (as a single story)**: Combined, the work spans three native secret stores, three script-injection paths, the shared JavaScript, and the public Java API — realistically 9-13 days. **This exceeds the 1-5 day INVEST target.** Splitting is required (see below).
+- ✅ **Testable**: The programmatic API (inject an in-memory store + a programmatic save-policy) makes save/fill observable from headless unit tests; the default UX is observable from a Swing harness.
+
+**Conclusion**: Needs splitting along platform-backend boundaries, exactly like the Browser-Initiated UI Dialogs feature. The shared Java contract + shared detection/fill JavaScript are designed once and co-delivered with macOS (the platform whose absence of this feature the user actually hit). Linux and Windows coverage stories add their native secret-store + injection wiring while conforming to the same contract.
+
+### Split Strategy
+
+Split by **technical dependency / native backend**, because:
+
+- Each platform's secret store is a distinct native API (Security.framework Keychain / libsecret Secret Service / Windows Credential Manager), and each platform's document-start script injection + message channel is distinct (WKUserScript+WKScriptMessageHandler / user-content-manager+script-message / AddScriptToExecuteOnDocumentCreated+WebMessageReceived). Wiring each is independent of the others.
+- The Java contract + the detection/fill JavaScript are shared and must be designed once — that is STORY-006-001's primary responsibility, co-delivered with macOS because macOS is the platform the user is blocked on.
+- Each story delivers independent value: STORY-006-001 alone gives macOS users working save + autofill; STORY-006-002 alone extends it to Linux; STORY-006-003 alone extends it to Windows. None regresses the others.
+- Each story is 2-5 days, within INVEST sizing.
+
+Story dependency graph:
+
+```
+STORY-006-001 (Java API contract + shared detection/fill JS + macOS Keychain)
+        │
+        ├──► STORY-006-002 (Linux libsecret) — depends on the Java contract + shared JS from 006-001
+        │
+        └──► STORY-006-003 (Windows Credential Manager) — depends on the Java contract + shared JS from 006-001
+```
+
+STORY-006-002 and STORY-006-003 can be developed in parallel once STORY-006-001 has landed.
+
+---
+
+## [STORY-006-001] Password-Manager Java API, Shared Detection/Fill Script, and macOS Keychain Coverage
+
+### Background
+
+Every mainstream browser offers to save a password after a successful login and autofills it on the next visit. The embedded engines this library wraps deliberately withhold that behaviour from third-party host apps: `WKWebView` never shows Safari's "Save Password" prompt (it is a Safari-private capability), and while it can surface iCloud Keychain items it only does so for a signed app under narrow conditions. The concrete consequence a user hit: logging into an Okta page inside `WebViewComponent` on macOS requires retyping the full password every single time, even though Safari and Chrome autofill it.
+
+This story builds the library's own password manager and delivers it on macOS. It does three things at once:
+
+1. **Designs and exposes the cross-platform Java contract**: a `WebViewCredential` POJO, a `WebViewCredentialStore` seam (default = OS-native store, overridable for tests), a `WebViewSavePasswordHandler` policy (default = Swing "Save password?" prompt, overridable/programmatic), a captured-submission event POJO, and the enable/disable + get/save/delete methods on `WebViewComponent`. This is the exact contract STORY-006-002 (Linux) and STORY-006-003 (Windows) conform to.
+2. **Authors the shared detection + fill JavaScript** injected at document-start on every backend. It (a) locates the login form (a `<input type="password">` and its associated username field), (b) on form submission posts `{origin, username, password}` back to Java over the existing reserved message channel, and (c) on load, when Java hands it a credential for the origin, writes the username + password into the detected fields and dispatches the appropriate input events so the page's own validation sees them.
+3. **Implements the macOS backend**: inject the shared script via `WKUserScript` at document-start, receive captures via a `WKScriptMessageHandler`, and implement `WebViewCredentialStore` against the macOS **Keychain** (Security.framework generic-password items keyed by origin).
+
+The chosen design mirrors the shipped `WebViewDialogHandler` feature: a policy interface with a sensible Swing default plus a store seam, both overridable per component instance, so the happy path "just works" and tests stay deterministic.
+
+Key points:
+- Business value: restores the "save once, autofill forever" experience inside the embedded WebView, eliminating password retyping. macOS is delivered first because that is where the user is blocked.
+- Relationship with other features: reuses the reserved `__webview_`-prefixed message channel and the EDT-marshaling dispatch precedent set by console capture (canvas 2), DOM mouse events (canvas 9), and the dialog handler (canvas 11). No new public JS binding is exposed to page authors.
+- Why now: the raw engine will never provide this; the user is retyping an Okta password on every login today.
+
+### Business Value
+
+- Provide **working "Save password?" capture** on macOS for login forms inside `WebViewComponent`, storing to the encrypted OS Keychain on the user's approval.
+- Provide **working autofill on page load** on macOS, so a returning user's saved username + password appear pre-filled without retyping.
+- Provide a **single Java contract** (`WebViewCredential`, `WebViewCredentialStore`, `WebViewSavePasswordHandler`, component methods) that the Linux and Windows stories conform to, so the embedded page behaves identically regardless of platform.
+- Provide a **secure-by-default storage backend** (OS Keychain) so host apps get encrypted-at-rest credential storage without writing any crypto.
+- Provide a **deterministic override path** (inject an in-memory store + a programmatic save-policy) so unit tests and headless environments exercise save/fill without spawning UI or touching the real Keychain.
+
+### Dependencies and Assumptions
+
+- **Prerequisites**: Canvases 5, 6, 7 (mode selection, heavyweight, lightweight) and the existing per-backend message-channel + document-start injection infrastructure used by console capture and the dialog handler. The macOS heavyweight engine already creates a `WKWebView`, attaches a `WKScriptMessageHandler`, and a `WKUserContentController` (`e->manager`) — this story adds a `WKUserScript` and a new message name to that same controller, and a Keychain-backed store.
+- **Data assumptions**: The only persisted state is the credentials themselves, held in the OS Keychain — never in a library file. A credential is `{origin, username, password}`. At most one credential per `{origin, username}` pair; saving a new password for an existing `{origin, username}` overwrites it.
+- **Integration points**: macOS — `WKUserContentController.addUserScript:` (document-start injection), `WKScriptMessageHandler` (capture channel), and Security.framework Keychain (`SecItemAdd`, `SecItemCopyMatching`, `SecItemUpdate`, `SecItemDelete`) for `kSecClassGenericPassword` items whose service is a library-namespaced constant and whose account encodes the origin.
+- **Business constraints**:
+  - **Origin** = scheme + host + port, with the default port implied by scheme (`https`→443, `http`→80). `https://example.okta.com` and `https://example.okta.com:443` are the same origin; `https://a.com` and `https://b.com` are different; `http://a.com` and `https://a.com` are different.
+  - Autofill for origin X must **never** fire on any origin other than X.
+  - The manager is **enabled by default** on macOS. When disabled, neither the save prompt nor autofill fires, but the programmatic API still works.
+  - The library must never log, print, or persist the password anywhere other than the OS Keychain. Passwords must not appear in `System.out`/`System.err`, in exception messages, or in any file the library writes.
+  - The save-policy callback and any UI it shows run on the Swing EDT. The default prompt is modal to the host `JFrame` (`SwingUtilities.getWindowAncestor(component)`), consistent with the dialog handler.
+
+### Scope In
+
+- New public POJO `ca.weblite.webview.WebViewCredential`, immutable, with public accessors `String origin()`, `String username()`, `String password()`; value-equality on `{origin, username}` (password excluded from `equals`/`hashCode`); `toString()` that redacts the password (never prints it).
+- New public interface `ca.weblite.webview.WebViewCredentialStore` — the storage seam:
+  - `void save(WebViewCredential credential)` — insert or overwrite the credential for `{origin, username}`.
+  - `java.util.Optional<WebViewCredential> find(String origin)` — the credential to autofill for an origin; when multiple usernames are stored for the origin, returns the most-recently-saved one.
+  - `java.util.List<WebViewCredential> findAll(String origin)` — all credentials stored for an origin (usernames + passwords), most-recently-saved first.
+  - `boolean delete(String origin, String username)` — remove one credential; returns whether anything was removed.
+  - The default implementation, `NativeCredentialStore`, is backed by the OS-native secret store (Keychain on macOS via this story). A host may install a different store (e.g. an in-memory one for tests).
+- New public POJO `ca.weblite.webview.WebViewSavePasswordEvent`, immutable — `WebViewComponent source()`, `String origin()`, `String username()`, `String password()` (the captured submission); `toString()` redacts the password.
+- New public interface `ca.weblite.webview.WebViewSavePasswordHandler` with a single method invoked on the EDT:
+  - `SavePasswordDisposition onLoginSubmitted(WebViewSavePasswordEvent event)` returning an enum `SavePasswordDisposition { SAVE, DONT_SAVE }`. Default impl: a Swing prompt ("Save password for `<origin>`?", showing the username, OK/Cancel) modal to the host `JFrame`; OK → `SAVE`, Cancel/close → `DONT_SAVE`. A host may override to decide programmatically without UI.
+- New public methods on `WebViewComponent`:
+  - `WebViewComponent setPasswordManagerEnabled(boolean enabled)` — master switch for auto-detect save + autofill. Enabled by default. Disabling stops the prompt and autofill; the programmatic methods below still work.
+  - `boolean isPasswordManagerEnabled()`.
+  - `WebViewComponent setCredentialStore(WebViewCredentialStore store)` — replace the store; `null` reinstalls the default `NativeCredentialStore`.
+  - `WebViewCredentialStore getCredentialStore()` — never null; returns the default when none set.
+  - `WebViewComponent setSavePasswordHandler(WebViewSavePasswordHandler handler)` — replace the save-policy; `null` reinstalls the default Swing-prompt handler.
+  - `WebViewSavePasswordHandler getSavePasswordHandler()` — never null.
+  - `void saveCredential(WebViewCredential credential)` — programmatic save (bypasses the prompt; writes to the store).
+  - `java.util.Optional<WebViewCredential> getCredential(String origin)` — programmatic lookup (delegates to the store's `find`).
+  - `java.util.List<WebViewCredential> getCredentials(String origin)` — programmatic list for an origin.
+  - `boolean deleteCredential(String origin, String username)` — programmatic delete.
+- Shared detection/fill JavaScript (authored once, used by all backends), covering: locating a password field and its associated username field (the text/email/tel input immediately preceding the password field within the same form, else the form's first such input, else a page-level heuristic when there is no `<form>`); posting `{origin, username, password}` on `submit` (and on a synthetic submit for SPA login buttons that don't fire a real `submit`, best-effort); and, on receiving a credential from Java, setting the fields' `.value` and dispatching `input` + `change` events so framework-driven forms observe the change. The script uses the reserved message channel; it exposes no new page-visible global.
+- macOS backend: inject the shared script as a document-start `WKUserScript`; register a `WKScriptMessageHandler` for the capture message; implement `NativeCredentialStore` against the Keychain via JNI (`SecItem*`), with items namespaced to this library so it never collides with Safari's iCloud Keychain items.
+- The autofill request is driven from Java after page load: when the manager is enabled and `store.find(origin)` returns a credential, the credential is handed to the injected script to fill.
+
+### Scope Out
+
+- Linux libsecret backend — STORY-006-002.
+- Windows Credential Manager backend — STORY-006-003.
+- The standalone in-process `WebView` class — this story targets embedded `WebViewComponent` only (same boundary the dialog-handler story drew). Adding the API to standalone `WebView` is a follow-up if requested.
+- A credential-management UI (a "manage saved passwords" list/editor window). Hosts build their own on top of the programmatic API; the library ships only the save prompt.
+- Multi-step / identifier-first login flows where username and password are on separate pages (e.g. Okta's split username→password screens) as a *guaranteed* capture. Best-effort capture is in scope (each page's fields are detected independently); guaranteeing cross-page correlation is out of scope for this story and noted as a known limitation.
+- Passkeys / WebAuthn, TOTP/2FA codes, passphrase generation, and password-strength evaluation.
+- Syncing credentials across machines (the OS Keychain may sync via iCloud on its own; the library neither adds nor prevents that beyond choosing a non-synchronizable item attribute where specified).
+- Biometric / re-authentication gating before autofill (Touch ID prompt per fill). Out of scope; the OS unlocks the Keychain at login.
+- Cross-origin or subdomain credential matching (e.g. offering `login.example.com` creds on `example.com`). Matching is exact-origin only in this story.
+
+### Acceptance Criteria
+
+#### AC1: Login submission triggers a Swing "Save password?" prompt on macOS
+**Given** a `WebViewComponent` on macOS with the password manager enabled (default) and no custom save-handler, loaded at `https://example.com/login` with a form containing a username input and `<input type="password">`,
+**When** the user types username `alice` and password `s3cret` and submits the form,
+**Then** a Swing prompt appears modal to the host `JFrame` asking to save the password for `https://example.com`, showing the username `alice`.
+
+#### AC2: Approving the prompt stores the credential in the Keychain
+**Given** the setup of AC1 with the save prompt showing,
+**When** the user clicks the prompt's OK/Save button,
+**Then** the credential `{origin: "https://example.com", username: "alice", password: "s3cret"}` is retrievable afterwards via `getCredential("https://example.com")` (username `alice`, password `s3cret`).
+
+#### AC3: Declining the prompt stores nothing
+**Given** the setup of AC1 with the save prompt showing,
+**When** the user clicks Cancel / closes the prompt,
+**Then** `getCredential("https://example.com")` returns an empty result and nothing is written to the store.
+
+#### AC4: Saved credential autofills on next load
+**Given** a `WebViewComponent` on macOS with the manager enabled and a stored credential `{https://example.com, alice, s3cret}`,
+**When** the component loads `https://example.com/login` containing an empty username input and `<input type="password">`,
+**Then** after load the username field's value is `alice` and the password field's value is `s3cret`, without the user typing anything.
+
+#### AC5: Autofill fires `input`/`change` so page validation sees the values
+**Given** the setup of AC4 where the page records `oninput` of the password field into `document.title`,
+**When** autofill populates the fields,
+**Then** `document.title` reflects that an `input` event fired for the password field (the page observed the change, not just a silent DOM mutation).
+
+#### AC6: Autofill is origin-exact — a different origin is not filled
+**Given** a `WebViewComponent` on macOS with a stored credential for `https://example.com`,
+**When** the component loads `https://evil.com/login` with the same field layout,
+**Then** neither field is filled and `getCredential("https://evil.com")` returns empty.
+
+#### AC7: Port and scheme are part of the origin key
+**Given** a stored credential for `https://example.com` (implied port 443),
+**When** the component loads `http://example.com/login` (scheme http) and separately `https://example.com:8443/login` (explicit non-default port),
+**Then** neither page is autofilled, because neither origin equals `https://example.com`.
+
+#### AC8: Programmatic save then get round-trips
+**Given** a `WebViewComponent` on macOS,
+**When** the host calls `saveCredential(new WebViewCredential("https://svc.example.com", "bob", "pw123"))` and then `getCredential("https://svc.example.com")`,
+**Then** the returned credential has username `bob` and password `pw123`.
+
+#### AC9: Programmatic delete removes the credential
+**Given** a `WebViewComponent` on macOS with a stored credential `{https://svc.example.com, bob, pw123}`,
+**When** the host calls `deleteCredential("https://svc.example.com", "bob")`,
+**Then** the call returns `true` and a subsequent `getCredential("https://svc.example.com")` returns empty.
+
+#### AC10: Saving a new password for an existing username overwrites it
+**Given** a stored credential `{https://svc.example.com, bob, oldpw}`,
+**When** the host calls `saveCredential(new WebViewCredential("https://svc.example.com", "bob", "newpw"))`,
+**Then** `getCredential("https://svc.example.com")` returns password `newpw`, and there is exactly one credential for `{https://svc.example.com, bob}` (no duplicate).
+
+#### AC11: Multiple usernames for one origin are all retained
+**Given** a `WebViewComponent` on macOS,
+**When** the host saves `{https://svc.example.com, bob, pw1}` and `{https://svc.example.com, carol, pw2}`,
+**Then** `getCredentials("https://svc.example.com")` returns both credentials, and `getCredential("https://svc.example.com")` returns the most-recently-saved one (`carol`).
+
+#### AC12: Disabling the manager suppresses prompt and autofill but keeps the API
+**Given** a `WebViewComponent` on macOS with `setPasswordManagerEnabled(false)` and a stored credential `{https://example.com, alice, s3cret}`,
+**When** the component loads `https://example.com/login` and the user submits a login form,
+**Then** no autofill occurs, no save prompt appears, yet `getCredential("https://example.com")` still returns `alice`/`s3cret` (programmatic API unaffected).
+
+#### AC13: Custom save-handler decides programmatically without UI
+**Given** a `WebViewComponent` on macOS with `setSavePasswordHandler(e -> SavePasswordDisposition.SAVE)`,
+**When** the user submits a login form with username `dan` / password `pw` at `https://example.com/login`,
+**Then** no Swing prompt appears and `getCredential("https://example.com")` returns `dan`/`pw` within a bounded time.
+
+#### AC14: Custom in-memory store replaces the Keychain for tests
+**Given** a `WebViewComponent` on macOS with `setCredentialStore(inMemoryStore)` where `inMemoryStore` is a caller-supplied `WebViewCredentialStore`,
+**When** a login submission is approved for saving,
+**Then** the credential is written to `inMemoryStore` (observable directly on that object) and nothing is written to the OS Keychain.
+
+#### AC15: Save-handler and store callbacks run on the EDT
+**Given** a `WebViewComponent` on macOS with a custom save-handler and a custom store that each record `SwingUtilities.isEventDispatchThread()`,
+**When** a login submission occurs and is approved,
+**Then** the save-handler was invoked on the EDT (recorded `true`).
+
+#### AC16: getCredentialStore / getSavePasswordHandler never return null
+**Given** a freshly constructed `WebViewComponent` on macOS with nothing set,
+**When** the host calls `getCredentialStore()` and `getSavePasswordHandler()`,
+**Then** both return non-null default instances (the `NativeCredentialStore` and the Swing-prompt handler).
+
+#### AC17: setCredentialStore(null) / setSavePasswordHandler(null) restore defaults
+**Given** a `WebViewComponent` on macOS with a custom store and custom handler installed,
+**When** the host calls `setCredentialStore(null)` and `setSavePasswordHandler(null)`,
+**Then** `getCredentialStore()` returns a `NativeCredentialStore` and `getSavePasswordHandler()` returns the default Swing-prompt handler.
+
+#### AC18: Password never appears in library output
+**Given** a `WebViewComponent` on macOS with a stored credential `{https://example.com, alice, s3cret}` and autofill exercised,
+**When** the host inspects `WebViewCredential.toString()`, `WebViewSavePasswordEvent.toString()`, and the library's stdout/stderr during save and fill,
+**Then** the literal password `s3cret` appears in none of them (POJO `toString()` redacts it; the library logs no password).
+
+#### AC19: No credential for the origin means no autofill and no error
+**Given** a `WebViewComponent` on macOS with the manager enabled and an empty store,
+**When** the component loads `https://example.com/login` with a login form,
+**Then** neither field is filled, no prompt appears, and no exception is raised.
+
+#### AC20: Save-handler exception does not crash the WebView
+**Given** a `WebViewComponent` on macOS with a save-handler whose `onLoginSubmitted` throws a `RuntimeException`,
+**When** the user submits a login form,
+**Then** the exception surfaces via standard EDT uncaught-exception handling, nothing is stored, the WebView stays responsive, and the host app does not crash.
+
+### Non-Functional Expectations
+
+- Passwords are stored only in the OS Keychain (encrypted at rest, unlocked by the user's macOS login). The library writes no plaintext credential file and prints no password.
+- The bridge from the WebKit message thread to the EDT (for the save prompt) must not deadlock the WebKit UI thread, consistent with the constraint the dialog-handler feature already documents.
+- Keychain I/O must not block the AppKit main thread for an unbounded period; where the platform allows, store operations are performed off the UI thread.
+- Autofill is best-effort: it must populate fields that exist at `DOMContentLoaded` and should make a bounded re-attempt for forms inserted shortly after load, without busy-looping indefinitely.
+- The detection heuristic must not fire a save prompt when no password field was involved (e.g. a search form submission must never trigger "Save password?").
+- The injected script must expose no new page-visible global or callable that page JavaScript could use to exfiltrate stored credentials; the fill direction only ever writes the single origin-matched credential Java chose to send.
+
+---
+
+## [STORY-006-002] Linux libsecret Coverage for the Password Manager
+
+### Background
+
+STORY-006-001 establishes the password-manager Java contract, the shared detection/fill JavaScript, and the macOS Keychain backend. This story extends the feature to Linux — both `WebViewHeavyweightComponent` (X11-reparented WebKitGTK) and `WebViewLightweightComponent` (offscreen WebKitGTK), which share the same WebKit engine and injection model.
+
+On Linux the two moving parts are:
+
+- **Script injection + capture channel**: WebKitGTK injects document-start scripts via `webkit_user_content_manager_add_script` (a `WebKitUserScript` created with `WEBKIT_USER_SCRIPT_INJECT_AT_DOCUMENT_START`) and delivers page→app messages via a registered script-message handler (`webkit_user_content_manager_register_script_message_handler` + the `script-message-received` signal). This is the same content-manager the console-capture and dialog features already use, so the shared JS from STORY-006-001 is injected here unchanged and its capture messages are received over the existing channel.
+- **Secret store**: Linux has no single "OS Keychain"; the standard is the freedesktop **Secret Service** accessed through **libsecret** (GNOME Keyring, KWallet via its Secret Service interface, etc.). The store is implemented against `secret_password_store_sync` / `secret_password_lookup_sync` / `secret_password_clear_sync` with a stable `SecretSchema` whose attributes carry the library namespace, the origin, and the username. Secrets are encrypted at rest by the keyring and unlocked with the user's login keyring.
+
+This story implements `NativeCredentialStore` for Linux against libsecret and wires the shared script + capture channel into the heavyweight and lightweight engines, so Linux callers get the same save + autofill behaviour and the same Java API semantics as macOS.
+
+Key points:
+- Business value: brings "save once, autofill forever" to Linux desktops, where the offscreen/reparented WebKit gives no built-in password UX at all.
+- Relationship with other features: reuses the JNI callback-into-Java-from-the-GTK-thread pattern already used by `ConsoleDispatcher` and the dialog dispatch; no new JNI infrastructure.
+- Why now: STORY-006-001 lands the contract; without this story `setPasswordManagerEnabled` / `saveCredential` do nothing on Linux.
+
+### Business Value
+
+- Provide **working "Save password?" capture** and **autofill on load** in both `WebViewHeavyweightComponent` and `WebViewLightweightComponent` on Linux.
+- Provide a **libsecret-backed `NativeCredentialStore`** so Linux credentials are stored encrypted in the user's login keyring (GNOME Keyring / KWallet), never in a plaintext file.
+- Fulfil the **cross-platform contract** from STORY-006-001: `saveCredential` / `getCredential` / `deleteCredential`, the save prompt, and autofill behave identically on Linux and macOS.
+
+### Dependencies and Assumptions
+
+- **Prerequisites**: STORY-006-001 complete (the `WebViewCredential`, `WebViewCredentialStore`, `WebViewSavePasswordHandler`, `WebViewSavePasswordEvent` types, the `WebViewComponent` methods, and the shared detection/fill JavaScript must already exist). Canvases 6 and 7 (heavyweight + lightweight engines) in place.
+- **Data assumptions**: Same credential model as macOS; the only persisted state is the libsecret-stored secrets keyed by `{origin, username}` plus a library-namespace attribute.
+- **Integration points**: WebKitGTK `WebKitUserContentManager` (`webkit_user_content_manager_add_script`, `webkit_user_content_manager_register_script_message_handler`, `script-message-received`) — the same manager instance the existing features use; and **libsecret** (`secret_password_store_sync`, `secret_password_lookup_sync`, `secret_password_clear_sync`, `SecretSchema`). libsecret is resolved the same way the codebase already resolves WebKitGTK symbols (runtime lookup; no hard SONAME pin beyond what the build documents).
+- **Business constraints**:
+  - The libsecret store must present the same origin-keying semantics as macOS (scheme+host+port, default port implied). The `SecretSchema` attributes are `service` (library namespace constant), `origin`, and `username`.
+  - libsecret's synchronous calls may block on the Secret Service D-Bus round-trip; they must be invoked off the GTK main-loop thread (or on a worker) so the engine's UI thread is not parked on keyring I/O.
+  - If **no Secret Service provider is available** (headless box with no keyring daemon, no D-Bus session), `NativeCredentialStore` operations fail gracefully: `save` reports failure without crashing, `find` returns empty, and the save prompt / autofill simply no-op. Tests that need determinism inject an in-memory store as on macOS.
+  - The capture handler runs on the GTK main thread; the save-policy must run on the EDT. The bridge marshals GTK→EDT, waits for the disposition, and proceeds — using the same deadlock-free pattern as the dialog dispatch.
+
+### Scope In
+
+- Native (Linux, shared by heavyweight + lightweight): inject the shared STORY-006-001 detection/fill script at document-start via the engine's `WebKitUserContentManager`, and register a script-message handler that receives `{origin, username, password}` captures and forwards them to the Java password dispatcher over the existing JNI callback bridge.
+- Native (Linux): implement the `NativeCredentialStore` operations (`save` / `find` / `findAll` / `delete`) against libsecret with a stable `SecretSchema`, exposed to Java through the same JNI entry points the macOS store uses (one native store, three platform bodies).
+- Native (Linux): drive autofill by handing the origin-matched credential from Java to the injected script via the content-manager message channel, identically in both modes.
+- Java: **no new public API** — all types come from STORY-006-001. Any internal dispatcher/JNI glue needed to route captures and store calls on Linux is internal.
+- Behaviour-symmetric across heavyweight and lightweight: same injection site, same capture channel, same store, same default Swing prompt.
+
+### Scope Out
+
+- Windows coverage — STORY-006-003.
+- macOS — STORY-006-001.
+- A specific keyring backend requirement (GNOME Keyring vs KWallet): the library targets the freedesktop Secret Service via libsecret and works with whichever provider implements it; it does not ship or require a particular daemon.
+- Prompting the user to unlock a locked login keyring: if the keyring is locked, libsecret/the Secret Service prompts per its own policy; the library adds no unlock UI of its own.
+- The multi-step login and other limitations already listed as out-of-scope in STORY-006-001.
+
+### Acceptance Criteria
+
+#### AC1: Login submission triggers the save prompt on Linux heavyweight
+**Given** a `WebViewHeavyweightComponent` on Linux with the manager enabled and no custom handler, loaded at `https://example.com/login` with a username input and `<input type="password">`,
+**When** the user submits username `alice` / password `s3cret`,
+**Then** a Swing "Save password?" prompt appears modal to the host `JFrame`, showing origin `https://example.com` and username `alice`.
+
+#### AC2: Login submission triggers the save prompt on Linux lightweight
+**Given** the same setup as AC1 but in `WebViewLightweightComponent`,
+**When** the user submits the login form,
+**Then** the same Swing "Save password?" prompt appears, with no `gdk_window_move_to_rect: 'window->transient_for'` warning attributable to this prompt.
+
+#### AC3: Approving stores the credential in the login keyring (both modes)
+**Given** a `WebViewComponent` on Linux (each mode in turn) with a Secret Service provider available and the save prompt showing,
+**When** the user approves,
+**Then** `getCredential("https://example.com")` afterwards returns username `alice` / password `s3cret`, and the secret is present in the user's keyring under the library namespace.
+
+#### AC4: Saved credential autofills on next load (both modes)
+**Given** a `WebViewComponent` on Linux (each mode in turn) with a stored credential `{https://example.com, alice, s3cret}`,
+**When** the component loads `https://example.com/login` with empty username + password fields,
+**Then** after load the username field reads `alice` and the password field reads `s3cret`, and the page observes `input`/`change` events for the filled fields.
+
+#### AC5: Autofill is origin-exact on Linux
+**Given** a `WebViewComponent` on Linux (each mode in turn) with a stored credential for `https://example.com`,
+**When** it loads `https://evil.com/login` with the same layout,
+**Then** neither field is filled.
+
+#### AC6: Programmatic save/get/delete round-trip via libsecret (both modes)
+**Given** a `WebViewComponent` on Linux (each mode in turn) with the default `NativeCredentialStore` and a Secret Service available,
+**When** the host calls `saveCredential({https://svc.example.com, bob, pw123})`, then `getCredential("https://svc.example.com")`, then `deleteCredential("https://svc.example.com", "bob")`,
+**Then** the get returns `bob`/`pw123`, the delete returns `true`, and a final `getCredential` returns empty.
+
+#### AC7: Overwrite semantics match macOS
+**Given** a stored credential `{https://svc.example.com, bob, oldpw}` on Linux,
+**When** the host saves `{https://svc.example.com, bob, newpw}`,
+**Then** `getCredential` returns `newpw` and exactly one credential exists for `{https://svc.example.com, bob}`.
+
+#### AC8: Custom in-memory store bypasses libsecret
+**Given** a `WebViewComponent` on Linux (each mode in turn) with `setCredentialStore(inMemoryStore)`,
+**When** a login submission is approved,
+**Then** the credential is written to `inMemoryStore` and nothing is written to the Secret Service.
+
+#### AC9: Disabling the manager suppresses prompt and autofill (both modes)
+**Given** a `WebViewComponent` on Linux (each mode in turn) with `setPasswordManagerEnabled(false)` and a stored credential for `https://example.com`,
+**When** the page loads and a login form is submitted,
+**Then** no autofill and no prompt occur, but `getCredential("https://example.com")` still returns the stored credential.
+
+#### AC10: Handler callback runs on the EDT (both modes)
+**Given** a `WebViewComponent` on Linux (each mode in turn) with a save-handler recording `SwingUtilities.isEventDispatchThread()`,
+**When** a login submission occurs,
+**Then** the recorded value is `true`.
+
+#### AC11: Heavyweight and lightweight produce identical behaviour
+**Given** the same login page and the same custom handler + custom store in `WebViewHeavyweightComponent` and `WebViewLightweightComponent` on Linux,
+**When** an identical submit sequence runs,
+**Then** both modes capture identical event field values (origin, username, password) and, on autofill, write identical field values.
+
+#### AC12: Graceful degradation when no Secret Service is available
+**Given** a `WebViewComponent` on Linux with the default `NativeCredentialStore` on a system with no available Secret Service provider,
+**When** the host calls `saveCredential(...)` and later `getCredential(...)`,
+**Then** the save fails without throwing to the point of crashing the app, `getCredential` returns empty, and page load / submission still work (the manager simply cannot persist).
+
+#### AC13: Password never appears in library output on Linux
+**Given** a `WebViewComponent` on Linux with a stored credential and autofill exercised,
+**When** the host inspects the POJO `toString()`s and the library's stdout/stderr,
+**Then** the literal password appears in none of them.
+
+### Non-Functional Expectations
+
+- libsecret's synchronous Secret Service calls must not park the GTK main-loop thread; keyring I/O runs off the UI thread so page rendering and event pumping continue.
+- The GTK→EDT marshal for the save prompt must be deadlock-free under the heavyweight model where the GTK pump runs on its own thread separate from AWT's X11 thread, matching the dialog-handler constraint.
+- Heavyweight and lightweight must produce byte-identical captured field values and identical stored/filled values for the same page input — no silent divergence between engines.
+- The library writes no plaintext credential file on Linux; the only persistence is the Secret Service.
+
+---
+
+## [STORY-006-003] Windows Credential Manager Coverage for the Password Manager
+
+### Background
+
+STORY-006-001 establishes the password-manager Java contract, the shared detection/fill JavaScript, and macOS. STORY-006-002 adds Linux. This story extends the feature to Windows, where `WebViewHeavyweightComponent` uses Microsoft WebView2 (embedded Edge/Chromium).
+
+WebView2 already has its own Edge password manager, but it is off by default and, more importantly, it stores into the user's Edge profile and is not exposed through the library's Java API — a host calling `saveCredential(...)` or expecting the library's uniform save prompt would find Windows behaving differently from macOS and Linux. To fulfil the cross-platform contract, Windows uses the **library's own** manager, exactly as the other platforms do, rather than Edge's.
+
+The two moving parts on Windows are:
+
+- **Script injection + capture channel**: WebView2 injects document-start scripts via `ICoreWebView2::AddScriptToExecuteOnDocumentCreated` and delivers page→app messages via `ICoreWebView2::add_WebMessageReceived` (the page calls `window.chrome.webview.postMessage(...)`). The codebase already shims `window.external.invoke` onto this channel and registers a `WebMessageReceived` handler, so the shared STORY-006-001 script is injected here and its captures arrive over the existing message pipe.
+- **Secret store**: Windows credentials go in the **Windows Credential Manager** via `CredWrite` / `CredRead` / `CredDelete` (`CRED_TYPE_GENERIC`), with the target name derived from the library namespace + origin + username. The stored blob is protected by the OS (DPAPI, per-user) — no library-managed crypto.
+
+This story implements `NativeCredentialStore` for Windows against the Credential Manager and wires the shared script + capture channel into the WebView2 engine, so Windows gets the same save + autofill behaviour and the same Java API semantics as macOS and Linux.
+
+Key points:
+- Business value: makes `setPasswordManagerEnabled` / `saveCredential` / the save prompt / autofill behave identically on Windows, using the library's manager rather than Edge's profile store.
+- Relationship with other features: the WebView2 message channel and `AddScriptToExecuteOnDocumentCreated` are already used for the `window.external.invoke` shim and dialog dispatch; this story adds one more document-start script and reuses the same `WebMessageReceived` handler routing.
+- Why now: closes the last platform gap in the cross-platform password-manager contract.
+
+### Business Value
+
+- Provide **handler-and-store consistency on Windows** — the library's own "Save password?" prompt, autofill on load, and `saveCredential`/`getCredential`/`deleteCredential` behave the same as macOS and Linux.
+- Provide a **Credential-Manager-backed `NativeCredentialStore`** so Windows credentials are stored in the OS credential vault (DPAPI-protected), never in a plaintext file, and independent of the Edge profile.
+- Make **programmatic and headless testing** work on Windows via the same in-memory-store / programmatic-handler seams.
+
+### Dependencies and Assumptions
+
+- **Prerequisites**: STORY-006-001 complete (Java types + shared script). STORY-006-002 is not a strict prerequisite, but any internal password dispatcher it introduces is reused here; landing 006-002 first reduces duplicated internal scaffolding.
+- **Data assumptions**: Same credential model; the only persisted state is Credential-Manager entries keyed by a target name encoding library namespace + origin + username.
+- **Integration points**: `ICoreWebView2::AddScriptToExecuteOnDocumentCreated`, `ICoreWebView2::add_WebMessageReceived` (already wired in `windows/webview_embed.cc`), and the Win32 Credential Management API (`CredWriteW`, `CredReadW`, `CredDeleteW`, `CredFree`) with `CRED_TYPE_GENERIC` and `CRED_PERSIST_LOCAL_MACHINE`/`CRED_PERSIST_ENTERPRISE` per-user persistence.
+- **Business constraints**:
+  - The Credential-Manager store must present the same origin-keying semantics as the other platforms (scheme+host+port, default port implied). The target name is a stable, collision-free encoding of `{namespace, origin, username}`; `CredEnumerate` with the namespace prefix backs `findAll` / `find`.
+  - Windows' own WebView2 (Edge) password autosave stays **off** (`ICoreWebView2Settings4::put_IsPasswordAutosaveEnabled(FALSE)`, the default) so Edge's prompt never competes with the library's prompt.
+  - The `WebMessageReceived` callback runs on the WebView2 worker thread; the save-policy must run on the EDT. The bridge marshals worker→EDT, waits for the disposition, and proceeds without parking the worker queue beyond the prompt's lifetime — the same discipline the dialog handler uses on Windows.
+  - `CredRead`/`CredWrite` are fast local calls but still run off the message-pump-critical path where practical.
+
+### Scope In
+
+- Native (Windows): inject the shared STORY-006-001 detection/fill script via `AddScriptToExecuteOnDocumentCreated`, and route its `{origin, username, password}` captures through the existing `WebMessageReceived` handler to the Java password dispatcher.
+- Native (Windows): implement the `NativeCredentialStore` operations (`save` / `find` / `findAll` / `delete`) against the Windows Credential Manager, exposed through the same JNI entry points as the macOS and Linux stores.
+- Native (Windows): drive autofill by handing the origin-matched credential from Java to the injected script via `PostWebMessageAsJson` / `ExecuteScript` on the WebView2 instance.
+- Native (Windows): ensure Edge's built-in password autosave is disabled so it does not double-prompt.
+- Java: **no new public API** — all types come from STORY-006-001; internal glue only.
+- README documentation: note that on Windows the library's own password manager is used (not Edge's profile store) and credentials live in the Windows Credential Manager.
+
+### Scope Out
+
+- macOS — STORY-006-001. Linux — STORY-006-002.
+- Using or importing Edge's existing saved passwords from the user's Edge profile — the library uses its own Credential-Manager namespace; it neither reads nor writes Edge's store.
+- Roaming/enterprise credential sync policies beyond choosing a per-user persistence flag.
+- The multi-step login and other limitations already listed as out-of-scope in STORY-006-001.
+
+### Acceptance Criteria
+
+#### AC1: Login submission triggers the library's save prompt on Windows
+**Given** a `WebViewHeavyweightComponent` on Windows 11 (WebView2 Runtime installed) with the manager enabled and no custom handler, loaded at `https://example.com/login` with a username input and `<input type="password">`,
+**When** the user submits username `alice` / password `s3cret`,
+**Then** the library's Swing "Save password?" prompt appears modal to the host `JFrame` (not Edge's built-in save-password bar), showing origin `https://example.com` and username `alice`.
+
+#### AC2: Approving stores the credential in the Windows Credential Manager
+**Given** the setup of AC1 with the prompt showing,
+**When** the user approves,
+**Then** `getCredential("https://example.com")` returns `alice`/`s3cret`, and a corresponding `CRED_TYPE_GENERIC` entry exists in the Windows Credential Manager under the library namespace.
+
+#### AC3: Saved credential autofills on next load
+**Given** a `WebViewHeavyweightComponent` on Windows with a stored credential `{https://example.com, alice, s3cret}`,
+**When** the component loads `https://example.com/login` with empty fields,
+**Then** after load the username field reads `alice`, the password field reads `s3cret`, and the page observes `input`/`change` events for the filled fields.
+
+#### AC4: Autofill is origin-exact on Windows
+**Given** a `WebViewHeavyweightComponent` on Windows with a stored credential for `https://example.com`,
+**When** it loads `https://evil.com/login` with the same layout,
+**Then** neither field is filled.
+
+#### AC5: Programmatic save/get/delete round-trip via Credential Manager
+**Given** a `WebViewHeavyweightComponent` on Windows with the default `NativeCredentialStore`,
+**When** the host calls `saveCredential({https://svc.example.com, bob, pw123})`, then `getCredential(...)`, then `deleteCredential("https://svc.example.com", "bob")`,
+**Then** the get returns `bob`/`pw123`, the delete returns `true`, and a final `getCredential` returns empty.
+
+#### AC6: Overwrite semantics match the other platforms
+**Given** a stored credential `{https://svc.example.com, bob, oldpw}` on Windows,
+**When** the host saves `{https://svc.example.com, bob, newpw}`,
+**Then** `getCredential` returns `newpw` and exactly one Credential-Manager entry exists for `{https://svc.example.com, bob}`.
+
+#### AC7: Multiple usernames for one origin are all retained
+**Given** a `WebViewHeavyweightComponent` on Windows,
+**When** the host saves `{https://svc.example.com, bob, pw1}` and `{https://svc.example.com, carol, pw2}`,
+**Then** `getCredentials("https://svc.example.com")` returns both, and `getCredential(...)` returns the most-recently-saved (`carol`).
+
+#### AC8: Custom in-memory store bypasses the Credential Manager
+**Given** a `WebViewHeavyweightComponent` on Windows with `setCredentialStore(inMemoryStore)`,
+**When** a login submission is approved,
+**Then** the credential is written to `inMemoryStore` and nothing is written to the Windows Credential Manager.
+
+#### AC9: Disabling the manager suppresses prompt and autofill
+**Given** a `WebViewHeavyweightComponent` on Windows with `setPasswordManagerEnabled(false)` and a stored credential for `https://example.com`,
+**When** the page loads and a login form is submitted,
+**Then** no autofill and no prompt occur, but `getCredential("https://example.com")` still returns the stored credential.
+
+#### AC10: Edge's built-in save-password bar does not appear
+**Given** a `WebViewHeavyweightComponent` on Windows with the default handler,
+**When** the user submits a login form,
+**Then** only the library's Swing prompt appears; Edge's own "Save password?" bar does not appear (Edge password autosave is disabled).
+
+#### AC11: Handler callback runs on the EDT
+**Given** a `WebViewHeavyweightComponent` on Windows with a save-handler recording `SwingUtilities.isEventDispatchThread()`,
+**When** a login submission occurs,
+**Then** the recorded value is `true`.
+
+#### AC12: Password never appears in library output on Windows
+**Given** a `WebViewHeavyweightComponent` on Windows with a stored credential and autofill exercised,
+**When** the host inspects the POJO `toString()`s and the library's stdout/stderr,
+**Then** the literal password appears in none of them.
+
+#### AC13: Save-handler exception completes cleanly without crashing WebView2
+**Given** a `WebViewHeavyweightComponent` on Windows with a save-handler whose `onLoginSubmitted` throws,
+**When** the user submits a login form,
+**Then** the exception surfaces via EDT uncaught-exception handling, nothing is stored, the WebView2 stays responsive, and the host app does not crash.
+
+### Non-Functional Expectations
+
+- The marshal from the WebView2 worker thread to the EDT and back must not require the worker queue to service EDT-dependent messages while it waits, matching the dialog-handler discipline.
+- Credential-Manager entries are per-user and DPAPI-protected by the OS; the library writes no plaintext credential file and prints no password.
+- Edge's own password autosave must be disabled from engine creation so it never competes with the library prompt.
+- The Windows behaviour (library manager, Credential-Manager storage) must be documented in `README.md` so callers understand credentials are not shared with the Edge profile.
+
+---
+
+## Quality Checks
+
+**STORY-006-001 (Java API + shared JS + macOS Keychain)**:
+- ✅ All required sections present (Background, Business Value, Dependencies and Assumptions, Scope In/Out, Acceptance Criteria, Non-Functional Expectations).
+- ✅ ACs use Given-When-Then with concrete inputs (`alice`/`s3cret`, `https://example.com` vs `https://evil.com` vs `https://example.com:8443`) and observable outcomes (`getCredential(...)` returns specific values, fields read specific strings, password absent from output).
+- ✅ Business-language ACs — public API names (`setPasswordManagerEnabled`, `saveCredential`, `WebViewSavePasswordHandler`) appear as the user-visible contract; no JNI signatures or ObjC selectors inside AC bodies (native APIs appear only in Background / Dependencies / Scope-In).
+- ✅ Covers happy path (save prompt, autofill), business rules (origin-exact, overwrite, multiple usernames), control (enable/disable, custom store, custom handler), and error/security (handler exception, password never logged).
+- ✅ At most three core functional points (Java API, shared detection/fill JS, macOS native + Keychain store).
+- ✅ 4-5 days of work.
+
+**STORY-006-002 (Linux libsecret)**:
+- ✅ All required sections present.
+- ✅ ACs run "in each mode in turn" for heavyweight + lightweight; parity AC (AC11) checks identical behaviour; graceful-degradation AC (AC12) covers the no-keyring case.
+- ✅ Business-language ACs; libsecret / WebKitGTK symbol names appear only in Background / Dependencies / Scope-In.
+- ✅ No new public API — conforms to the STORY-006-001 contract.
+- ✅ At most two core functional points (WebKitGTK script injection + capture, libsecret store).
+- ✅ 3-4 days of work.
+
+**STORY-006-003 (Windows Credential Manager)**:
+- ✅ All required sections present.
+- ✅ Concrete inputs/outputs; AC10 explicitly asserts Edge's built-in bar does not appear; AC13 covers handler-exception cleanup.
+- ✅ Business-language ACs; COM / Win32 names appear only in Background / Dependencies / Scope-In.
+- ✅ No new public API — conforms to the STORY-006-001 contract.
+- ✅ Two core functional points (WebView2 script injection + capture, Credential-Manager store).
+- ✅ 2-3 days of work.
+
+## Final INVEST Re-validation
+
+| Property | STORY-006-001 | STORY-006-002 | STORY-006-003 |
+|---|---|---|---|
+| Independent | ✅ (designs the API + shared JS; depends only on existing engine plumbing) | ✅ (depends only on the 006-001 contract; native code independent) | ✅ (depends only on the 006-001 contract; native code independent of Linux's) |
+| Complete | ✅ (full Java contract + shared JS + working macOS save/fill/store) | ✅ (full Linux coverage, both modes, libsecret store) | ✅ (full Windows coverage, Credential-Manager store) |
+| Valuable | ✅ (fixes the concrete macOS retyping pain; ships the contract) | ✅ (brings save/autofill to Linux desktops) | ✅ (uniform library manager on Windows, independent of Edge profile) |
+| Estimable | ✅ (POJOs + two interfaces + component methods + one ObjC injection + Keychain JNI + shared JS) | ✅ (one content-manager injection + libsecret JNI, reusing the JS + contract) | ✅ (one AddScriptToExecuteOnDocumentCreated + Credential-Manager JNI, reusing the JS + contract) |
+| Right-sized | ✅ (4-5 days) | ✅ (3-4 days) | ✅ (2-3 days) |
+| Testable | ✅ (in-memory store + programmatic handler drive save/fill headlessly; Swing harness shows default UX) | ✅ (both-mode ACs + parity AC + graceful-degradation AC) | ✅ (in-memory store + programmatic handler; Edge-bar-suppression AC) |
+
+All three stories pass INVEST.

--- a/requirements/[User-story-6]webview-native-password-manager.md
+++ b/requirements/[User-story-6]webview-native-password-manager.md
@@ -246,6 +246,16 @@ Key points:
 **When** the user submits a login form,
 **Then** the exception surfaces via standard EDT uncaught-exception handling, nothing is stored, the WebView stays responsive, and the host app does not crash.
 
+#### AC21: Re-submitting an unchanged credential does not re-prompt to save
+**Given** a `WebViewComponent` with the manager enabled and a stored credential `{https://example.com, alice, s3cret}` (e.g. just autofilled),
+**When** the user submits the login form with username `alice` and password `s3cret` (the same, unchanged credential),
+**Then** no "Save password?" prompt appears and nothing new is written — the manager only offers to save a credential that is new or whose password changed.
+
+#### AC22: A changed password still prompts to save
+**Given** a `WebViewComponent` with the manager enabled and a stored credential `{https://example.com, alice, s3cret}`,
+**When** the user submits the login form with username `alice` and a **different** password `n3wpw`,
+**Then** the "Save password?" prompt appears (a changed password is offered for saving), and approving it updates the stored password to `n3wpw`.
+
 ### Non-Functional Expectations
 
 - Passwords are stored only in the OS Keychain (encrypted at rest, unlocked by the user's macOS login). The library writes no plaintext credential file and prints no password.

--- a/requirements/[User-story-6]webview-native-password-manager.md
+++ b/requirements/[User-story-6]webview-native-password-manager.md
@@ -55,10 +55,14 @@ STORY-006-001 (Java API contract + shared detection/fill JS + macOS Keychain)
         │
         ├──► STORY-006-002 (Linux libsecret) — depends on the Java contract + shared JS from 006-001
         │
-        └──► STORY-006-003 (Windows Credential Manager) — depends on the Java contract + shared JS from 006-001
+        ├──► STORY-006-003 (Windows Credential Manager) — depends on the Java contract + shared JS from 006-001
+        │
+        ├──► STORY-006-004 (Autofill-consent handler) — Java-contract-only; depends on 006-001; cross-platform by construction
+        │
+        └──► STORY-006-005 (Enumerate-all credentials) — extends the store seam; Java contract + native enumerate on macOS/Linux/Windows
 ```
 
-STORY-006-002 and STORY-006-003 can be developed in parallel once STORY-006-001 has landed.
+STORY-006-002 and STORY-006-003 can be developed in parallel once STORY-006-001 has landed. STORY-006-004 and STORY-006-005 are follow-on enhancements that build on the shipped contract (006-001) and, for 006-005's native enumerate bodies, the per-platform stores from 006-002 / 006-003. **Both reverse a Scope-Out item that STORY-006-001 originally deferred**: 006-004 reverses "Biometric / re-authentication gating before autofill", and 006-005 reverses "A credential-management UI … Hosts build their own on top of the programmatic API" by supplying the missing enumerate-all primitive that a management UI needs.
 
 ---
 
@@ -509,6 +513,236 @@ Key points:
 
 ---
 
+## [STORY-006-004] Autofill-Consent Handler (Confirm / Re-Authenticate Before Fill)
+
+### Background
+
+STORY-006-001 shipped the password manager with a deliberately asymmetric consent model. The **save** direction is gated: a captured login submission is routed through a `WebViewSavePasswordHandler` policy (default: a Swing "Save password?" prompt) that decides SAVE vs DON'T-SAVE before anything is written. The **fill** direction is *not* gated: on page load, when the manager is enabled and a credential exists for the origin, the library injects the username + password into the detected fields automatically, with no policy consulted and no confirmation shown.
+
+That silent autofill is fine for many hosts, but it diverges from what mainstream browsers actually do. Chrome, Edge, and Safari's password managers typically **confirm** a fill and, on managed or sensitive systems, **re-authenticate** the user (OS login password, Windows Hello, Touch ID / biometric) before revealing or filling a stored password. A host embedding `WebViewComponent` today has no seam to insert that step: the fill path runs from store lookup straight to injection.
+
+This story adds the missing seam — a fill-side policy exactly symmetric to the save-side one — so a host can require confirmation and/or an OS re-auth before autofill, and can decline a fill. It **explicitly reverses** the STORY-006-001 Scope-Out item *"Biometric / re-authentication gating before autofill (Touch ID prompt per fill). Out of scope; the OS unlocks the Keychain at login."* — not by shipping a biometric implementation itself, but by providing the decision point at which a host (or a future platform enhancement) can perform that gating.
+
+Key points:
+- Business value: brings the embedded WebView's autofill into line with browser-grade "confirm before fill" behaviour and unblocks hosts that must re-authenticate the user before a credential is revealed.
+- Relationship with other features: mirrors `WebViewSavePasswordHandler` one-for-one (policy interface + Swing default + component setter/getter, invoked on the EDT), reusing the same dispatch discipline.
+- Why now: with save + autofill shipped and being adopted, the silent-fill behaviour is the next gap between "works" and "behaves like a real browser's password manager".
+
+### Business Value
+
+- Provide a **fill-consent decision point** so a host can show a browser-style "Use saved password for `<origin>`?" confirmation before autofill occurs.
+- Provide a **re-authentication seam** so a host can require an OS credential / biometric (Touch ID, Windows Hello) check and decline the fill if it fails — without the library shipping or mandating any particular biometric mechanism.
+- Preserve the **zero-configuration happy path**: hosts that do nothing keep today's automatic autofill (no behavioural regression).
+- Keep the fill decision **password-free**: the decision is made from the origin + username only; the stored password is never handed to the consent policy.
+
+### Dependencies and Assumptions
+
+- **Prerequisites**: STORY-006-001 complete (the `PasswordDispatcher` autofill path, `WebViewComponent` password API, and the shared fill script exist). No dependency on 006-002 / 006-003; being Java-contract-only, this story is cross-platform by construction and needs no native change.
+- **Data assumptions**: Same credential model. The fill-consent event exposes `{source, origin, username}` — never the password.
+- **Integration points**: purely internal — the existing `PasswordDispatcher.doFill(origin)` path and the `WebViewComponent` API surface. No native or JS change.
+- **Business constraints**:
+  - The consent policy is consulted **only** on the automatic autofill path (page-load fill). The programmatic API (`getCredential` / `getCredentials` / `getAllCredentials` / `saveCredential` / `deleteCredential`) is host-initiated trusted code and is **not** gated by this handler.
+  - The handler runs on the Swing EDT (so it may show UI or block on a modal re-auth), consistent with `WebViewSavePasswordHandler`.
+  - Backward compatibility is a **hard requirement**: the default handler must return FILL, so every STORY-006-001/002/003 autofill AC continues to pass unchanged.
+  - The consent policy must never receive the password; only origin + username are exposed to it.
+
+### Scope In
+
+- New public enum `ca.weblite.webview.FillPasswordDisposition { FILL, DONT_FILL }`.
+- New public POJO `ca.weblite.webview.WebViewFillPasswordEvent`, immutable — `WebViewComponent source()`, `String origin()`, `String username()`. It carries **no password** (no accessor, no field exposed via `toString()`); `toString()` shows origin + username only.
+- New public interface `ca.weblite.webview.WebViewFillPasswordHandler` with a single method invoked on the EDT:
+  - `FillPasswordDisposition onAutofillRequested(WebViewFillPasswordEvent event)`.
+  - `WebViewFillPasswordHandler DEFAULT` — returns `FILL` unconditionally (preserves today's automatic autofill).
+  - `WebViewFillPasswordHandler CONFIRM` — a ready-made opt-in policy that shows a Swing confirmation ("Use the saved password for `<origin>`?", showing the username, never the password) modal to the host window; OK → `FILL`, Cancel/close → `DONT_FILL`. Hosts install this (or their own, e.g. one that performs a biometric check) to require confirmation.
+- New public methods on `WebViewComponent`:
+  - `WebViewComponent setFillPasswordHandler(WebViewFillPasswordHandler handler)` — replace the fill policy; `null` reinstalls `WebViewFillPasswordHandler.DEFAULT`.
+  - `WebViewFillPasswordHandler getFillPasswordHandler()` — never null.
+- Autofill dispatch change: on the page-load fill path, after the origin-matched credential is found, the dispatcher consults the fill handler on the EDT with `{source, origin, username}`; it injects the credential only if the disposition is `FILL`, and does nothing (no injection, no error) on `DONT_FILL`. A handler exception is caught and forwarded to the default EDT uncaught-exception handling; nothing is filled and the WebView stays responsive.
+
+### Scope Out
+
+- Shipping an actual biometric / OS-credential implementation (Touch ID, Windows Hello, `LAContext`, `CredUIPromptForWindowsCredentials`). The story supplies the decision seam and a Swing-confirm default; a concrete biometric check is the host's to implement inside a custom handler (or a later story).
+- Gating the **programmatic** read API (`getCredential`/`getCredentials`/`getAllCredentials`) — those are trusted host calls, not automatic fills.
+- Per-field or per-credential fill selection UI (choosing among multiple usernames at fill time). Autofill continues to use the store's origin-`find` (most-recently-saved) result; richer selection is out of scope.
+- Any change to the save-side policy, the shared JS, or the native layer.
+
+### Acceptance Criteria
+
+#### AC1: Default behaviour still autofills automatically (no regression)
+**Given** a `WebViewComponent` with the manager enabled, a stored credential `{https://example.com, alice, s3cret}`, and no fill-handler installed,
+**When** the component loads `https://example.com/login` with empty username + password fields,
+**Then** after load the username field reads `alice` and the password field reads `s3cret`, with no confirmation shown — identical to STORY-006-001 AC4.
+
+#### AC2: CONFIRM handler shows a confirmation before filling
+**Given** a `WebViewComponent` with a stored credential `{https://example.com, alice, s3cret}` and `setFillPasswordHandler(WebViewFillPasswordHandler.CONFIRM)`,
+**When** the component loads `https://example.com/login`,
+**Then** a Swing confirmation appears modal to the host window asking to use the saved password for `https://example.com`, showing username `alice` and **not** showing the password.
+
+#### AC3: Approving the confirmation fills the fields
+**Given** the setup of AC2 with the confirmation showing,
+**When** the user approves it,
+**Then** the username field reads `alice` and the password field reads `s3cret`.
+
+#### AC4: Declining the confirmation fills nothing
+**Given** the setup of AC2 with the confirmation showing,
+**When** the user cancels / closes it,
+**Then** neither field is filled, no exception is raised, and the page is left as loaded.
+
+#### AC5: A custom handler decides programmatically without UI
+**Given** a `WebViewComponent` with a stored credential for `https://example.com` and `setFillPasswordHandler(e -> FillPasswordDisposition.DONT_FILL)`,
+**When** the component loads `https://example.com/login`,
+**Then** no prompt appears and neither field is filled.
+
+#### AC6: The fill event never exposes the password
+**Given** a `WebViewComponent` with a stored credential `{https://example.com, alice, s3cret}` and a custom fill-handler that records the event it receives,
+**When** autofill is requested on load,
+**Then** the recorded `WebViewFillPasswordEvent` exposes origin `https://example.com` and username `alice`, offers no accessor returning the password, and its `toString()` does not contain `s3cret`.
+
+#### AC7: The fill handler runs on the EDT
+**Given** a `WebViewComponent` with a fill-handler recording `SwingUtilities.isEventDispatchThread()`,
+**When** autofill is requested on load,
+**Then** the recorded value is `true`.
+
+#### AC8: getFillPasswordHandler never returns null; setter null restores default
+**Given** a freshly constructed `WebViewComponent`,
+**When** the host calls `getFillPasswordHandler()`, then installs a custom handler, then calls `setFillPasswordHandler(null)` and `getFillPasswordHandler()` again,
+**Then** the first call returns the non-null `DEFAULT`, and after the null reset the getter returns the `DEFAULT` handler again.
+
+#### AC9: The programmatic read API is not gated by the fill handler
+**Given** a `WebViewComponent` with a stored credential `{https://example.com, alice, s3cret}` and `setFillPasswordHandler(e -> FillPasswordDisposition.DONT_FILL)`,
+**When** the host calls `getCredential("https://example.com")`,
+**Then** it returns `alice`/`s3cret` — the DONT_FILL policy suppresses automatic autofill but does not block trusted host reads.
+
+#### AC10: Disabling the manager suppresses fill regardless of handler
+**Given** a `WebViewComponent` with `setPasswordManagerEnabled(false)`, a stored credential for `https://example.com`, and `setFillPasswordHandler(WebViewFillPasswordHandler.CONFIRM)`,
+**When** the component loads `https://example.com/login`,
+**Then** no confirmation appears and neither field is filled (the disabled manager short-circuits before the handler is consulted).
+
+#### AC11: A fill-handler exception does not crash the WebView
+**Given** a `WebViewComponent` with a fill-handler whose `onAutofillRequested` throws a `RuntimeException`,
+**When** autofill is requested on load,
+**Then** the exception surfaces via standard EDT uncaught-exception handling, nothing is filled, and the WebView stays responsive.
+
+### Non-Functional Expectations
+
+- The default configuration must not change any observable autofill behaviour shipped by STORY-006-001/002/003 — the fill handler is additive and defaults to FILL.
+- The consent policy must be given only origin + username; the password must not be reachable from `WebViewFillPasswordEvent`.
+- The handler is invoked on the EDT and may block on a modal confirmation or re-auth; the native engine thread must not be parked waiting on it (the fill path is already non-blocking off the native thread).
+
+---
+
+## [STORY-006-005] Enumerate-All Credentials for a Management UI
+
+### Background
+
+STORY-006-001 designed every credential **read** around a known origin: `WebViewCredentialStore.find(origin)` and `findAll(origin)`, surfaced as `getCredential(origin)` / `getCredentials(origin)` on `WebViewComponent`. That is exactly what autofill needs, but it makes one thing impossible: a host cannot ask *"which origins / credentials do I have saved?"* without already knowing every origin. Every mainstream browser exposes a password-management surface (Chrome's `chrome://password-manager`, Edge's `edge://settings/passwords`, Safari's Passwords pane) that lists **all** saved logins across **all** sites. A host embedding `WebViewComponent` cannot build that over the library's native OS store today, because there is no enumerate-all operation.
+
+STORY-006-001 explicitly deferred this: its Scope-Out list includes *"A credential-management UI (a 'manage saved passwords' list/editor window). Hosts build their own on top of the programmatic API; the library ships only the save prompt."* The programmatic API it shipped, however, is insufficient to build one — it can add, edit (`saveCredential`), and delete (`deleteCredential`) for a known origin, but it cannot enumerate. This story supplies the missing primitive so that Scope-Out reversal is actually achievable: an all-origins enumeration, exposed on both the store seam and the component.
+
+The native backends already contain the enumeration primitive; the Java contract simply never surfaced it. macOS's Keychain lookup already runs a two-phase `SecItemCopyMatching` and can pass `kSecMatchLimitAll` over the library's service namespace; Windows' `webview_cred_store_find` already calls `CredEnumerateW` with a namespace filter; Linux libsecret supports schema-wide search (`secret_password_search` / `secret_service_search`). This story lifts that capability into the public contract and implements the all-origins variant on each platform.
+
+Key points:
+- Business value: lets a host build a browser-grade "manage saved passwords" screen (list every saved login, then edit/delete via the existing API) over the library's native OS store.
+- Relationship with other features: extends the `WebViewCredentialStore` seam and `WebViewComponent` API from 006-001; reuses each platform's existing enumeration primitive from 006-001 (macOS), 006-002 (Linux), 006-003 (Windows).
+- Why now: with save/fill shipped, "manage what's saved" is the natural next capability, and it is the one primitive missing to make the 006-001 management-UI Scope-Out reversible.
+
+### Business Value
+
+- Provide an **enumerate-all** operation so a host can list every saved credential across every origin — the data a Chrome-style password-manager UI needs.
+- **Complete the management surface**: combined with the existing `saveCredential` (add/edit) and `deleteCredential` (remove), enumerate-all lets a host implement full list/edit/delete over the native OS store.
+- Preserve **cross-platform parity**: the enumerate-all semantics (ordering, dedup, degradation when no store is available) match across macOS, Linux, and Windows.
+- Keep the **security posture** unchanged: enumeration returns credentials to trusted host Java only; page JavaScript still has no path to read any stored credential, and passwords are still never logged.
+
+### Dependencies and Assumptions
+
+- **Prerequisites**: STORY-006-001 (Java contract + macOS store) for the macOS enumerate body and the Java surface; STORY-006-002 (Linux libsecret) and STORY-006-003 (Windows Credential Manager) for the Linux and Windows enumerate bodies respectively. The Java contract change is independent; each native body lands on its platform's canvas.
+- **Data assumptions**: Same credential model; the only persisted state remains the OS-native secret store entries under the library namespace. Enumerate-all reads exactly those entries.
+- **Integration points**: `WebViewCredentialStore` + `WebViewComponent`; macOS Keychain (`SecItemCopyMatching` with `kSecMatchLimitAll` over the library service namespace); Windows Credential Manager (`CredEnumerateW` over the namespace prefix); Linux libsecret (`secret_password_search` / `secret_service_search` over the `SecretSchema`). `InMemoryCredentialStore` enumerates its in-memory map.
+- **Business constraints**:
+  - Enumerate-all returns **every** credential under the library namespace across **all** origins, most-recently-saved first (same recency contract as origin-scoped `findAll`).
+  - It returns full `WebViewCredential` objects (origin + username + password) to the calling host Java, exactly as origin-scoped `find`/`findAll` already do — no new exposure surface; page JS still cannot reach it.
+  - When the backing store is unavailable (no Secret Service on Linux, etc.), enumerate-all degrades to an empty list, never throwing — consistent with the existing store contract.
+  - Passwords are still never logged or printed by the enumerate path.
+
+### Scope In
+
+- Extend `ca.weblite.webview.WebViewCredentialStore` with `java.util.List<WebViewCredential> findAll()` (no argument) — every credential across all origins under the library namespace, most-recently-saved first, as an unmodifiable list (empty when none / store unavailable).
+- New public method on `WebViewComponent`: `java.util.List<WebViewCredential> getAllCredentials()` — delegates to the active store's no-argument `findAll()`.
+- `InMemoryCredentialStore`: implement `findAll()` by enumerating its map, honouring the most-recently-saved-first ordering.
+- `NativeCredentialStore`: implement `findAll()` via a new process-global JNI primitive that enumerates all namespaced entries; provide the three platform bodies:
+  - macOS (Canvas 26): `SecItemCopyMatching` with `kSecMatchLimitAll` filtered to the library service namespace, two-phase (attributes then per-item secret) exactly as the origin-scoped find already does.
+  - Linux (Canvas 27): libsecret schema-wide search over the `SecretSchema` (library-namespace attribute), returning every match.
+  - Windows (Canvas 28): `CredEnumerateW` over the namespace target-prefix (the origin-scoped find already enumerates with a per-origin filter; this uses the namespace-wide filter).
+- Ordering + dedup semantics identical to origin-scoped `findAll` (most-recently-saved first; at most one credential per `{origin, username}`).
+
+### Scope Out
+
+- A shipped management-UI window. This story supplies the enumerate primitive; the actual list/editor UI remains the host's to build (still out of scope per 006-001).
+- A `savedOrigins()`-only variant returning just origins without credentials — `getAllCredentials()` returns full credentials, from which a host derives the origin list; a separate origins-only method is not added.
+- Cross-origin search, fuzzy matching, or paging of results — enumerate-all returns the full set in one call.
+- Any change to autofill, the save/fill handlers, or the shared JS.
+
+### Acceptance Criteria
+
+#### AC1: Enumerate-all returns credentials across multiple origins
+**Given** a `WebViewComponent` whose store holds `{https://a.example, alice, pw1}`, `{https://b.example, bob, pw2}`, and `{https://c.example, carol, pw3}`,
+**When** the host calls `getAllCredentials()`,
+**Then** the returned list contains all three credentials (each origin + username + password), regardless of origin.
+
+#### AC2: Enumerate-all is most-recently-saved first
+**Given** a `WebViewComponent` where the host saves `{https://a.example, alice, pw1}` then `{https://b.example, bob, pw2}` then `{https://c.example, carol, pw3}` in that order,
+**When** the host calls `getAllCredentials()`,
+**Then** the list is ordered most-recently-saved first (`carol`, then `bob`, then `alice`).
+
+#### AC3: Multiple usernames on one origin are all enumerated
+**Given** a `WebViewComponent` whose store holds `{https://svc.example, bob, pw1}` and `{https://svc.example, carol, pw2}`,
+**When** the host calls `getAllCredentials()`,
+**Then** both credentials for `https://svc.example` appear in the result.
+
+#### AC4: Empty store enumerates to an empty list
+**Given** a `WebViewComponent` with an empty store,
+**When** the host calls `getAllCredentials()`,
+**Then** it returns an empty list (not null) and raises no exception.
+
+#### AC5: Deletion is reflected in enumerate-all
+**Given** a `WebViewComponent` whose store holds `{https://a.example, alice, pw1}` and `{https://b.example, bob, pw2}`,
+**When** the host calls `deleteCredential("https://a.example", "alice")` and then `getAllCredentials()`,
+**Then** the result contains only `{https://b.example, bob, pw2}`.
+
+#### AC6: In-memory store enumerates for tests
+**Given** a `WebViewComponent` with `setCredentialStore(inMemoryStore)` where two credentials for different origins have been saved,
+**When** the host calls `getAllCredentials()`,
+**Then** it returns both credentials from `inMemoryStore`, and nothing is read from the OS-native store.
+
+#### AC7: Native round-trip — save two origins then enumerate (per platform)
+**Given** a `WebViewComponent` on macOS / Linux / Windows (each in turn) with the default `NativeCredentialStore` and a working OS secret store,
+**When** the host saves `{https://svc1.example, u1, p1}` and `{https://svc2.example, u2, p2}` and then calls `getAllCredentials()`,
+**Then** both credentials are returned from the OS-native store with their correct usernames and passwords.
+
+#### AC8: Enumerate-all degrades gracefully when the store is unavailable
+**Given** a `WebViewComponent` on a system whose OS secret store is unavailable (e.g. no Secret Service on Linux),
+**When** the host calls `getAllCredentials()`,
+**Then** it returns an empty list without throwing.
+
+#### AC9: Enumerate-all does not expose credentials to page JavaScript
+**Given** a `WebViewComponent` with stored credentials and a loaded page,
+**When** page JavaScript attempts to reach a stored credential (there is no injected global or channel that returns one),
+**Then** the page cannot obtain any credential; enumerate-all is reachable only from host Java via `getAllCredentials()`.
+
+#### AC10: Password never appears in library output during enumeration
+**Given** a `WebViewComponent` with stored credentials,
+**When** the host calls `getAllCredentials()` and inspects the returned objects' `toString()` and the library's stdout/stderr,
+**Then** no literal password appears (POJO `toString()` redacts it; the enumerate path logs no password).
+
+### Non-Functional Expectations
+
+- Enumerate-all's ordering, dedup, and graceful-degradation semantics must be identical across macOS, Linux, and Windows and consistent with the existing origin-scoped `findAll`.
+- The enumerate path performs OS secret-store I/O off the engine UI thread where the platform requires it, matching the existing store-I/O discipline.
+- The library writes no plaintext credential file and prints no password during enumeration.
+- Page JavaScript gains no new capability — enumerate-all is host-Java-only; the injected fill script remains write-only and origin-scoped.
+
+---
+
 ## Quality Checks
 
 **STORY-006-001 (Java API + shared JS + macOS Keychain)**:
@@ -535,6 +769,24 @@ Key points:
 - ✅ Two core functional points (WebView2 script injection + capture, Credential-Manager store).
 - ✅ 2-3 days of work.
 
+**STORY-006-004 (Autofill-consent handler)**:
+- ✅ All required sections present.
+- ✅ ACs use Given-When-Then with concrete inputs (`alice`/`s3cret`, `https://example.com`) and observable outcomes (fields filled or not, confirmation shown or not, EDT recorded `true`, password absent from event).
+- ✅ Business-language ACs; the public contract (`WebViewFillPasswordHandler`, `FillPasswordDisposition`, `setFillPasswordHandler`) is the user-visible surface. No native names in ACs (there are none — Java-contract-only).
+- ✅ Explicitly reverses the 006-001 Scope-Out item "Biometric / re-authentication gating before autofill" by supplying the decision seam (AC1 guarantees the default is a no-regression auto-fill).
+- ✅ Covers backward-compat default (AC1), opt-in confirm (AC2-4), programmatic decision (AC5), password-free event (AC6), EDT (AC7), null-restore (AC8), ungated read API (AC9), disabled-manager short-circuit (AC10), exception isolation (AC11).
+- ✅ One core functional point (a fill-side policy symmetric to the save-side one).
+- ✅ 1-2 days of work.
+
+**STORY-006-005 (Enumerate-all credentials)**:
+- ✅ All required sections present.
+- ✅ ACs use Given-When-Then with concrete multi-origin fixtures and observable outcomes (ordering, dedup, deletion reflected, empty→empty, graceful degradation, password absent from output).
+- ✅ Business-language ACs; the public contract (`getAllCredentials`, `WebViewCredentialStore.findAll()`) is the surface; native enumerate APIs appear only in Background / Dependencies / Scope-In.
+- ✅ Explicitly reverses the 006-001 Scope-Out item "A credential-management UI … Hosts build their own on top of the programmatic API" by supplying the one missing primitive (all-origins enumeration).
+- ✅ Covers multi-origin enumerate (AC1), recency ordering (AC2), multi-username (AC3), empty (AC4), deletion (AC5), in-memory (AC6), native per-platform round-trip (AC7), graceful degradation (AC8), no page-JS exposure (AC9), password never logged (AC10).
+- ✅ Two core functional points (the Java enumerate-all seam, the per-platform native enumerate bodies).
+- ✅ 2-3 days of work.
+
 ## Final INVEST Re-validation
 
 | Property | STORY-006-001 | STORY-006-002 | STORY-006-003 |
@@ -546,4 +798,13 @@ Key points:
 | Right-sized | ✅ (4-5 days) | ✅ (3-4 days) | ✅ (2-3 days) |
 | Testable | ✅ (in-memory store + programmatic handler drive save/fill headlessly; Swing harness shows default UX) | ✅ (both-mode ACs + parity AC + graceful-degradation AC) | ✅ (in-memory store + programmatic handler; Edge-bar-suppression AC) |
 
-All three stories pass INVEST.
+| Property | STORY-006-004 | STORY-006-005 |
+|---|---|---|
+| Independent | ✅ (Java-contract-only; depends only on the 006-001 fill path; no native change) | ✅ (Java seam is independent; each native enumerate body builds on that platform's shipped store) |
+| Complete | ✅ (policy interface + Swing default/confirm + component seam + gated dispatch) | ✅ (enumerate-all on the store + component + all three native bodies + in-memory) |
+| Valuable | ✅ (browser-grade confirm/re-auth before fill; unblocks re-auth-required hosts) | ✅ (supplies the one primitive a Chrome-style manage-passwords UI needs) |
+| Estimable | ✅ (one enum + one POJO + one interface with two default impls + two component methods + one dispatch tweak) | ✅ (one no-arg store method + one component method + one JNI primitive with three platform bodies + in-memory impl) |
+| Right-sized | ✅ (1-2 days) | ✅ (2-3 days) |
+| Testable | ✅ (default-fill no-regression AC + programmatic DONT_FILL + EDT + password-free event, all headless) | ✅ (in-memory enumerate + per-platform native round-trip + ordering/dedup/degradation ACs) |
+
+All five stories pass INVEST.

--- a/run-linux-password-demo.sh
+++ b/run-linux-password-demo.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# One-shot script: build the Linux native lib, build WebView.jar, compile
+# and run the built-in password-manager demo (WebViewPasswordDemo).
+#
+# Exercises the programmatic saveCredential / getCredential /
+# deleteCredential API, the enable/disable gate, and the Keychain vs
+# in-memory store swap.  See demos/WebViewPasswordDemo/README.md.
+#
+# COVERAGE CAVEAT: automatic login-capture and autofill are macOS-only in
+# this release.  On Linux the demo still runs and the programmatic API
+# plus the in-memory store work, but the native capture/fill channel and
+# the OS secret store (libsecret) arrive with a follow-up canvas, so
+# submitting the form will not raise the "Save password?" prompt and
+# Reload will not autofill yet.  Use the In-memory store and the
+# Save/Get/Delete buttons to exercise the API here.
+#
+# Usage:    ./run-linux-password-demo.sh             # lightweight (default)
+#           ./run-linux-password-demo.sh heavyweight # force heavyweight mode
+#           ./run-linux-password-demo.sh lightweight # force lightweight mode
+#           WEBVIEW_MODE=heavyweight ./run-linux-password-demo.sh
+#
+# Override JDK:  JAVA_HOME=/path/to/jdk ./run-linux-password-demo.sh
+#
+# Required packages:
+#   - g++, pkg-config
+#   - libgtk-3-dev
+#   - libwebkit2gtk-4.1-dev (Ubuntu 24.04+) or libwebkit2gtk-4.0-dev (older)
+#   - libx11-dev
+#   - libxt-dev   <-- pulled in because JDK 8's jawt_md.h includes X11/Intrinsic.h
+set -e
+set -o pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR"
+
+# ---------------------------------------------------------------------------
+# 0. Mode selection
+# ---------------------------------------------------------------------------
+MODE="${1:-${WEBVIEW_MODE:-lightweight}}"
+case "$MODE" in
+    heavyweight|lightweight) ;;
+    *)
+        echo "Unknown mode: $MODE" >&2
+        echo "Usage: $0 [heavyweight|lightweight]" >&2
+        exit 1
+        ;;
+esac
+echo "Mode: $MODE"
+
+# ---------------------------------------------------------------------------
+# 1. Resolve JAVA_HOME
+# ---------------------------------------------------------------------------
+if [ -z "$JAVA_HOME" ]; then
+    if command -v javac >/dev/null 2>&1; then
+        JAVAC_PATH="$(readlink -f "$(command -v javac)" 2>/dev/null || command -v javac)"
+        JAVA_HOME="$(dirname "$(dirname "$JAVAC_PATH")")"
+    fi
+fi
+if [ -z "$JAVA_HOME" ] || [ ! -d "$JAVA_HOME" ]; then
+    echo "JAVA_HOME is not set and could not be resolved automatically." >&2
+    echo "Install a JDK and export JAVA_HOME, e.g. via mise / asdf:" >&2
+    echo "  mise install   # picks up .tool-versions" >&2
+    exit 1
+fi
+export JAVA_HOME
+echo "Using JAVA_HOME=$JAVA_HOME"
+JAVAC="$JAVA_HOME/bin/javac"
+JAVA="$JAVA_HOME/bin/java"
+JAR="$JAVA_HOME/bin/jar"
+for tool in "$JAVAC" "$JAVA" "$JAR"; do
+    if [ ! -x "$tool" ]; then
+        echo "Missing tool: $tool" >&2; exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 2. Pick a WebKit pkg-config name
+# ---------------------------------------------------------------------------
+if pkg-config --exists webkit2gtk-4.1; then
+    WEBKIT_PKG=webkit2gtk-4.1
+elif pkg-config --exists webkit2gtk-4.0; then
+    WEBKIT_PKG=webkit2gtk-4.0
+else
+    echo "Neither webkit2gtk-4.1 nor webkit2gtk-4.0 was found via pkg-config." >&2
+    echo "Install one of the following with your package manager:" >&2
+    echo "  Debian/Ubuntu 24.04+:  sudo apt install libgtk-3-dev libwebkit2gtk-4.1-dev libx11-dev libxt-dev" >&2
+    echo "  Debian/Ubuntu older:   sudo apt install libgtk-3-dev libwebkit2gtk-4.0-dev libx11-dev libxt-dev" >&2
+    echo "  Fedora:                sudo dnf install gtk3-devel webkit2gtk4.1-devel libX11-devel libXt-devel" >&2
+    exit 1
+fi
+if ! pkg-config --exists gtk+-3.0; then
+    echo "gtk+-3.0 (libgtk-3-dev) is required." >&2
+    exit 1
+fi
+echo "Using WebKit package: $WEBKIT_PKG"
+
+if ! printf '#include <X11/Intrinsic.h>\nint main(){return 0;}\n' | \
+        g++ -E -x c++ - >/dev/null 2>&1; then
+    echo "" >&2
+    echo "ERROR: <X11/Intrinsic.h> not found." >&2
+    echo "" >&2
+    echo "JDK 8 on Linux pulls X11 Intrinsics in via jawt_md.h.  Install:" >&2
+    echo "  Debian/Ubuntu:  sudo apt install libxt-dev" >&2
+    echo "  Fedora:         sudo dnf install libXt-devel" >&2
+    echo "  Arch:           sudo pacman -S libxt" >&2
+    echo "" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Build libwebview.so for the current arch
+# ---------------------------------------------------------------------------
+case "$(uname -m)" in
+    x86_64|amd64)   NATIVE_DIR=linux_64 ;;
+    aarch64|arm64)  NATIVE_DIR=linux_arm64 ;;
+    armv7l|armv7)   NATIVE_DIR=linux_arm ;;
+    i?86)           NATIVE_DIR=linux_32 ;;
+    *)              NATIVE_DIR=linux_64 ;;
+esac
+echo "Native dir: $NATIVE_DIR (arch: $(uname -m))"
+mkdir -p "$REPO_DIR/src/$NATIVE_DIR"
+SO="$REPO_DIR/src/$NATIVE_DIR/libwebview.so"
+
+NEED_SO=0
+if [ ! -f "$SO" ]; then
+    NEED_SO=1
+else
+    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp src_c/webkit_loader.cpp src_c/webkit_loader.h src_c/webkit_shim.h; do
+        if [ "$src" -nt "$SO" ]; then NEED_SO=1; break; fi
+    done
+fi
+
+if [ "$NEED_SO" = "1" ]; then
+    echo "Building libwebview.so ..."
+    g++ -fPIC -std=c++11 -Wall \
+        -DWEBVIEW_GTK=1 \
+        -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/linux" \
+        -I./src_c \
+        $(pkg-config --cflags gtk+-3.0 "$WEBKIT_PKG") \
+        src_c/webview.c src_c/webview_embed.cpp src_c/webkit_loader.cpp \
+        $(pkg-config --libs gtk+-3.0) \
+        -lX11 -ldl \
+        -shared -o "$SO"
+    echo "Built $SO"
+else
+    echo "libwebview.so up to date."
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Compile WebView Java sources
+# ---------------------------------------------------------------------------
+BUILD_DIR="$REPO_DIR/build"
+WV_CLASSES="$BUILD_DIR/classes-webview"
+WV_JAR="$REPO_DIR/dist/WebView.jar"
+mkdir -p "$WV_CLASSES" "$REPO_DIR/dist"
+echo "Compiling WebView Java sources ..."
+find src -name '*.java' > "$BUILD_DIR/wv-sources.txt"
+"$JAVAC" -d "$WV_CLASSES" -classpath "lib/*" @"$BUILD_DIR/wv-sources.txt"
+
+# ---------------------------------------------------------------------------
+# 5. Build WebView.jar -- classes + linux_*/libwebview.so at jar root
+# ---------------------------------------------------------------------------
+echo "Building WebView.jar ..."
+STAGE="$BUILD_DIR/stage-webview"
+rm -rf "$STAGE"
+mkdir -p "$STAGE/$NATIVE_DIR"
+cp -R "$WV_CLASSES"/. "$STAGE"/
+cp "$SO" "$STAGE/$NATIVE_DIR/libwebview.so"
+( cd "$STAGE" && "$JAR" cf "$WV_JAR" . )
+echo "Built $WV_JAR"
+
+# ---------------------------------------------------------------------------
+# 6. Compile and run the password demo
+# ---------------------------------------------------------------------------
+DEMO_DIR="$REPO_DIR/demos/WebViewPasswordDemo"
+DEMO_CLASSES="$BUILD_DIR/classes-password-demo"
+mkdir -p "$DEMO_CLASSES"
+echo "Compiling demo ..."
+"$JAVAC" -d "$DEMO_CLASSES" -classpath "$WV_JAR" \
+    "$DEMO_DIR/src/ca/weblite/webview/demos/WebViewPasswordDemo.java"
+
+echo "Launching WebViewPasswordDemo (mode=$MODE) ..."
+# Force the X11 GDK backend; embedding via XReparentWindow needs a real X11
+# GdkDisplay on both sides.
+export GDK_BACKEND=x11
+export WEBKIT_DISABLE_DMABUF_RENDERER=1
+export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
+
+exec "$JAVA" \
+    "-Dca.weblite.webview.mode=$MODE" \
+    -cp "$DEMO_CLASSES:$WV_JAR" \
+    ca.weblite.webview.demos.WebViewPasswordDemo

--- a/run-linux-password-demo.sh
+++ b/run-linux-password-demo.sh
@@ -6,14 +6,13 @@
 # deleteCredential API, the enable/disable gate, and the Keychain vs
 # in-memory store swap.  See demos/WebViewPasswordDemo/README.md.
 #
-# COVERAGE CAVEAT: automatic login-capture and autofill are wired on macOS
-# (Keychain) and Windows (Credential Manager).  Linux is the remaining
-# platform: the demo still runs and the programmatic API plus the in-memory
-# store work, but the native capture/fill channel and the OS secret store
-# (libsecret) arrive with a follow-up canvas, so submitting the form will
-# not raise the "Save password?" prompt and Reload will not autofill yet.
-# Use the In-memory store and the Save/Get/Delete buttons to exercise the
-# API here.
+# Automatic login-capture, the "Save password?" prompt, and autofill on
+# reload are wired on Linux (Canvas 27): the native __webview_pw__ channel
+# routes through WebKitGTK's script-message handler (heavyweight and
+# lightweight), and credentials are stored via libsecret (the freedesktop
+# Secret Service -- GNOME Keyring, KWallet, etc.).  libsecret is dlopen'd at
+# runtime; on a session with no Secret Service provider the store degrades
+# to a no-op (submit/reload still work, nothing persists).
 #
 # Usage:    ./run-linux-password-demo.sh             # lightweight (default)
 #           ./run-linux-password-demo.sh heavyweight # force heavyweight mode

--- a/run-linux-password-demo.sh
+++ b/run-linux-password-demo.sh
@@ -6,13 +6,14 @@
 # deleteCredential API, the enable/disable gate, and the Keychain vs
 # in-memory store swap.  See demos/WebViewPasswordDemo/README.md.
 #
-# COVERAGE CAVEAT: automatic login-capture and autofill are macOS-only in
-# this release.  On Linux the demo still runs and the programmatic API
-# plus the in-memory store work, but the native capture/fill channel and
-# the OS secret store (libsecret) arrive with a follow-up canvas, so
-# submitting the form will not raise the "Save password?" prompt and
-# Reload will not autofill yet.  Use the In-memory store and the
-# Save/Get/Delete buttons to exercise the API here.
+# COVERAGE CAVEAT: automatic login-capture and autofill are wired on macOS
+# (Keychain) and Windows (Credential Manager).  Linux is the remaining
+# platform: the demo still runs and the programmatic API plus the in-memory
+# store work, but the native capture/fill channel and the OS secret store
+# (libsecret) arrive with a follow-up canvas, so submitting the form will
+# not raise the "Save password?" prompt and Reload will not autofill yet.
+# Use the In-memory store and the Save/Get/Delete buttons to exercise the
+# API here.
 #
 # Usage:    ./run-linux-password-demo.sh             # lightweight (default)
 #           ./run-linux-password-demo.sh heavyweight # force heavyweight mode

--- a/run-linux-password-optin-demo.sh
+++ b/run-linux-password-optin-demo.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+# One-shot script: build the Linux native lib, build WebView.jar, compile
+# and run the Chrome-style opt-in autofill demo (WebViewPasswordOptInDemo).
+#
+# Demonstrates a user-opt-in fill: silent autofill is suppressed, and
+# focusing a login field pops a chooser of the saved accounts; picking one
+# runs a simulated unlock and only then fills the fields.  Saved accounts
+# live in an in-memory store (no libsecret / Secret Service writes).  The
+# demo serves a login form from a loopback HTTP server so the manager sees
+# a real origin.  The demo class is platform-neutral (public API only), so
+# the flow matches macOS and Windows.  See
+# demos/WebViewPasswordOptInDemo/README.md.
+#
+# Usage:    ./run-linux-password-optin-demo.sh             # lightweight (default)
+#           ./run-linux-password-optin-demo.sh heavyweight # force heavyweight mode
+#           ./run-linux-password-optin-demo.sh lightweight # force lightweight mode
+#           WEBVIEW_MODE=heavyweight ./run-linux-password-optin-demo.sh
+#
+# Override JDK:  JAVA_HOME=/path/to/jdk ./run-linux-password-optin-demo.sh
+#
+# Required packages:
+#   - g++, pkg-config
+#   - libgtk-3-dev
+#   - libwebkit2gtk-4.1-dev (Ubuntu 24.04+) or libwebkit2gtk-4.0-dev (older)
+#   - libx11-dev
+#   - libxt-dev   <-- pulled in because JDK 8's jawt_md.h includes X11/Intrinsic.h
+set -e
+set -o pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR"
+
+# ---------------------------------------------------------------------------
+# 0. Mode selection
+# ---------------------------------------------------------------------------
+MODE="${1:-${WEBVIEW_MODE:-lightweight}}"
+case "$MODE" in
+    heavyweight|lightweight) ;;
+    *)
+        echo "Unknown mode: $MODE" >&2
+        echo "Usage: $0 [heavyweight|lightweight]" >&2
+        exit 1
+        ;;
+esac
+echo "Mode: $MODE"
+
+# ---------------------------------------------------------------------------
+# 1. Resolve JAVA_HOME
+# ---------------------------------------------------------------------------
+if [ -z "$JAVA_HOME" ]; then
+    if command -v javac >/dev/null 2>&1; then
+        JAVAC_PATH="$(readlink -f "$(command -v javac)" 2>/dev/null || command -v javac)"
+        JAVA_HOME="$(dirname "$(dirname "$JAVAC_PATH")")"
+    fi
+fi
+if [ -z "$JAVA_HOME" ] || [ ! -d "$JAVA_HOME" ]; then
+    echo "JAVA_HOME is not set and could not be resolved automatically." >&2
+    echo "Install a JDK and export JAVA_HOME, e.g. via mise / asdf:" >&2
+    echo "  mise install   # picks up .tool-versions" >&2
+    exit 1
+fi
+export JAVA_HOME
+echo "Using JAVA_HOME=$JAVA_HOME"
+JAVAC="$JAVA_HOME/bin/javac"
+JAVA="$JAVA_HOME/bin/java"
+JAR="$JAVA_HOME/bin/jar"
+for tool in "$JAVAC" "$JAVA" "$JAR"; do
+    if [ ! -x "$tool" ]; then
+        echo "Missing tool: $tool" >&2; exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 2. Pick a WebKit pkg-config name
+# ---------------------------------------------------------------------------
+if pkg-config --exists webkit2gtk-4.1; then
+    WEBKIT_PKG=webkit2gtk-4.1
+elif pkg-config --exists webkit2gtk-4.0; then
+    WEBKIT_PKG=webkit2gtk-4.0
+else
+    echo "Neither webkit2gtk-4.1 nor webkit2gtk-4.0 was found via pkg-config." >&2
+    echo "Install one of the following with your package manager:" >&2
+    echo "  Debian/Ubuntu 24.04+:  sudo apt install libgtk-3-dev libwebkit2gtk-4.1-dev libx11-dev libxt-dev" >&2
+    echo "  Debian/Ubuntu older:   sudo apt install libgtk-3-dev libwebkit2gtk-4.0-dev libx11-dev libxt-dev" >&2
+    echo "  Fedora:                sudo dnf install gtk3-devel webkit2gtk4.1-devel libX11-devel libXt-devel" >&2
+    exit 1
+fi
+if ! pkg-config --exists gtk+-3.0; then
+    echo "gtk+-3.0 (libgtk-3-dev) is required." >&2
+    exit 1
+fi
+echo "Using WebKit package: $WEBKIT_PKG"
+
+if ! printf '#include <X11/Intrinsic.h>\nint main(){return 0;}\n' | \
+        g++ -E -x c++ - >/dev/null 2>&1; then
+    echo "" >&2
+    echo "ERROR: <X11/Intrinsic.h> not found." >&2
+    echo "" >&2
+    echo "JDK 8 on Linux pulls X11 Intrinsics in via jawt_md.h.  Install:" >&2
+    echo "  Debian/Ubuntu:  sudo apt install libxt-dev" >&2
+    echo "  Fedora:         sudo dnf install libXt-devel" >&2
+    echo "  Arch:           sudo pacman -S libxt" >&2
+    echo "" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Build libwebview.so for the current arch
+# ---------------------------------------------------------------------------
+case "$(uname -m)" in
+    x86_64|amd64)   NATIVE_DIR=linux_64 ;;
+    aarch64|arm64)  NATIVE_DIR=linux_arm64 ;;
+    armv7l|armv7)   NATIVE_DIR=linux_arm ;;
+    i?86)           NATIVE_DIR=linux_32 ;;
+    *)              NATIVE_DIR=linux_64 ;;
+esac
+echo "Native dir: $NATIVE_DIR (arch: $(uname -m))"
+mkdir -p "$REPO_DIR/src/$NATIVE_DIR"
+SO="$REPO_DIR/src/$NATIVE_DIR/libwebview.so"
+
+NEED_SO=0
+if [ ! -f "$SO" ]; then
+    NEED_SO=1
+else
+    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp src_c/webkit_loader.cpp src_c/webkit_loader.h src_c/webkit_shim.h; do
+        if [ "$src" -nt "$SO" ]; then NEED_SO=1; break; fi
+    done
+fi
+
+if [ "$NEED_SO" = "1" ]; then
+    echo "Building libwebview.so ..."
+    g++ -fPIC -std=c++11 -Wall \
+        -DWEBVIEW_GTK=1 \
+        -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/linux" \
+        -I./src_c \
+        $(pkg-config --cflags gtk+-3.0 "$WEBKIT_PKG") \
+        src_c/webview.c src_c/webview_embed.cpp src_c/webkit_loader.cpp \
+        $(pkg-config --libs gtk+-3.0) \
+        -lX11 -ldl \
+        -shared -o "$SO"
+    echo "Built $SO"
+else
+    echo "libwebview.so up to date."
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Compile WebView Java sources
+# ---------------------------------------------------------------------------
+BUILD_DIR="$REPO_DIR/build"
+WV_CLASSES="$BUILD_DIR/classes-webview"
+WV_JAR="$REPO_DIR/dist/WebView.jar"
+mkdir -p "$WV_CLASSES" "$REPO_DIR/dist"
+echo "Compiling WebView Java sources ..."
+find src -name '*.java' > "$BUILD_DIR/wv-sources.txt"
+"$JAVAC" -d "$WV_CLASSES" -classpath "lib/*" @"$BUILD_DIR/wv-sources.txt"
+
+# ---------------------------------------------------------------------------
+# 5. Build WebView.jar -- classes + linux_*/libwebview.so at jar root
+# ---------------------------------------------------------------------------
+echo "Building WebView.jar ..."
+STAGE="$BUILD_DIR/stage-webview"
+rm -rf "$STAGE"
+mkdir -p "$STAGE/$NATIVE_DIR"
+cp -R "$WV_CLASSES"/. "$STAGE"/
+cp "$SO" "$STAGE/$NATIVE_DIR/libwebview.so"
+( cd "$STAGE" && "$JAR" cf "$WV_JAR" . )
+echo "Built $WV_JAR"
+
+# ---------------------------------------------------------------------------
+# 6. Compile and run the password demo
+# ---------------------------------------------------------------------------
+DEMO_DIR="$REPO_DIR/demos/WebViewPasswordOptInDemo"
+DEMO_CLASSES="$BUILD_DIR/classes-password-demo"
+mkdir -p "$DEMO_CLASSES"
+echo "Compiling demo ..."
+"$JAVAC" -d "$DEMO_CLASSES" -classpath "$WV_JAR" \
+    "$DEMO_DIR/src/ca/weblite/webview/demos/WebViewPasswordOptInDemo.java"
+
+echo "Launching WebViewPasswordOptInDemo (mode=$MODE) ..."
+# Force the X11 GDK backend; embedding via XReparentWindow needs a real X11
+# GdkDisplay on both sides.
+export GDK_BACKEND=x11
+export WEBKIT_DISABLE_DMABUF_RENDERER=1
+export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
+
+exec "$JAVA" \
+    "-Dca.weblite.webview.mode=$MODE" \
+    -cp "$DEMO_CLASSES:$WV_JAR" \
+    ca.weblite.webview.demos.WebViewPasswordOptInDemo

--- a/run-mac-password-demo.sh
+++ b/run-mac-password-demo.sh
@@ -63,6 +63,14 @@ else
     for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp; do
         if [ "$src" -nt "$DYLIB" ]; then NEED_DYLIB=1; break; fi
     done
+    # A sibling run-mac-*.sh may have built this dylib WITHOUT
+    # -framework Security, leaving the Keychain SecItem* / kSec* symbols
+    # unbound so every credential-store call silently fails.  Force a
+    # rebuild in that case regardless of mtime.
+    if [ "$NEED_DYLIB" = "0" ] && ! otool -L "$DYLIB" | grep -q Security; then
+        echo "Existing dylib does not link Security.framework; rebuilding."
+        NEED_DYLIB=1
+    fi
 fi
 
 if [ "$NEED_DYLIB" = "1" ]; then

--- a/run-mac-password-demo.sh
+++ b/run-mac-password-demo.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# One-shot script: build the macOS native lib, build WebView.jar, compile
+# and run the built-in password-manager demo (WebViewPasswordDemo).
+#
+# Exercises login-submission capture + the Swing "Save password?" prompt,
+# autofill on reload, the programmatic saveCredential / getCredential /
+# deleteCredential API, the enable/disable gate, and the Keychain vs
+# in-memory store swap.  The demo serves a login form from a loopback
+# HTTP server so the manager sees a real origin.  See
+# demos/WebViewPasswordDemo/README.md for details.
+#
+# Usage:    ./run-mac-password-demo.sh
+# Override: JAVA_HOME=/path/to/jdk ./run-mac-password-demo.sh
+#
+set -e
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR"
+
+# ---------------------------------------------------------------------------
+# 1. Resolve JAVA_HOME
+# ---------------------------------------------------------------------------
+if [ -z "$JAVA_HOME" ]; then
+    if [ -x /usr/libexec/java_home ]; then
+        JAVA_HOME="$(/usr/libexec/java_home)"
+    fi
+fi
+if [ -z "$JAVA_HOME" ] || [ ! -d "$JAVA_HOME" ]; then
+    echo "JAVA_HOME is not set and could not be resolved automatically." >&2
+    echo "Install a JDK and export JAVA_HOME, e.g.:" >&2
+    echo "  brew install --cask temurin" >&2
+    echo "  export JAVA_HOME=\"\$(/usr/libexec/java_home)\"" >&2
+    exit 1
+fi
+export JAVA_HOME
+echo "Using JAVA_HOME=$JAVA_HOME"
+JAVAC="$JAVA_HOME/bin/javac"
+JAVA="$JAVA_HOME/bin/java"
+JAR="$JAVA_HOME/bin/jar"
+for tool in "$JAVAC" "$JAVA" "$JAR"; do
+    if [ ! -x "$tool" ]; then
+        echo "Missing tool: $tool" >&2; exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 2. Build libwebview.dylib if missing or source is newer.
+#    -framework Security is required for the Keychain-backed credential
+#    store (SecItem*) used by the password manager.
+# ---------------------------------------------------------------------------
+case "$(uname -m)" in
+    arm64|aarch64) NATIVE_DIR=osx_arm64 ;;
+    x86_64)        NATIVE_DIR=osx_64 ;;
+    *)             NATIVE_DIR=osx_64 ;;
+esac
+echo "Native dir: $NATIVE_DIR"
+mkdir -p "$REPO_DIR/src/$NATIVE_DIR"
+DYLIB="$REPO_DIR/src/$NATIVE_DIR/libwebview.dylib"
+NEED_DYLIB=0
+if [ ! -f "$DYLIB" ]; then
+    NEED_DYLIB=1
+else
+    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp; do
+        if [ "$src" -nt "$DYLIB" ]; then NEED_DYLIB=1; break; fi
+    done
+fi
+
+if [ "$NEED_DYLIB" = "1" ]; then
+    echo "Building libwebview.dylib (arch: $(uname -m)) ..."
+    c++ \
+        -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/darwin" \
+        -dynamiclib \
+        src_c/webview_embed.cpp \
+        -o "$DYLIB" \
+        -DWEBVIEW_COCOA=1 \
+        -std=c++11 \
+        -framework WebKit -framework Cocoa -framework QuartzCore -framework Security \
+        -Wl,-undefined,dynamic_lookup
+    echo "Built $DYLIB"
+else
+    echo "libwebview.dylib up to date."
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Compile WebView Java sources
+# ---------------------------------------------------------------------------
+BUILD_DIR="$REPO_DIR/build"
+WV_CLASSES="$BUILD_DIR/classes-webview"
+WV_JAR="$REPO_DIR/dist/WebView.jar"
+mkdir -p "$WV_CLASSES" "$REPO_DIR/dist"
+echo "Compiling WebView Java sources ..."
+find src -name '*.java' > "$BUILD_DIR/wv-sources.txt"
+"$JAVAC" -d "$WV_CLASSES" \
+    -classpath "lib/*" @"$BUILD_DIR/wv-sources.txt"
+
+# ---------------------------------------------------------------------------
+# 4. Build WebView.jar -- classes + osx_*/libwebview.dylib at the jar root
+# ---------------------------------------------------------------------------
+echo "Building WebView.jar ..."
+STAGE="$BUILD_DIR/stage-webview"
+rm -rf "$STAGE"
+mkdir -p "$STAGE/$NATIVE_DIR"
+cp -R "$WV_CLASSES"/. "$STAGE"/
+cp "$DYLIB" "$STAGE/$NATIVE_DIR/libwebview.dylib"
+( cd "$STAGE" && "$JAR" cf "$WV_JAR" . )
+echo "Built $WV_JAR"
+
+# ---------------------------------------------------------------------------
+# 5. Compile and run the password demo
+# ---------------------------------------------------------------------------
+DEMO_DIR="$REPO_DIR/demos/WebViewPasswordDemo"
+DEMO_CLASSES="$BUILD_DIR/classes-password-demo"
+mkdir -p "$DEMO_CLASSES"
+echo "Compiling demo ..."
+"$JAVAC" -d "$DEMO_CLASSES" \
+    -classpath "$WV_JAR" \
+    "$DEMO_DIR/src/ca/weblite/webview/demos/WebViewPasswordDemo.java"
+
+echo "Launching WebViewPasswordDemo ..."
+exec "$JAVA" \
+    -cp "$DEMO_CLASSES:$WV_JAR" \
+    ca.weblite.webview.demos.WebViewPasswordDemo

--- a/run-mac-password-optin-demo.sh
+++ b/run-mac-password-optin-demo.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# One-shot script: build the macOS native lib, build WebView.jar, compile
+# and run the Chrome-style opt-in autofill demo (WebViewPasswordOptInDemo).
+#
+# Demonstrates a Chrome-style, user-opt-in autofill: silent autofill is
+# suppressed, and focusing a login field pops a chooser of the saved
+# accounts; picking one runs a simulated unlock and only then fills the
+# fields.  Saved accounts live in an in-memory store (no real Keychain).
+# The demo serves a login form from a loopback HTTP server so the manager
+# sees a real origin.  See demos/WebViewPasswordOptInDemo/README.md.
+#
+# Usage:    ./run-mac-password-optin-demo.sh
+# Override: JAVA_HOME=/path/to/jdk ./run-mac-password-optin-demo.sh
+#
+set -e
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR"
+
+# ---------------------------------------------------------------------------
+# 1. Resolve JAVA_HOME
+# ---------------------------------------------------------------------------
+if [ -z "$JAVA_HOME" ]; then
+    if [ -x /usr/libexec/java_home ]; then
+        JAVA_HOME="$(/usr/libexec/java_home)"
+    fi
+fi
+if [ -z "$JAVA_HOME" ] || [ ! -d "$JAVA_HOME" ]; then
+    echo "JAVA_HOME is not set and could not be resolved automatically." >&2
+    echo "Install a JDK and export JAVA_HOME, e.g.:" >&2
+    echo "  brew install --cask temurin" >&2
+    echo "  export JAVA_HOME=\"\$(/usr/libexec/java_home)\"" >&2
+    exit 1
+fi
+export JAVA_HOME
+echo "Using JAVA_HOME=$JAVA_HOME"
+JAVAC="$JAVA_HOME/bin/javac"
+JAVA="$JAVA_HOME/bin/java"
+JAR="$JAVA_HOME/bin/jar"
+for tool in "$JAVAC" "$JAVA" "$JAR"; do
+    if [ ! -x "$tool" ]; then
+        echo "Missing tool: $tool" >&2; exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 2. Build libwebview.dylib if missing or source is newer.
+#    -framework Security is required for the Keychain-backed credential
+#    store (SecItem*) used by the password manager.
+# ---------------------------------------------------------------------------
+case "$(uname -m)" in
+    arm64|aarch64) NATIVE_DIR=osx_arm64 ;;
+    x86_64)        NATIVE_DIR=osx_64 ;;
+    *)             NATIVE_DIR=osx_64 ;;
+esac
+echo "Native dir: $NATIVE_DIR"
+mkdir -p "$REPO_DIR/src/$NATIVE_DIR"
+DYLIB="$REPO_DIR/src/$NATIVE_DIR/libwebview.dylib"
+NEED_DYLIB=0
+if [ ! -f "$DYLIB" ]; then
+    NEED_DYLIB=1
+else
+    for src in src_c/webview.c src_c/webview.h src_c/webview_embed.cpp; do
+        if [ "$src" -nt "$DYLIB" ]; then NEED_DYLIB=1; break; fi
+    done
+    # A sibling run-mac-*.sh may have built this dylib WITHOUT
+    # -framework Security, leaving the Keychain SecItem* / kSec* symbols
+    # unbound so every credential-store call silently fails.  Force a
+    # rebuild in that case regardless of mtime.
+    if [ "$NEED_DYLIB" = "0" ] && ! otool -L "$DYLIB" | grep -q Security; then
+        echo "Existing dylib does not link Security.framework; rebuilding."
+        NEED_DYLIB=1
+    fi
+fi
+
+if [ "$NEED_DYLIB" = "1" ]; then
+    echo "Building libwebview.dylib (arch: $(uname -m)) ..."
+    c++ \
+        -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/darwin" \
+        -dynamiclib \
+        src_c/webview_embed.cpp \
+        -o "$DYLIB" \
+        -DWEBVIEW_COCOA=1 \
+        -std=c++11 \
+        -framework WebKit -framework Cocoa -framework QuartzCore -framework Security \
+        -Wl,-undefined,dynamic_lookup
+    echo "Built $DYLIB"
+else
+    echo "libwebview.dylib up to date."
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Compile WebView Java sources
+# ---------------------------------------------------------------------------
+BUILD_DIR="$REPO_DIR/build"
+WV_CLASSES="$BUILD_DIR/classes-webview"
+WV_JAR="$REPO_DIR/dist/WebView.jar"
+mkdir -p "$WV_CLASSES" "$REPO_DIR/dist"
+echo "Compiling WebView Java sources ..."
+find src -name '*.java' > "$BUILD_DIR/wv-sources.txt"
+"$JAVAC" -d "$WV_CLASSES" \
+    -classpath "lib/*" @"$BUILD_DIR/wv-sources.txt"
+
+# ---------------------------------------------------------------------------
+# 4. Build WebView.jar -- classes + osx_*/libwebview.dylib at the jar root
+# ---------------------------------------------------------------------------
+echo "Building WebView.jar ..."
+STAGE="$BUILD_DIR/stage-webview"
+rm -rf "$STAGE"
+mkdir -p "$STAGE/$NATIVE_DIR"
+cp -R "$WV_CLASSES"/. "$STAGE"/
+cp "$DYLIB" "$STAGE/$NATIVE_DIR/libwebview.dylib"
+( cd "$STAGE" && "$JAR" cf "$WV_JAR" . )
+echo "Built $WV_JAR"
+
+# ---------------------------------------------------------------------------
+# 5. Compile and run the password demo
+# ---------------------------------------------------------------------------
+DEMO_DIR="$REPO_DIR/demos/WebViewPasswordOptInDemo"
+DEMO_CLASSES="$BUILD_DIR/classes-password-demo"
+mkdir -p "$DEMO_CLASSES"
+echo "Compiling demo ..."
+"$JAVAC" -d "$DEMO_CLASSES" \
+    -classpath "$WV_JAR" \
+    "$DEMO_DIR/src/ca/weblite/webview/demos/WebViewPasswordOptInDemo.java"
+
+echo "Launching WebViewPasswordOptInDemo ..."
+exec "$JAVA" \
+    -cp "$DEMO_CLASSES:$WV_JAR" \
+    ca.weblite.webview.demos.WebViewPasswordOptInDemo

--- a/run-windows-password-demo.bat
+++ b/run-windows-password-demo.bat
@@ -10,13 +10,13 @@ REM Exercises the programmatic saveCredential / getCredential /
 REM deleteCredential API, the enable/disable gate, and the Keychain vs
 REM in-memory store swap.  See demos\WebViewPasswordDemo\README.md.
 REM
-REM COVERAGE CAVEAT: automatic login-capture and autofill are macOS-only in
-REM this release.  On Windows the demo still runs and the programmatic API
-REM plus the in-memory store work, but the native capture/fill channel and
-REM the OS secret store (Credential Manager) arrive with a follow-up canvas,
-REM so submitting the form will not raise the "Save password?" prompt and
-REM Reload will not autofill yet.  Use the In-memory store and the
-REM Save/Get/Delete buttons to exercise the API here.
+REM Automatic login-capture, the "Save password?" prompt, and autofill on
+REM reload are wired on Windows (Canvas 28): the native __webview_pw__
+REM channel routes through WebView2's WebMessageReceived, and credentials
+REM are stored in the Windows Credential Manager (this library's own
+REM namespace, not the Edge profile; Edge autosave is disabled).  Requires a
+REM WebView2 Runtime exposing ICoreWebView2Settings4 for the autosave
+REM toggle; the capture/store path itself works on any Evergreen runtime.
 REM
 REM Requires:
 REM   - JAVA_HOME set to a JDK 8+ install.

--- a/run-windows-password-demo.bat
+++ b/run-windows-password-demo.bat
@@ -1,0 +1,221 @@
+@echo off
+REM ============================================================================
+REM run-windows-password-demo.bat
+REM
+REM One-shot build & launch of WebViewPasswordDemo on Windows.  Builds the
+REM WebView2-backed native DLL, packages WebView.jar, compiles the demo, and
+REM runs it.  No Ant required.
+REM
+REM Exercises the programmatic saveCredential / getCredential /
+REM deleteCredential API, the enable/disable gate, and the Keychain vs
+REM in-memory store swap.  See demos\WebViewPasswordDemo\README.md.
+REM
+REM COVERAGE CAVEAT: automatic login-capture and autofill are macOS-only in
+REM this release.  On Windows the demo still runs and the programmatic API
+REM plus the in-memory store work, but the native capture/fill channel and
+REM the OS secret store (Credential Manager) arrive with a follow-up canvas,
+REM so submitting the form will not raise the "Save password?" prompt and
+REM Reload will not autofill yet.  Use the In-memory store and the
+REM Save/Get/Delete buttons to exercise the API here.
+REM
+REM Requires:
+REM   - JAVA_HOME set to a JDK 8+ install.
+REM   - Visual Studio 2019 or newer with "Desktop development with C++".
+REM   - The WebView2 runtime (ships with Windows 11; install Evergreen on
+REM     older Windows: https://aka.ms/webview2 ).
+REM ============================================================================
+setlocal enabledelayedexpansion
+
+set "REPO_DIR=%~dp0"
+if "%REPO_DIR:~-1%"=="\" set "REPO_DIR=%REPO_DIR:~0,-1%"
+echo Repo: %REPO_DIR%
+
+REM ---------------------------------------------------------------------------
+REM 1. Resolve JAVA_HOME
+REM ---------------------------------------------------------------------------
+if "%JAVA_HOME%"=="" (
+    echo.
+    echo JAVA_HOME is not set.  Set it to your JDK install and re-run, e.g.:
+    echo.
+    echo     set "JAVA_HOME=C:\Program Files\Amazon Corretto\jdk1.8.0_xxx"
+    echo     run-windows-password-demo.bat
+    echo.
+    exit /b 1
+)
+if not exist "%JAVA_HOME%\bin\javac.exe" (
+    echo ERROR: javac.exe not found in "%JAVA_HOME%\bin".
+    echo Check that JAVA_HOME points at the JDK root, not the JRE.
+    exit /b 1
+)
+echo Using JAVA_HOME=%JAVA_HOME%
+
+REM ---------------------------------------------------------------------------
+REM 2. Locate Visual Studio via vswhere
+REM ---------------------------------------------------------------------------
+set "vswhere=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%vswhere%" set "vswhere=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%vswhere%" (
+    echo ERROR: vswhere.exe not found.
+    echo Install Visual Studio 2019 or newer with the
+    echo "Desktop development with C++" workload.
+    exit /b 1
+)
+set "vc_dir="
+for /f "usebackq tokens=*" %%i in (`"%vswhere%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+    set "vc_dir=%%i"
+)
+if "%vc_dir%"=="" (
+    echo ERROR: Could not locate a Visual Studio installation with VC tools x86/x64.
+    exit /b 1
+)
+echo Visual Studio: %vc_dir%
+
+REM ---------------------------------------------------------------------------
+REM 3. Activate the MSVC x64 environment
+REM ---------------------------------------------------------------------------
+call "%vc_dir%\Common7\Tools\vsdevcmd.bat" -arch=x64 -host_arch=x64
+if errorlevel 1 (
+    echo ERROR: vsdevcmd.bat failed.
+    exit /b 1
+)
+
+set "SDK_OK="
+for %%I in ("%INCLUDE:;=";"%") do (
+    if exist "%%~I\windows.h" set "SDK_OK=1"
+)
+
+if defined SDK_OK goto :sdk_check_done
+set "KITS_ROOT=C:\Program Files (x86)\Windows Kits\10"
+set "SDK_VER="
+if not exist "%KITS_ROOT%\Include" goto :sdk_check_done
+for /f "delims=" %%V in ('dir /b /ad /on "%KITS_ROOT%\Include" 2^>nul') do (
+    if exist "%KITS_ROOT%\Include\%%V\um\windows.h" set "SDK_VER=%%V"
+)
+if "%SDK_VER%"=="" goto :sdk_check_done
+echo NOTE: vsdevcmd did not register a Windows SDK, but one is present
+echo       on disk.  Manually adding Windows SDK %SDK_VER% at %KITS_ROOT%.
+set "INCLUDE=%INCLUDE%;%KITS_ROOT%\Include\%SDK_VER%\ucrt;%KITS_ROOT%\Include\%SDK_VER%\um;%KITS_ROOT%\Include\%SDK_VER%\shared;%KITS_ROOT%\Include\%SDK_VER%\winrt;%KITS_ROOT%\Include\%SDK_VER%\cppwinrt"
+set "LIB=%LIB%;%KITS_ROOT%\Lib\%SDK_VER%\ucrt\x64;%KITS_ROOT%\Lib\%SDK_VER%\um\x64"
+set "SDK_OK=1"
+:sdk_check_done
+
+if defined SDK_OK goto :build_dll
+echo.
+echo ERROR: Windows SDK headers not found on the cl.exe INCLUDE path.
+echo        vsdevcmd activated successfully but no SDK provides windows.h.
+echo.
+echo Fix: open the Visual Studio Installer, click Modify on your VS install,
+echo and on the "Individual components" tab tick a "Windows 11 SDK" or
+echo "Windows 10 SDK" entry, then re-run this script.
+echo.
+exit /b 1
+:build_dll
+
+REM ---------------------------------------------------------------------------
+REM 4. Build webview.dll (x64)
+REM ---------------------------------------------------------------------------
+set "NATIVE_DIR=windows_64"
+set "DLL_OUT=%REPO_DIR%\src\%NATIVE_DIR%"
+if not exist "%DLL_OUT%" mkdir "%DLL_OUT%"
+set "BUILD_DIR=%REPO_DIR%\build"
+if not exist "%BUILD_DIR%" mkdir "%BUILD_DIR%"
+set "WEBVIEW2_VERSION=1.0.2592.51"
+set "WEBVIEW2_DIR=%REPO_DIR%\windows\script\Microsoft.Web.WebView2.%WEBVIEW2_VERSION%"
+set "WEBVIEW2_NUPKG=%WEBVIEW2_DIR%\Microsoft.Web.WebView2.%WEBVIEW2_VERSION%.nupkg"
+set "WEBVIEW2_URL=https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/%WEBVIEW2_VERSION%"
+
+set "PWSH=%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe"
+if not exist "%PWSH%" set "PWSH=powershell.exe"
+
+if exist "%WEBVIEW2_DIR%\build\native\include\WebView2.h" goto :webview2_ready
+if not exist "%WEBVIEW2_DIR%" mkdir "%WEBVIEW2_DIR%"
+if exist "%WEBVIEW2_NUPKG%" goto :webview2_extract
+echo Downloading Microsoft.Web.WebView2 %WEBVIEW2_VERSION% from NuGet ...
+"%PWSH%" -NoProfile -Command "$ProgressPreference='SilentlyContinue'; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri '%WEBVIEW2_URL%' -OutFile '%WEBVIEW2_NUPKG%' -UseBasicParsing"
+if not exist "%WEBVIEW2_NUPKG%" (
+    echo ERROR: failed to download WebView2 SDK from %WEBVIEW2_URL%.
+    exit /b 1
+)
+:webview2_extract
+echo Extracting Microsoft.Web.WebView2.%WEBVIEW2_VERSION%.nupkg ...
+"%PWSH%" -NoProfile -Command "Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory('%WEBVIEW2_NUPKG%', '%WEBVIEW2_DIR%')"
+if not exist "%WEBVIEW2_DIR%\build\native\include\WebView2.h" (
+    echo ERROR: failed to extract WebView2 SDK.
+    exit /b 1
+)
+:webview2_ready
+
+echo Building webview.dll (x64) ...
+cl /nologo ^
+    /D "WEBVIEW_API=__declspec(dllexport)" ^
+    /D "_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS" ^
+    /I "%JAVA_HOME%\include" ^
+    /I "%JAVA_HOME%\include\win32" ^
+    /I "%REPO_DIR%\windows" ^
+    /I "%WEBVIEW2_DIR%\build\native\include" ^
+    /std:c++17 /EHsc ^
+    /Fo"%BUILD_DIR%\\" ^
+    "%REPO_DIR%\windows\webview.cc" ^
+    "%REPO_DIR%\windows\webview_embed.cc" ^
+    /link /DLL ^
+    "%WEBVIEW2_DIR%\build\native\x64\WebView2LoaderStatic.lib" ^
+    "%JAVA_HOME%\lib\jawt.lib" ^
+    advapi32.lib ole32.lib oleaut32.lib shlwapi.lib shell32.lib user32.lib version.lib winhttp.lib ^
+    /OUT:"%BUILD_DIR%\webview.dll"
+if errorlevel 1 (
+    echo ERROR: cl.exe build failed.
+    exit /b 1
+)
+copy /Y "%BUILD_DIR%\webview.dll" "%DLL_OUT%\webview.dll" >nul
+echo Built %DLL_OUT%\webview.dll
+
+REM ---------------------------------------------------------------------------
+REM 5. Compile WebView Java sources
+REM ---------------------------------------------------------------------------
+set "WV_CLASSES=%BUILD_DIR%\classes-webview"
+if exist "%WV_CLASSES%" rmdir /s /q "%WV_CLASSES%"
+mkdir "%WV_CLASSES%"
+echo Compiling WebView Java sources ...
+dir /s /b "%REPO_DIR%\src\*.java" > "%BUILD_DIR%\wv-sources.txt"
+"%JAVA_HOME%\bin\javac.exe" -d "%WV_CLASSES%" -classpath "%REPO_DIR%\lib\*" @"%BUILD_DIR%\wv-sources.txt"
+if errorlevel 1 (
+    echo ERROR: javac failed.
+    exit /b 1
+)
+
+REM ---------------------------------------------------------------------------
+REM 6. Build WebView.jar
+REM ---------------------------------------------------------------------------
+set "WV_JAR=%REPO_DIR%\dist\WebView.jar"
+if not exist "%REPO_DIR%\dist" mkdir "%REPO_DIR%\dist"
+set "STAGE=%BUILD_DIR%\stage-webview"
+if exist "%STAGE%" rmdir /s /q "%STAGE%"
+mkdir "%STAGE%\%NATIVE_DIR%"
+"%SystemRoot%\System32\xcopy.exe" /e /q /y "%WV_CLASSES%\*" "%STAGE%\" >nul
+if errorlevel 1 (
+    echo ERROR: xcopy of compiled classes into the jar staging dir failed.
+    exit /b 1
+)
+copy /Y "%DLL_OUT%\webview.dll" "%STAGE%\%NATIVE_DIR%\webview.dll" >nul
+pushd "%STAGE%"
+"%JAVA_HOME%\bin\jar.exe" cf "%WV_JAR%" .
+popd
+echo Built %WV_JAR%
+
+REM ---------------------------------------------------------------------------
+REM 7. Compile and launch the password demo
+REM ---------------------------------------------------------------------------
+set "DEMO_DIR=%REPO_DIR%\demos\WebViewPasswordDemo"
+set "DEMO_CLASSES=%BUILD_DIR%\classes-password-demo"
+if not exist "%DEMO_CLASSES%" mkdir "%DEMO_CLASSES%"
+echo Compiling demo ...
+"%JAVA_HOME%\bin\javac.exe" -d "%DEMO_CLASSES%" -classpath "%WV_JAR%" "%DEMO_DIR%\src\ca\weblite\webview\demos\WebViewPasswordDemo.java"
+if errorlevel 1 (
+    echo ERROR: javac failed on demo.
+    exit /b 1
+)
+
+echo Launching WebViewPasswordDemo ...
+"%JAVA_HOME%\bin\java.exe" -cp "%DEMO_CLASSES%;%WV_JAR%" ca.weblite.webview.demos.WebViewPasswordDemo
+
+endlocal

--- a/run-windows-password-optin-demo.bat
+++ b/run-windows-password-optin-demo.bat
@@ -1,0 +1,218 @@
+@echo off
+REM ============================================================================
+REM run-windows-password-optin-demo.bat
+REM
+REM One-shot build & launch of WebViewPasswordOptInDemo on Windows.  Builds the
+REM WebView2-backed native DLL, packages WebView.jar, compiles the demo, and
+REM runs it.  No Ant required.
+REM
+REM Demonstrates a Chrome-style, user-opt-in autofill: silent autofill is
+REM suppressed, and focusing a login field pops a chooser of the saved
+REM accounts; picking one runs a simulated unlock and only then fills the
+REM fields.  Saved accounts live in an in-memory store (no Credential
+REM Manager writes).  The demo serves a login form from a loopback HTTP
+REM server so the manager sees a real origin.  The demo class is
+REM platform-neutral (public API only), so the flow matches macOS.  See
+REM demos\WebViewPasswordOptInDemo\README.md.
+REM
+REM Requires:
+REM   - JAVA_HOME set to a JDK 8+ install.
+REM   - Visual Studio 2019 or newer with "Desktop development with C++".
+REM   - The WebView2 runtime (ships with Windows 11; install Evergreen on
+REM     older Windows: https://aka.ms/webview2 ).
+REM ============================================================================
+setlocal enabledelayedexpansion
+
+set "REPO_DIR=%~dp0"
+if "%REPO_DIR:~-1%"=="\" set "REPO_DIR=%REPO_DIR:~0,-1%"
+echo Repo: %REPO_DIR%
+
+REM ---------------------------------------------------------------------------
+REM 1. Resolve JAVA_HOME
+REM ---------------------------------------------------------------------------
+if "%JAVA_HOME%"=="" (
+    echo.
+    echo JAVA_HOME is not set.  Set it to your JDK install and re-run, e.g.:
+    echo.
+    echo     set "JAVA_HOME=C:\Program Files\Amazon Corretto\jdk1.8.0_xxx"
+    echo     run-windows-password-optin-demo.bat
+    echo.
+    exit /b 1
+)
+if not exist "%JAVA_HOME%\bin\javac.exe" (
+    echo ERROR: javac.exe not found in "%JAVA_HOME%\bin".
+    echo Check that JAVA_HOME points at the JDK root, not the JRE.
+    exit /b 1
+)
+echo Using JAVA_HOME=%JAVA_HOME%
+
+REM ---------------------------------------------------------------------------
+REM 2. Locate Visual Studio via vswhere
+REM ---------------------------------------------------------------------------
+set "vswhere=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%vswhere%" set "vswhere=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%vswhere%" (
+    echo ERROR: vswhere.exe not found.
+    echo Install Visual Studio 2019 or newer with the
+    echo "Desktop development with C++" workload.
+    exit /b 1
+)
+set "vc_dir="
+for /f "usebackq tokens=*" %%i in (`"%vswhere%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+    set "vc_dir=%%i"
+)
+if "%vc_dir%"=="" (
+    echo ERROR: Could not locate a Visual Studio installation with VC tools x86/x64.
+    exit /b 1
+)
+echo Visual Studio: %vc_dir%
+
+REM ---------------------------------------------------------------------------
+REM 3. Activate the MSVC x64 environment
+REM ---------------------------------------------------------------------------
+call "%vc_dir%\Common7\Tools\vsdevcmd.bat" -arch=x64 -host_arch=x64
+if errorlevel 1 (
+    echo ERROR: vsdevcmd.bat failed.
+    exit /b 1
+)
+
+set "SDK_OK="
+for %%I in ("%INCLUDE:;=";"%") do (
+    if exist "%%~I\windows.h" set "SDK_OK=1"
+)
+
+if defined SDK_OK goto :sdk_check_done
+set "KITS_ROOT=C:\Program Files (x86)\Windows Kits\10"
+set "SDK_VER="
+if not exist "%KITS_ROOT%\Include" goto :sdk_check_done
+for /f "delims=" %%V in ('dir /b /ad /on "%KITS_ROOT%\Include" 2^>nul') do (
+    if exist "%KITS_ROOT%\Include\%%V\um\windows.h" set "SDK_VER=%%V"
+)
+if "%SDK_VER%"=="" goto :sdk_check_done
+echo NOTE: vsdevcmd did not register a Windows SDK, but one is present
+echo       on disk.  Manually adding Windows SDK %SDK_VER% at %KITS_ROOT%.
+set "INCLUDE=%INCLUDE%;%KITS_ROOT%\Include\%SDK_VER%\ucrt;%KITS_ROOT%\Include\%SDK_VER%\um;%KITS_ROOT%\Include\%SDK_VER%\shared;%KITS_ROOT%\Include\%SDK_VER%\winrt;%KITS_ROOT%\Include\%SDK_VER%\cppwinrt"
+set "LIB=%LIB%;%KITS_ROOT%\Lib\%SDK_VER%\ucrt\x64;%KITS_ROOT%\Lib\%SDK_VER%\um\x64"
+set "SDK_OK=1"
+:sdk_check_done
+
+if defined SDK_OK goto :build_dll
+echo.
+echo ERROR: Windows SDK headers not found on the cl.exe INCLUDE path.
+echo        vsdevcmd activated successfully but no SDK provides windows.h.
+echo.
+echo Fix: open the Visual Studio Installer, click Modify on your VS install,
+echo and on the "Individual components" tab tick a "Windows 11 SDK" or
+echo "Windows 10 SDK" entry, then re-run this script.
+echo.
+exit /b 1
+:build_dll
+
+REM ---------------------------------------------------------------------------
+REM 4. Build webview.dll (x64)
+REM ---------------------------------------------------------------------------
+set "NATIVE_DIR=windows_64"
+set "DLL_OUT=%REPO_DIR%\src\%NATIVE_DIR%"
+if not exist "%DLL_OUT%" mkdir "%DLL_OUT%"
+set "BUILD_DIR=%REPO_DIR%\build"
+if not exist "%BUILD_DIR%" mkdir "%BUILD_DIR%"
+set "WEBVIEW2_VERSION=1.0.2592.51"
+set "WEBVIEW2_DIR=%REPO_DIR%\windows\script\Microsoft.Web.WebView2.%WEBVIEW2_VERSION%"
+set "WEBVIEW2_NUPKG=%WEBVIEW2_DIR%\Microsoft.Web.WebView2.%WEBVIEW2_VERSION%.nupkg"
+set "WEBVIEW2_URL=https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/%WEBVIEW2_VERSION%"
+
+set "PWSH=%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe"
+if not exist "%PWSH%" set "PWSH=powershell.exe"
+
+if exist "%WEBVIEW2_DIR%\build\native\include\WebView2.h" goto :webview2_ready
+if not exist "%WEBVIEW2_DIR%" mkdir "%WEBVIEW2_DIR%"
+if exist "%WEBVIEW2_NUPKG%" goto :webview2_extract
+echo Downloading Microsoft.Web.WebView2 %WEBVIEW2_VERSION% from NuGet ...
+"%PWSH%" -NoProfile -Command "$ProgressPreference='SilentlyContinue'; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri '%WEBVIEW2_URL%' -OutFile '%WEBVIEW2_NUPKG%' -UseBasicParsing"
+if not exist "%WEBVIEW2_NUPKG%" (
+    echo ERROR: failed to download WebView2 SDK from %WEBVIEW2_URL%.
+    exit /b 1
+)
+:webview2_extract
+echo Extracting Microsoft.Web.WebView2.%WEBVIEW2_VERSION%.nupkg ...
+"%PWSH%" -NoProfile -Command "Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory('%WEBVIEW2_NUPKG%', '%WEBVIEW2_DIR%')"
+if not exist "%WEBVIEW2_DIR%\build\native\include\WebView2.h" (
+    echo ERROR: failed to extract WebView2 SDK.
+    exit /b 1
+)
+:webview2_ready
+
+echo Building webview.dll (x64) ...
+cl /nologo ^
+    /D "WEBVIEW_API=__declspec(dllexport)" ^
+    /D "_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS" ^
+    /I "%JAVA_HOME%\include" ^
+    /I "%JAVA_HOME%\include\win32" ^
+    /I "%REPO_DIR%\windows" ^
+    /I "%WEBVIEW2_DIR%\build\native\include" ^
+    /std:c++17 /EHsc ^
+    /Fo"%BUILD_DIR%\\" ^
+    "%REPO_DIR%\windows\webview.cc" ^
+    "%REPO_DIR%\windows\webview_embed.cc" ^
+    /link /DLL ^
+    "%WEBVIEW2_DIR%\build\native\x64\WebView2LoaderStatic.lib" ^
+    "%JAVA_HOME%\lib\jawt.lib" ^
+    advapi32.lib ole32.lib oleaut32.lib shlwapi.lib shell32.lib user32.lib version.lib winhttp.lib ^
+    /OUT:"%BUILD_DIR%\webview.dll"
+if errorlevel 1 (
+    echo ERROR: cl.exe build failed.
+    exit /b 1
+)
+copy /Y "%BUILD_DIR%\webview.dll" "%DLL_OUT%\webview.dll" >nul
+echo Built %DLL_OUT%\webview.dll
+
+REM ---------------------------------------------------------------------------
+REM 5. Compile WebView Java sources
+REM ---------------------------------------------------------------------------
+set "WV_CLASSES=%BUILD_DIR%\classes-webview"
+if exist "%WV_CLASSES%" rmdir /s /q "%WV_CLASSES%"
+mkdir "%WV_CLASSES%"
+echo Compiling WebView Java sources ...
+dir /s /b "%REPO_DIR%\src\*.java" > "%BUILD_DIR%\wv-sources.txt"
+"%JAVA_HOME%\bin\javac.exe" -d "%WV_CLASSES%" -classpath "%REPO_DIR%\lib\*" @"%BUILD_DIR%\wv-sources.txt"
+if errorlevel 1 (
+    echo ERROR: javac failed.
+    exit /b 1
+)
+
+REM ---------------------------------------------------------------------------
+REM 6. Build WebView.jar
+REM ---------------------------------------------------------------------------
+set "WV_JAR=%REPO_DIR%\dist\WebView.jar"
+if not exist "%REPO_DIR%\dist" mkdir "%REPO_DIR%\dist"
+set "STAGE=%BUILD_DIR%\stage-webview"
+if exist "%STAGE%" rmdir /s /q "%STAGE%"
+mkdir "%STAGE%\%NATIVE_DIR%"
+"%SystemRoot%\System32\xcopy.exe" /e /q /y "%WV_CLASSES%\*" "%STAGE%\" >nul
+if errorlevel 1 (
+    echo ERROR: xcopy of compiled classes into the jar staging dir failed.
+    exit /b 1
+)
+copy /Y "%DLL_OUT%\webview.dll" "%STAGE%\%NATIVE_DIR%\webview.dll" >nul
+pushd "%STAGE%"
+"%JAVA_HOME%\bin\jar.exe" cf "%WV_JAR%" .
+popd
+echo Built %WV_JAR%
+
+REM ---------------------------------------------------------------------------
+REM 7. Compile and launch the password demo
+REM ---------------------------------------------------------------------------
+set "DEMO_DIR=%REPO_DIR%\demos\WebViewPasswordOptInDemo"
+set "DEMO_CLASSES=%BUILD_DIR%\classes-password-demo"
+if not exist "%DEMO_CLASSES%" mkdir "%DEMO_CLASSES%"
+echo Compiling demo ...
+"%JAVA_HOME%\bin\javac.exe" -d "%DEMO_CLASSES%" -classpath "%WV_JAR%" "%DEMO_DIR%\src\ca\weblite\webview\demos\WebViewPasswordOptInDemo.java"
+if errorlevel 1 (
+    echo ERROR: javac failed on demo.
+    exit /b 1
+)
+
+echo Launching WebViewPasswordOptInDemo ...
+"%JAVA_HOME%\bin\java.exe" -cp "%DEMO_CLASSES%;%WV_JAR%" ca.weblite.webview.demos.WebViewPasswordOptInDemo
+
+endlocal

--- a/spdd/analysis/GGQPA-XXX-202608131530-[Analysis]-webview-native-password-manager.md
+++ b/spdd/analysis/GGQPA-XXX-202608131530-[Analysis]-webview-native-password-manager.md
@@ -1,0 +1,380 @@
+# SPDD Analysis: Built-in Password Manager for the Embedded WebView
+
+## Original Business Requirement
+
+The complete, verbatim requirement is the three-story decomposition in
+`requirements/[User-story-6]webview-native-password-manager.md`
+(STORY-006-001 macOS + Java contract + shared JS, STORY-006-002 Linux
+libsecret, STORY-006-003 Windows Credential Manager). It is preserved in
+that file and not re-pasted here to avoid divergence; this analysis treats
+that file as the authoritative requirement and references its ACs by number.
+
+In one paragraph: the embedded engines (`WKWebView`, `WebKitGTK`,
+`WebView2`) withhold the browser "offer to save this password / autofill it
+next time" experience from third-party host apps — concretely, an Okta
+login inside `WebViewComponent` on macOS forces the user to retype the
+password every time. The feature builds the library's own password manager:
+injected JS detects login-form submissions and the library shows a Swing
+"Save password?" prompt; on approval the credential is written to the
+OS-native secret store (Keychain / libsecret / Windows Credential Manager);
+on a later page load a stored credential for the same origin is auto-filled.
+A public Java API on `WebViewComponent` (enable/disable, get/save/delete,
+plus overridable store and save-policy seams) makes it deterministic for
+hosts and headless tests. Credentials are keyed by page origin
+(scheme+host+port); autofill is exact-origin only.
+
+## Domain Concept Identification
+
+### Existing Concepts (from codebase)
+
+- **`WebViewComponent`** (`src/ca/weblite/webview/swing/WebViewComponent.java`)
+  — abstract base + static factory (`create()` picks HEAVYWEIGHT on
+  mac/win, LIGHTWEIGHT on linux). **Owns all per-component handler/dispatcher
+  state** (`consoleDispatcher`, `mouseDispatcher`, `dialogDispatcher`,
+  `popupDispatcher`), each constructed eagerly and surviving native
+  peer create/destroy. This is where the new password-manager state and
+  public API attach — as a sibling dispatcher + `final` methods on the base,
+  never re-implemented per subclass. This exactly matches how
+  `setDialogHandler` / `getDialogHandler` are `final` on the base and delegate
+  to `dialogDispatcher`.
+- **Dispatcher pattern** (`DialogDispatcher`, `ConsoleDispatcher`,
+  `WebViewMouseDispatcher`, `EvalDispatcher`, `FunctionDispatcher`) — the
+  established "per-component fan-out hub between the native/JS layer and a
+  Java handler, with EDT marshaling and exception isolation" shape. The new
+  feature introduces a `PasswordDispatcher` in this family. Two flavours
+  already exist and matter for the design decision below:
+  - **Blocking** (`DialogDispatcher`): `SwingUtilities.invokeAndWait`, native
+    thread parked until the handler returns. Used because `alert`/`confirm`/
+    `prompt` are *synchronous* JS contracts.
+  - **Non-blocking** (`ConsoleDispatcher`, `WebViewMouseDispatcher`):
+    `invokeLater`, fire-and-forget to the EDT. Used for events with no JS
+    return value.
+- **`addOnBeforeLoad(String js)`** (`WebViewComponent.java:286`) — the
+  existing **document-start user-script injection** mechanism. Every
+  dispatcher bootstraps by injecting its `SHIM_JS` here; it is replayed on
+  every new document and on peer re-attach. Maps natively to
+  `WKUserScript` (macOS, `webview_embed.cpp:5691`),
+  `webkit_user_script_new(... INJECT_AT_DOCUMENT_START)` (Linux,
+  `:1897`), and `AddScriptToExecuteOnDocumentCreated` (Windows,
+  `webview_embed.cc:2155`). **The detection/fill script is injected through
+  this existing path — no new injection plumbing is required.**
+- **`addJavascriptFunction(name, fn)`** (`WebViewComponent.java:350`,
+  `FunctionDispatcher`) — the **deadlock-free, value-returning** JS→Java
+  channel: page calls `window.<name>(arg)` → `Promise`, and the Java handler
+  runs **on a background worker pool, never the engine UI thread**
+  (`FunctionDispatcher.java:141`). This is the natural home for a keychain
+  *read* on the autofill path, because keychain I/O can block and must not
+  sit on the UI/EDT thread.
+- **`addJavascriptCallback(name, cb)`** — one-way JS→Java message channel
+  (no return), used by console/mouse. Natural home for the *save* capture
+  (page posts a submission; no synchronous answer needed).
+- **Reserved-binding convention** — `RESERVED_BINDING_PREFIX = "__webview_"`
+  (`WebViewComponent.java:59`); public binding registration rejects this
+  prefix, internal channels bypass the check. Existing reserved names:
+  `__webview_console__`, `__webview_dom_event`, `__webview_eval_result__`,
+  `__webview_fn_call__`. The feature adds new reserved names in this family.
+- **JNI callback registration pattern** — `Engine::<name>_callback` jobject
+  global ref, set via `NewGlobalRef` in a `..._set_<name>_callback` function,
+  deleted on destroy; native→Java invocation attaches the thread defensively,
+  resolves the method ID per-call, calls, then `ExceptionCheck/Clear`
+  (canonical: `fire_dialog_alert`, `webview_embed.cpp:475`). The
+  native-mediated password channel (below) follows this shape.
+- **Native-stamped frame URL** — the dialog selectors read the *committed*
+  frame URL natively from the engine (`webView.URL.absoluteString` on macOS)
+  and hand it to Java as `pageUrl`/`frameUrl`. This is the only trusted
+  source of origin, and it is the pivot of the security design below.
+
+### New Concepts Required
+
+- **Credential** (`WebViewCredential`) — the `{origin, username, password}`
+  value object. New public POJO; value-equality on `{origin, username}`,
+  password redacted from `toString`/`equals`.
+- **Origin** — normalised `scheme + host + port` (default port implied by
+  scheme). The credential key and the anti-phishing boundary. A small
+  normalisation concept, new to this codebase (no existing URL/origin
+  utility was found).
+- **Credential store** (`WebViewCredentialStore` seam + `NativeCredentialStore`
+  default) — the storage abstraction. New. Backed per-platform by the
+  OS-native secret store. **Greenfield on the native side**: a repo-wide
+  grep found zero existing `SecItem` / `libsecret` / `CredWrite` usage, and
+  `Security.framework` / `libsecret` / `wincred` are not yet linked.
+- **Save policy** (`WebViewSavePasswordHandler` + `WebViewSavePasswordEvent`)
+  — the "should this captured submission be saved?" decision, default =
+  Swing prompt, overridable/programmatic. New, mirrors `WebViewDialogHandler`.
+- **Password dispatcher** (`PasswordDispatcher`) — new per-component hub
+  routing native captures/lookups to the store and the save policy.
+- **Detection/fill script** — the shared injected JS that locates login
+  fields, reports submissions, and writes filled values + fires
+  `input`/`change`. New; injected via existing `addOnBeforeLoad`.
+
+### Key Business Rules
+
+- **Origin-exact matching** governs `WebViewCredential` ↔ page: a credential
+  for origin X is only ever offered on origin X (STORY-006-001 AC6, AC7; and
+  the Linux/Windows mirrors). Scheme and port are part of the key.
+- **Overwrite, not duplicate** on `{origin, username}` (AC10); multiple
+  distinct usernames per origin are all retained, and `find` returns the
+  most-recently-saved (AC11).
+- **Enable/disable gates the automatic behaviour only** — disabling stops the
+  prompt and autofill, but the programmatic get/save/delete API still
+  functions (AC12).
+- **Password is secret material** — stored only in the OS store; never
+  logged, printed, redacted in `toString`, never written to a library file
+  (AC18 and the "password never in output" ACs on all three platforms).
+- **Store and save-policy are replaceable seams; getters never return null;
+  `setX(null)` restores the default** (AC14, AC16, AC17) — identical
+  invariant discipline to `getDialogHandler() != null`.
+- **A non-password form submission must never trigger "Save password?"**
+  (STORY-006-001 NFE) — the detector keys on the presence of a password
+  field.
+
+## Strategic Approach
+
+### Solution Direction
+
+Clone the **dispatcher + reserved-channel + `addOnBeforeLoad`** architecture
+already proven by the dialog/console features, and attach a new
+`PasswordDispatcher` and public API to the abstract `WebViewComponent` base
+exactly as `dialogDispatcher` is attached. The data flows are:
+
+- **Save**: injected detection JS observes a login submission and posts the
+  captured `{username, password}` over a reserved channel → the **native
+  message handler stamps the committed frame origin** → `PasswordDispatcher`
+  → EDT (`invokeLater`, non-blocking) → `WebViewSavePasswordHandler`
+  (default Swing prompt) → on `SAVE`, write to the store **off the EDT/UI
+  thread**.
+- **Autofill**: on document load, the injected JS requests a credential; the
+  **native layer supplies the trusted committed origin**; Java looks up the
+  store **on a worker thread** and, on a hit and with the manager enabled,
+  pushes `{username, password}` back into the page (which sets the field
+  values and dispatches `input`/`change`).
+- **Store**: `NativeCredentialStore` calls **process-global** JNI store
+  primitives implemented per-platform (Keychain / libsecret / Credential
+  Manager). Because the secret store is process-global, these primitives need
+  no per-engine handle.
+
+The public Java surface (`WebViewCredential`, `WebViewCredentialStore`,
+`WebViewSavePasswordHandler`, `WebViewSavePasswordEvent`, and the
+`WebViewComponent` methods) is designed once in STORY-006-001 and unchanged
+by the Linux/Windows stories, which add only native store + native channel
+wiring — the same split the dialog feature used.
+
+### Key Design Decisions
+
+- **Non-blocking dispatch (`invokeLater`), NOT the dialog's blocking
+  `invokeAndWait`.** → Trade-off: the dialog dispatcher parks the native JS
+  thread because `alert`/`confirm`/`prompt` are synchronous JS contracts. A
+  login submission has **no synchronous JS contract** — the form submits and
+  navigates regardless of whether we save — and autofill is a page-load side
+  effect, not a JS return value. Blocking the engine thread on a Swing prompt
+  here would be gratuitous (it would freeze the page during navigation) and
+  risk the very deadlocks the dialog Safeguards warn about. **Recommendation:
+  model `PasswordDispatcher` on the non-blocking `WebViewMouseDispatcher` /
+  `ConsoleDispatcher` shape, not `DialogDispatcher`.** Keychain I/O runs on a
+  worker (the `addJavascriptFunction` pool or a dedicated single-thread
+  executor), never the EDT or the engine UI thread.
+
+- **Origin is stamped natively; it is NEVER accepted as a JS-supplied
+  argument.** → This is the security crux. A reserved channel binding is a
+  real global function the page can call **directly**, bypassing our injected
+  script — so if the origin were a channel argument, a page at `evil.com`
+  could request `bank.com`'s credential. `location.origin` read inside our
+  script is genuinely unforgeable (`[Unforgeable]` in WebIDL), but the
+  *channel* is not. Therefore the trusted origin must come from the engine,
+  exactly as the dialog selectors already read `webView.URL.absoluteString`
+  natively. **Recommendation: the save/fill channel is native-mediated per
+  platform** (the message handler reads the committed frame URL and hands it
+  to Java), which is the real reason each platform needs native work beyond
+  the store. Any origin value that arrives from JS is ignored.
+
+- **Autofill = JS-initiated ping + native origin-stamp + Java-push via
+  `eval`; no general navigation callback is needed.** → Given the previous
+  decision, the fill path cannot trust a JS-supplied origin. A repo search
+  confirmed there is **no** general navigation/load-finished callback and no
+  `getUrl` in the Java API (only popup events carry a natively-stamped
+  `pageUrl`). Rather than build a navigation subsystem, resolve the origin the
+  same way the dialog selectors already do: the injected script, once the DOM
+  is ready and a login form is present, posts a one-way "fill request" on a
+  **native-mediated** reserved channel; the **native message handler reads the
+  engine's committed URL at the moment the message arrives**
+  (`webView.URL` / `webkit_web_view_get_uri` / WebView2 `get_Source`) — which
+  is by construction the document that just ran the script — and hands that
+  trusted origin to Java. Java looks up the store on a worker and, on a hit
+  with the manager enabled, pushes the credential back by `eval`-ing a fill
+  entrypoint (`window.__webview_pw_fill__(user, pass)`) that only *writes*
+  values into the detected fields and never returns a credential (so a page
+  calling it directly can only fill its own form with attacker-chosen text —
+  harmless). This works for redirect chains (Okta) because the origin is read
+  per-message from the committed document, not tracked across navigations.
+  **This closes the earlier open question** — no navigation/load callback has
+  to be added; the resolution is stamp-at-message-time, mirroring dialog
+  `frameUrl`.
+
+- **Store primitives are process-global static JNI, greenfield native.** →
+  macOS: add `-framework Security` to `build-mac.sh`, use `SecItem*`
+  generic-password items namespaced to the library. Linux: add **libsecret**,
+  and — to match the existing runtime-`dlopen` convention for WebKitGTK
+  (`webkit_loader.cpp`) rather than hard-linking — `dlopen` libsecret so a
+  missing keyring degrades gracefully instead of failing to load the `.so`.
+  Windows: `wincred.h` (`CredWriteW`/`CredReadW`/`CredDeleteW`) via Advapi32.
+  Trade-off: static (no engine handle) keeps the store independent of any
+  component's lifecycle, which matches a machine-global secret store and lets
+  the programmatic API work before any page loads.
+
+- **Reuse `addOnBeforeLoad` for injection; add reserved channel name(s) in
+  the `__webview_` family.** → No new injection infrastructure; the script is
+  replayed per-document automatically. Likely names: a save-capture channel
+  and a fill entrypoint. The `RESERVED_BINDING_PREFIX` guard already prevents
+  application code from colliding with them.
+
+### Alternatives Considered
+
+- **Reuse the blocking `DialogDispatcher` channel for the save prompt.** →
+  Rejected: it would freeze the page/engine during the prompt for no
+  contract reason and invites the documented `invokeAndWait` deadlocks.
+- **Pure-JS channel with a JS-supplied origin (`addJavascriptFunction`
+  taking `origin`).** → Rejected on security grounds: the reserved binding is
+  page-callable directly, so a JS-supplied origin is spoofable and would
+  allow cross-origin credential theft.
+- **Inject the script into an isolated content world** (WKContentWorld /
+  WebKitScriptWorld) so the reserved binding is not page-callable, then trust
+  a JS-supplied origin. → Rejected for this iteration: content-world support
+  is uneven across the three engines (well-supported on WKWebView 11+,
+  partial on WebKitGTK, awkward on WebView2's
+  `AddScriptToExecuteOnDocumentCreated`), so it cannot deliver a uniform
+  contract. Native origin-stamping is uniform and strictly safer. Worth
+  revisiting later as defense-in-depth.
+- **A library-managed encrypted file instead of the OS store.** → Already
+  rejected in the requirement (the user chose OS-native). Noted only to
+  record that it would put master-key management on the library, which the
+  OS store avoids.
+- **Standalone `WebView` (non-embedded) coverage.** → Deferred, same
+  boundary the dialog feature drew; the feature targets `WebViewComponent`.
+
+## Risk & Gap Analysis
+
+### Requirement Ambiguities
+
+- **Trusted committed-URL signal for autofill — RESOLVED.** The requirement
+  says "autofill on page load". A repo search confirmed no general
+  navigation/load callback and no `getUrl` exists, so the design does not
+  depend on one: the native message handler stamps the engine's committed URL
+  at the instant the injected script posts its fill request (mirroring dialog
+  `frameUrl`). The remaining Canvas task is only to specify the per-engine URL
+  read (`webView.URL` / `webkit_web_view_get_uri` / WebView2 `get_Source`),
+  not to introduce a navigation subsystem. AC4/AC5 are no longer gated.
+- **What counts as a "login submission" in a SPA / redirect flow.** The
+  requirement acknowledges best-effort for non-`submit` login buttons and
+  explicitly scopes out *guaranteed* multi-step (identifier-first) capture.
+  The Canvas must pin the heuristic (real `submit` event + a best-effort
+  synthetic-submit observer) and keep the "no password field ⇒ no prompt"
+  invariant.
+- **"Most-recently-saved" ordering** (`find` when multiple usernames exist,
+  AC11) requires a recency signal. The OS stores don't all preserve insertion
+  order natively; the Canvas must specify how recency is derived (e.g. a
+  stored timestamp attribute) so AC11 is deterministic.
+- **Origin string canonical form.** Whether the stored/returned origin string
+  omits the default port (`https://example.com`, not `:443`) must be fixed so
+  AC7's equality checks and the store key are unambiguous.
+
+### Edge Cases
+
+- **Autofilled credential is readable by page scripts.** Once filled into the
+  DOM, any script on the page (including third-party/XSS) can read the
+  password field — this is exactly browser autofill's baseline exposure, not
+  a regression, but it must be documented and kept in scope-bounds (fill only
+  the single origin-matched credential Java chose to send).
+- **Redirect chains (Okta).** The motivating flow bounces across SSO
+  redirects; each committed document is a separate origin/URL. Save capture
+  works per page; cross-page username↔password correlation is explicitly
+  out of scope (documented limitation).
+- **Locked / absent keyring on Linux.** No Secret Service provider, or a
+  locked login keyring: `save` must fail gracefully, `find` returns empty,
+  page load/submission still work (STORY-006-002 AC12).
+- **iframe / cross-origin subframe login.** Matching is exact top-frame
+  origin only; a login inside a cross-origin iframe is out of scope and must
+  not fill with the top origin's credential.
+- **Two components / simultaneous prompts.** Each component has its own
+  dispatcher; EDT serialises prompts. Non-blocking dispatch means no engine
+  thread is parked while they queue.
+- **Manager toggled or store swapped mid-session** — the enabled flag and
+  store reference are read per-operation (volatile), like the dialog handler.
+- **Password containing channel/JSON metacharacters or newlines** — the
+  save-capture payload encoding must be binary-safe (the console channel's
+  base64 precedent applies) so a password with `|`, quotes, or newlines
+  round-trips intact.
+
+### Technical Risks
+
+- **Native origin-stamping must hook the right thread/URL** on each engine
+  (`WKScriptMessageHandler` message → `webView.URL`; WebKitGTK
+  `script-message-received` → `webkit_web_view_get_uri`; WebView2
+  `WebMessageReceived` → `args->get_Source`/`webview->get_Source`). Getting
+  the *committed* (not pending) URL is the correctness-critical detail.
+  Mitigation: mirror the dialog selectors' proven URL read; add a focused
+  test page that asserts origin under redirect.
+- **Keychain/keyring I/O latency** blocking a UI/EDT thread. Mitigation: all
+  store calls on a worker; the design already routes reads through the
+  worker-pool function channel and writes after the EDT prompt returns.
+- **Greenfield native linkage** (`Security.framework`, libsecret dlopen,
+  Advapi32) across three build scripts and the runtime-dlopen convention on
+  Linux. Mitigation: additive build changes; libsecret dlopen keeps the `.so`
+  loadable where the library is absent.
+- **JNI safety on native callbacks** — global-ref lifecycle, per-call method
+  ID resolution, `ExceptionCheck/Clear`, attach/detach symmetry. Mitigation:
+  copy the `fire_dialog_*` helpers verbatim in shape.
+- **Password material on the JVM heap** (Java `String` immutability means it
+  lingers until GC). Mitigation: minimise retention, never log, redact
+  `toString`; a `char[]`-based path is possible but the requirement's
+  "minimise, don't guarantee zeroisation" bar is met by discipline. Note as a
+  known limitation.
+- **Header staleness** — `ca_weblite_webview_WebViewNative.h` is
+  javah-generated and already partial; new natives are implemented as mangled
+  `JNIEXPORT` directly. Low risk, matches current practice.
+
+### Acceptance Criteria Coverage
+
+STORY-006-001 (macOS + contract + shared JS):
+
+| AC# | Description | Addressable? | Gaps/Notes |
+|-----|-------------|--------------|------------|
+| 1 | Submission triggers Swing save prompt | Yes | Detection JS + native-stamped origin + non-blocking prompt |
+| 2 | Approve → stored in Keychain | Yes | `SecItemAdd`, worker-thread write |
+| 3 | Decline → nothing stored | Yes | Save-policy `DONT_SAVE` path |
+| 4 | Autofill on next load | Yes | Native origin stamped at fill-request message time; Java-push via eval |
+| 5 | Autofill fires input/change | Yes | Fill entrypoint dispatches events |
+| 6 | Origin-exact (evil.com not filled) | Yes | Native origin, exact match |
+| 7 | Scheme+port part of key | Yes | Origin normalisation rule must be fixed |
+| 8 | Programmatic save→get | Yes | Store API |
+| 9 | Programmatic delete | Yes | `SecItemDelete` |
+| 10 | Overwrite existing username | Yes | Upsert semantics |
+| 11 | Multiple usernames retained; find = most recent | Partial | Needs a recency attribute in the store |
+| 12 | Disable suppresses UI, API still works | Yes | Enabled flag gates automation only |
+| 13 | Custom save-handler, no UI | Yes | Policy seam |
+| 14 | Custom in-memory store | Yes | Store seam |
+| 15 | Callbacks on EDT | Yes | Dispatcher marshals |
+| 16 | Getters never null | Yes | Default instances |
+| 17 | setX(null) restores default | Yes | Invariant discipline |
+| 18 | Password never in output | Yes | Redaction + no logging |
+| 19 | No credential ⇒ no fill, no error | Yes | Lookup-miss path |
+| 20 | Save-handler exception isolated | Yes | Try/catch → default uncaught handler |
+
+STORY-006-002 (Linux): AC1–AC13 all addressable; **AC4** shares the
+committed-URL gate; **AC12** (graceful degradation) needs the dlopen-libsecret
+approach; parity **AC11** requires identical field values across
+heavyweight/lightweight (single shared JS + single dispatcher makes this
+natural).
+
+STORY-006-003 (Windows): AC1–AC13 all addressable; **AC10** (Edge bar
+suppressed) needs `put_IsPasswordAutosaveEnabled(FALSE)` at engine creation;
+**AC3/AC4** share the committed-URL gate via WebView2's `get_Source`.
+
+**Overall:** every AC is addressable, and the previously-flagged cross-cutting
+dependency (a trusted committed-URL signal for autofill) is resolved by
+stamping origin at fill-request message time — no navigation subsystem is
+required. Everything maps cleanly onto the existing dispatcher /
+`addOnBeforeLoad` / reserved-channel / native-callback / JNI patterns plus the
+greenfield native store per platform. The remaining genuinely-open items are
+smaller and local to the Canvas: the origin canonical-form rule (AC7), the
+recency attribute for `find` ordering (AC11), and the SPA/synthetic-submit
+detection heuristic — all specifiable without new infrastructure.

--- a/spdd/analysis/GGQPA-XXX-202608131530-[Analysis]-webview-native-password-manager.md
+++ b/spdd/analysis/GGQPA-XXX-202608131530-[Analysis]-webview-native-password-manager.md
@@ -378,3 +378,194 @@ greenfield native store per platform. The remaining genuinely-open items are
 smaller and local to the Canvas: the origin canonical-form rule (AC7), the
 recency attribute for `find` ordering (AC11), and the SPA/synthetic-submit
 detection heuristic — all specifiable without new infrastructure.
+
+---
+
+# Addendum Analysis: STORY-006-004 (Autofill-Consent Handler) and STORY-006-005 (Enumerate-All)
+
+This addendum extends the analysis above to the two follow-on stories that
+reverse Scope-Out items 006-001 originally deferred. It treats the shipped
+code (`PasswordDispatcher`, `WebViewCredentialStore`, `NativeCredentialStore`,
+`WebViewComponent` password API, and the three native store bodies) as the
+authoritative baseline and analyses only the deltas.
+
+## Shipped baseline the deltas build on
+
+- **`PasswordDispatcher`** (`src/ca/weblite/webview/PasswordDispatcher.java`)
+  — holds `store` (volatile), `handler` (the save-policy, volatile),
+  `enabled` (volatile), and a single-thread `io` executor
+  (`webview-password-io`, daemon). Two native-facing entrypoints:
+  - `dispatchLoginSubmitted(...)` → `invokeLater(runPrompt)` → consults the
+    **save** handler on the EDT → on SAVE, `io.execute(safeSave)`.
+  - `dispatchFillRequested(frameUrl)` → `io.execute(doFill)` →
+    `store.find(origin)` → `source.eval("window.__webview_pw_fill__(...)")`.
+    **`doFill` consults no policy — this is the exact gap 006-004 fills.**
+- **`WebViewCredentialStore`** — `save`, `find(origin)`, `findAll(origin)`,
+  `delete(origin, username)`. Implementations must be thread-safe and must
+  degrade to "no result" rather than throw. **No no-argument enumerate — the
+  exact gap 006-005 fills.**
+- **`NativeCredentialStore`** delegates to process-global JNI primitives
+  `webview_cred_store_{save,find,delete,available}`; `find`/`findAll` already
+  wrap a JNI find that returns an array. The three native bodies each already
+  enumerate namespaced items (macOS two-phase `SecItemCopyMatching`; Windows
+  `CredEnumerateW` with a per-origin filter; Linux libsecret lookup).
+
+## STORY-006-004 — strategic direction
+
+**This is a pure, additive symmetry fix on the fill path — no native, no JS.**
+The save path already proves the exact shape: a policy interface with a Swing
+default, a component setter/getter delegating to the dispatcher, EDT
+invocation, and try/catch exception isolation forwarding to the default
+uncaught-exception handler. 006-004 mirrors it on the fill side.
+
+### Key decisions
+
+- **Where the gate goes.** `doFill` currently runs entirely on the `io`
+  worker: it does `store.find(origin)` (correctly off the EDT, because
+  keychain reads can block), then evals. The consent policy must run on the
+  **EDT** (it may show UI / a modal re-auth), exactly like `runPrompt`. So
+  `doFill`'s shape becomes: (1) `store.find(origin)` on the `io` worker as
+  today; (2) if present, marshal `{source, origin, username}` to the EDT via
+  `invokeLater` and consult the fill handler; (3) on `FILL`, eval the
+  write-only fill entrypoint. The eval itself is already safe to issue from
+  the EDT (it is a fire-and-forget `source.eval`). This keeps the blocking
+  keychain read off the EDT while putting only the (host-controlled) consent
+  decision on it — the same split the save path uses (worker for I/O, EDT for
+  policy).
+- **Default must be FILL (hard backward-compat constraint).** Existing
+  006-001/002/003 autofill ACs assert fields are filled with no prompt. So
+  `WebViewFillPasswordHandler.DEFAULT` returns `FILL` unconditionally and is
+  the dispatcher's initial handler. The **`CONFIRM`** constant is the opt-in
+  browser-style Swing prompt; it reuses the `SwingUtilities.getWindowAncestor`
+  + `JOptionPane.showConfirmDialog` recipe from
+  `WebViewSavePasswordHandler.DEFAULT`, showing origin + username only.
+- **Password-free event.** `WebViewFillPasswordEvent` carries `source`,
+  `origin`, `username` — deliberately **no password accessor**. This is a
+  security improvement over reusing `WebViewSavePasswordEvent` (which exposes
+  the password): the fill decision needs only identity, so the password is
+  never handed to host consent code. `doFill` already has the full credential
+  in hand; it simply does not put the password into the event.
+- **Disabled-manager short-circuit stays first.** `doFill` already returns
+  early when `disposed || !enabled`; the handler is consulted only after that,
+  so AC10 (disabled ⇒ no confirmation, no fill) holds for free.
+- **Re-auth is a seam, not an implementation.** The story ships the decision
+  point + a Swing-confirm default; a biometric/Windows-Hello/Touch-ID check is
+  a host-supplied handler (or a later story). No `LAContext`/Windows Hello
+  code in this story — that keeps it Java-only and cross-platform.
+
+### Edge cases
+
+- **Handler throws** → caught in `doFill`, forwarded to
+  `Thread.getDefaultUncaughtExceptionHandler` (the existing `forward` helper);
+  nothing filled, engine responsive (AC11).
+- **Handler blocks on a modal** → it is on the EDT, not the native engine
+  thread; the native side already returned after posting the fill request, so
+  nothing native is parked (the fill path was already non-blocking).
+- **Programmatic reads unaffected** — `getCredential`/`getCredentials`/
+  `getAllCredentials` call the store directly and never touch the fill
+  handler (AC9).
+- **Multiple fill requests** (SPA late-inserted form posts `F` again) — each
+  request re-consults the handler; a host that shows a modal should expect one
+  prompt per request, matching today's one-eval-per-request behaviour.
+
+### AC coverage — STORY-006-004
+
+| AC# | Description | Addressable? | Notes |
+|-----|-------------|--------------|-------|
+| 1 | Default still autofills, no prompt | Yes | `DEFAULT` returns FILL; dispatcher initial handler |
+| 2 | CONFIRM shows confirmation, no password | Yes | `CONFIRM` Swing prompt, origin+username only |
+| 3 | Approve → filled | Yes | FILL → eval fill entrypoint |
+| 4 | Decline → nothing filled, no error | Yes | DONT_FILL → skip eval |
+| 5 | Programmatic DONT_FILL handler | Yes | Policy seam, no UI |
+| 6 | Event exposes no password | Yes | `WebViewFillPasswordEvent` has no password accessor |
+| 7 | Handler on EDT | Yes | `invokeLater` marshal in `doFill` |
+| 8 | Getter non-null; setter null restores default | Yes | Same invariant discipline as save handler |
+| 9 | Programmatic read not gated | Yes | Read API bypasses the fill handler |
+| 10 | Disabled manager ⇒ no fill regardless of handler | Yes | `!enabled` early-return precedes handler |
+| 11 | Handler exception isolated | Yes | try/catch → `forward` |
+
+## STORY-006-005 — strategic direction
+
+**One new no-argument enumerate that lifts an existing native capability into
+the public contract.** The Java surface gains `WebViewCredentialStore.findAll()`
+(all origins) and `WebViewComponent.getAllCredentials()`; the native layer
+gains one process-global JNI primitive (`webview_cred_store_find_all`) with
+three platform bodies that reuse each platform's already-present enumeration.
+
+### Key decisions
+
+- **Return full credentials, not just origins.** `getAllCredentials()` returns
+  `List<WebViewCredential>` (origin+username+password), from which a host
+  derives the origin list for a manager UI. A separate `savedOrigins()` is not
+  added (Scope-Out) — one method, richest result, no new exposure surface
+  beyond what `find`/`findAll` already return to host Java.
+- **Reuse the per-platform enumerate primitive.**
+  - **macOS** (`src_c/webview_embed.cpp`, Canvas 26): the existing
+    `webview_cred_store_find` already does a two-phase read (phase-1
+    attributes via `kSecMatchLimitAll`, phase-2 per-item secret). `find_all`
+    is the same two-phase read with the **service-namespace-only** query (drop
+    the per-origin service filter, keep the `kSecClassGenericPassword` +
+    library-namespace scoping). The two-phase split is what avoids the
+    `errSecParam` bug the shipped code already documents — reuse it verbatim.
+  - **Windows** (`windows/webview_embed.cc`, Canvas 28): `webview_cred_store_find`
+    already calls `CredEnumerateW` with a `"<svc>:*"`-style filter and decodes
+    the `b64url(origin)|b64url(username)` target names. `find_all` uses the
+    **namespace-prefix filter** (`"<namespace>:*"`) and decodes every match —
+    the decode/blob-parse path is identical; only the filter widens.
+  - **Linux** (`src_c/webview_embed_linux.*` per Canvas 27): libsecret schema
+    search (`secret_password_search` / `secret_service_search_sync` over the
+    `SecretSchema` with only the library-namespace attribute bound) returns
+    every entry; map each to `{origin, username, password}` from the schema
+    attributes + secret. Same graceful-degradation (`available()` false ⇒
+    empty) contract.
+- **Recency ordering reused.** Every platform already stamps `savedAtMillis`
+  in the value blob (`millis\npassword`) and orders origin-scoped `findAll`
+  most-recent-first. `find_all` applies the same sort across the full set, so
+  ordering/dedup semantics are identical to origin-scoped `findAll` (AC2, AC3).
+- **`InMemoryCredentialStore`** enumerates its map (all origins), applying the
+  same most-recent-first ordering it already uses per-origin (AC6).
+- **No page-JS exposure.** Enumerate-all is a host-Java call only; there is no
+  reserved channel or injected global that returns it. The fill script stays
+  write-only and origin-scoped (AC9). This is a pure host-side capability.
+
+### Edge cases / risks
+
+- **Native enumerate cannot be locally compiled for Windows/Linux** (macOS dev
+  machine) — same constraint the shipped Windows body hit. Mitigation: mirror
+  the existing `find` body's structure exactly (only the query filter widens),
+  and rely on the CI native build matrix (all-platforms jar + per-arch native
+  jobs) to validate compilation, as the shipped code did.
+- **Large stores** — enumerate returns the full set in one call (Scope-Out:
+  paging). Acceptable for a personal password store; noted.
+- **Namespace collisions** — the query is scoped to the library service
+  namespace exactly as `find` is, so it never returns Safari/Edge/other-app
+  items (the shipped `find` already guarantees this scoping).
+- **Empty / unavailable store** → empty list, never throw (AC4, AC8),
+  matching the store contract.
+
+### AC coverage — STORY-006-005
+
+| AC# | Description | Addressable? | Notes |
+|-----|-------------|--------------|-------|
+| 1 | Enumerate across multiple origins | Yes | `find_all` namespace-scoped query |
+| 2 | Most-recently-saved first | Yes | Reuse `savedAtMillis` sort across full set |
+| 3 | Multiple usernames per origin | Yes | Enumerate returns each `{origin,username}` |
+| 4 | Empty store ⇒ empty list | Yes | No-match ⇒ empty, non-null |
+| 5 | Deletion reflected | Yes | Enumerate re-reads store |
+| 6 | In-memory store enumerates | Yes | Map enumeration |
+| 7 | Native round-trip per platform | Yes | Three native bodies reuse existing enumerate |
+| 8 | Graceful degradation | Yes | `available()` false ⇒ empty |
+| 9 | No page-JS exposure | Yes | Host-Java-only; fill script stays write-only |
+| 10 | Password never logged | Yes | Redacting `toString`; no logging on enumerate path |
+
+## Overall
+
+Both stories map cleanly onto shipped patterns with **no new infrastructure**:
+006-004 is a Java-only fill-side mirror of the existing save-side policy
+(dispatcher tweak + one enum + one password-free POJO + one interface with
+DEFAULT/CONFIRM + two component methods); 006-005 is one no-argument store
+method + one component method + one JNI primitive whose three bodies each widen
+an already-present per-origin enumerate to the namespace scope. The only
+genuinely non-local risk is native enumerate compilation on Windows/Linux,
+mitigated by structural parity with the shipped `find` bodies and the CI native
+matrix.

--- a/spdd/prompt/23-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
+++ b/spdd/prompt/23-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
@@ -1,0 +1,1279 @@
+---
+generated_at: 2026-08-13T15:30:00-07:00
+---
+
+# REASONS Canvas: Built-in Password Manager (Java API + Shared Detection/Fill Script + macOS Keychain Coverage)
+
+## R · Requirements
+
+- Give `WebViewComponent` a browser-grade password manager: detect
+  login-form submissions inside the embedded page, offer to save the
+  credential via a Swing "Save password?" prompt, store it in the
+  OS-native secret store, and auto-fill a stored credential into the
+  matching login fields on a later page load. This canvas designs the
+  full cross-platform Java contract, authors the shared detection/fill
+  JavaScript once, and ships the **macOS** backend (Keychain via
+  Security.framework). Linux (libsecret) and Windows (Credential
+  Manager) coverage land in the two follow-up canvases (24, 25) and
+  reuse this contract and this JavaScript unchanged.
+- The engines this library wraps deliberately withhold this behaviour
+  from embedding apps (`WKWebView` never shows Safari's private
+  "Save Password" prompt), so the library provides its own. The
+  concrete motivating failure: an Okta login inside `WebViewComponent`
+  on macOS forces the user to retype the password every visit.
+- Expose these new public types in `ca.weblite.webview`:
+  - `WebViewCredential` — immutable `{origin, username, password}`
+    value object; equality on `{origin, username}` (password excluded);
+    `toString()` redacts the password.
+  - `WebViewCredentialStore` — the storage seam interface: `save`,
+    `find(origin)`, `findAll(origin)`, `delete(origin, username)`.
+  - `NativeCredentialStore` — the default `WebViewCredentialStore`,
+    backed by the OS-native secret store (Keychain on macOS in this
+    canvas) through new process-global static JNI primitives.
+  - `InMemoryCredentialStore` — a public, dependency-free
+    `WebViewCredentialStore` for tests / hosts that do not want OS
+    persistence.
+  - `WebViewSavePasswordEvent` — immutable captured-submission event
+    (`source`, `origin`, `username`, `password`); `toString()` redacts
+    the password.
+  - `SavePasswordDisposition` — enum `{ SAVE, DONT_SAVE }`.
+  - `WebViewSavePasswordHandler` — functional interface,
+    `SavePasswordDisposition onLoginSubmitted(WebViewSavePasswordEvent)`,
+    invoked on the EDT; `DEFAULT` shows a Swing "Save password?" prompt
+    modal to the host `JFrame`.
+  - `WebViewPasswordCallback` — the JNI-facing callback interface (two
+    void methods, invoked from the native message thread), analogous to
+    `WebViewDialogCallback`. Application code never implements it; it
+    routes through `WebViewComponent`.
+- Expose these new public methods on `WebViewComponent` as concrete
+  `final` methods (no abstract overload), all delegating to a
+  per-component `PasswordDispatcher`:
+  - `WebViewComponent setPasswordManagerEnabled(boolean)` /
+    `boolean isPasswordManagerEnabled()` — master switch for the
+    automatic save-prompt + autofill. **Enabled by default.** Disabling
+    suppresses both automatic behaviours; the programmatic methods below
+    still work.
+  - `WebViewComponent setCredentialStore(WebViewCredentialStore)` /
+    `WebViewCredentialStore getCredentialStore()` — the store seam;
+    `null` reinstalls the default `NativeCredentialStore`;
+    `get` never returns null.
+  - `WebViewComponent setSavePasswordHandler(WebViewSavePasswordHandler)`
+    / `WebViewSavePasswordHandler getSavePasswordHandler()` — the
+    save-policy seam; `null` reinstalls the default Swing-prompt handler;
+    `get` never returns null.
+  - `void saveCredential(WebViewCredential)` — programmatic upsert.
+  - `java.util.Optional<WebViewCredential> getCredential(String origin)`
+    — programmatic lookup (most-recently-saved for the origin).
+  - `java.util.List<WebViewCredential> getCredentials(String origin)` —
+    all credentials for the origin, most-recently-saved first.
+  - `boolean deleteCredential(String origin, String username)`.
+- Author the shared detection/fill JavaScript
+  (`PasswordDispatcher.SHIM_JS`), injected at document-start on every
+  backend via the existing `addOnBeforeLoad` mechanism (no new injection
+  plumbing). It:
+  1. Locates the login form: the first `<input type="password">` and its
+     associated username field (the text/email/tel input immediately
+     preceding the password field within the same `<form>`; else the
+     form's first such input; else, when there is no `<form>`, the
+     nearest preceding such input in document order).
+  2. On `submit` of a form containing a password field — and,
+     best-effort, on click of a plausible submit control in a
+     `<form>`-less SPA login — reads the username + password, base64url
+     encodes each, and posts `S|<b64user>|<b64pass>` on the reserved
+     native password channel.
+  3. When the DOM is ready and a login form is present, posts `F` (fill
+     request) on the same channel. Re-checks once via a bounded
+     `MutationObserver` (single re-arm, disconnected after the first
+     hit or after a short bounded window) for late-inserted forms.
+  4. Exposes exactly one page-visible entrypoint,
+     `window.__webview_pw_fill__(b64user, b64pass)`, which base64url
+     decodes the two arguments, writes them into the detected username /
+     password fields, and dispatches `input` then `change` events on
+     each so framework-driven forms observe the change. This entrypoint
+     only ever *writes* values; it never reads or returns a credential.
+- The **origin is stamped natively, never trusted from JavaScript.** The
+  reserved password channel is a native script-message handler whose
+  implementation reads the committed frame URL from the engine at the
+  instant the message arrives (`message.frameInfo` /
+  `webView.URL` on macOS) and hands that URL to Java. Any origin-like
+  value present in the JS payload is ignored. This prevents a page at
+  one origin from saving-into or reading another origin's credential by
+  posting a forged origin directly to the channel.
+- All save-policy callbacks run on the Swing EDT. The dispatcher
+  marshals via `SwingUtilities.invokeLater` (NON-blocking — unlike
+  `DialogDispatcher`'s `invokeAndWait`), because a login submission has
+  no synchronous JS contract: the form submits and navigates regardless
+  of whether the credential is saved, so the native message thread must
+  not be parked on a modal Swing prompt.
+- All secret-store I/O (Keychain reads/writes) runs off the EDT and off
+  the engine UI thread, on the dispatcher's single-thread executor. The
+  autofill lookup and the post-approval save both run there.
+- Add new JNI entry points on `WebViewNative`:
+  - `webview_embed_set_password_callback(long, WebViewPasswordCallback)`
+    and `webview_offscreen_set_password_callback(long, WebViewPasswordCallback)`
+    — mirror the `..._set_dialog_callback` precedent
+    (`WebViewNative.java:284, 449`). The offscreen setter is a native
+    no-op stub on macOS (offscreen is itself a stub on macOS); Linux
+    lightweight wires it in canvas 24.
+  - Process-global static store primitives (no engine handle, because
+    the OS secret store is process-global):
+    - `boolean webview_cred_store_save(String service, String origin, String username, String password, long savedAtMillis)`
+    - `String[] webview_cred_store_find(String service, String origin)`
+      — flat triples `[username, savedAtMillis, password, ...]`,
+      most-recently-saved first; empty array when none / unavailable.
+    - `boolean webview_cred_store_delete(String service, String origin, String username)`
+    - `boolean webview_cred_store_available()` — whether the platform
+      secret store is usable (always `true` on macOS; meaningful on
+      Linux in canvas 24).
+    This canvas implements the macOS bodies (Keychain) and provides
+    stub bodies (return `false` / empty / `false`) for the non-macOS
+    compilation of `webview_embed.cpp` and for `windows/webview_embed.cc`,
+    so the class links on every platform; canvases 24 / 25 fill them in.
+- Add `setPasswordCallback(WebViewPasswordCallback)` to both
+  `EmbeddedWebView` and `OffscreenWebView`, mirroring
+  `setDialogCallback` (`EmbeddedWebView.java:566`,
+  `OffscreenWebView.java:431`) — anchor the callback in the wrapper's
+  `heap` `IdentityHashMap` so the JVM does not collect it while native
+  holds a global ref.
+- Add `-framework Security` to `build-mac.sh` (Keychain access). This is
+  the only build-script change in this canvas; libsecret / Advapi32
+  linkage is added by canvases 24 / 25.
+- Definition of Done:
+  - All 20 STORY-006-001 ACs pass on macOS with the new code.
+  - A `WebViewPasswordDemo` under `demos/` exercises capture + save
+    prompt + autofill in default-handler, custom-handler, and
+    in-memory-store modes.
+  - README grows a "Password manager" subsection documenting the
+    `setPasswordManagerEnabled` / store / save-handler API, the
+    origin-keying and origin-exact-match rules, the security notes
+    (autofilled value is DOM-readable by page scripts; passwords live
+    only in the OS store), and the macOS-only coverage caveat for this
+    iteration.
+  - Unit tests (`PasswordDispatcherTest`, `WebViewCredentialTest`,
+    `InMemoryCredentialStoreTest`, `OriginsTest`) validate the Java
+    contract headlessly (no real engine, no real Keychain): programmatic
+    save/find/delete, upsert + recency ordering, origin normalisation +
+    exact match, enable/disable gating, store/handler null-restores-default
+    and never-null invariants, save-handler exception isolation, and
+    password redaction in `toString`. Native Keychain + injection code is
+    integration-tested via the demo (consistent with the
+    no-automated-GUI-tests policy).
+- Out of scope (explicit non-goals):
+  - Linux WebKitGTK message handler + libsecret store (canvas 24).
+  - Windows WebView2 message handler + Credential Manager store, and
+    disabling Edge's built-in autosave (canvas 25).
+  - The standalone in-process `WebView` class — this canvas only touches
+    the embedded `WebViewComponent` surface.
+  - A credential-management UI (a "manage saved passwords" window). Hosts
+    build their own on the programmatic API.
+  - Guaranteed multi-step / identifier-first (split username→password
+    page) capture. Best-effort per-page capture is in scope; cross-page
+    correlation is a documented limitation.
+  - Passkeys / WebAuthn, TOTP/2FA, password generation, strength
+    metering.
+  - Cross-origin / subdomain credential matching, and login inside a
+    cross-origin iframe. Matching is exact top-frame origin only.
+  - Biometric / re-auth gating before autofill.
+  - Guaranteed zeroisation of password material on the JVM heap (Java
+    `String` immutability prevents a hard guarantee; the library
+    minimises retention and never logs — documented limitation).
+
+## E · Entities
+
+- **WebViewCredential** (new public final class,
+  `src/ca/weblite/webview/WebViewCredential.java`). Immutable value
+  type. Public constructor `WebViewCredential(String origin, String
+  username, String password)`. Invariants: `origin` and `username`
+  non-null (NPE naming the parameter); `password` non-null (NPE);
+  `origin` is stored **as supplied** (normalisation happens at the store
+  boundary, not in the POJO, so a caller can construct a credential with
+  any origin string and the store canonicalises it). Accessors
+  `origin()`, `username()`, `password()`. `equals`/`hashCode` on
+  `{origin, username}` only (password excluded). `toString()` returns
+  `"WebViewCredential[origin=<...>, username=<...>, password=***]"` —
+  never the password.
+
+- **WebViewCredentialStore** (new public interface,
+  `src/ca/weblite/webview/WebViewCredentialStore.java`). The storage
+  seam.
+  - `void save(WebViewCredential credential)` — insert or overwrite the
+    credential for `{origin, username}`.
+  - `java.util.Optional<WebViewCredential> find(String origin)` —
+    most-recently-saved credential for the origin, or empty.
+  - `java.util.List<WebViewCredential> findAll(String origin)` — all
+    credentials for the origin, most-recently-saved first
+    (unmodifiable list; empty when none).
+  - `boolean delete(String origin, String username)` — remove one;
+    returns whether anything was removed.
+  No `DEFAULT` constant on the interface (the default *instance* is a
+  `NativeCredentialStore`, created by the dispatcher).
+
+- **NativeCredentialStore** (new public final class,
+  `src/ca/weblite/webview/NativeCredentialStore.java`). Default store,
+  backed by the OS-native secret store via the static JNI primitives.
+  Owns origin canonicalisation (through `Origins`) and translates
+  between `WebViewCredential` and the flat JNI triples. Stateless and
+  thread-safe (the JNI primitives are process-global and serialise
+  internally at the OS level). A single library-namespace `service`
+  constant (`"ca.weblite.webview.passwords"`).
+
+- **InMemoryCredentialStore** (new public final class,
+  `src/ca/weblite/webview/InMemoryCredentialStore.java`). A
+  `WebViewCredentialStore` backed by a `ConcurrentHashMap` keyed by
+  canonical origin → ordered list of `{username, savedAtMillis,
+  password}`. Applies the same canonicalisation and recency ordering as
+  `NativeCredentialStore`, so tests observe identical semantics. Never
+  touches the OS store. Used by tests and available to hosts.
+
+- **WebViewSavePasswordEvent** (new public final class,
+  `src/ca/weblite/webview/WebViewSavePasswordEvent.java`). Immutable.
+  Package-private constructor `WebViewSavePasswordEvent(WebViewComponent
+  source, String origin, String username, String password)`; `source`
+  non-null (NPE), other fields non-null coerced (empty string is the
+  no-value sentinel, matching the dialog POJOs). Accessors `source()`,
+  `origin()`, `username()`, `password()`. `toString()` redacts the
+  password.
+
+- **SavePasswordDisposition** (new public enum,
+  `src/ca/weblite/webview/SavePasswordDisposition.java`): `SAVE`,
+  `DONT_SAVE`.
+
+- **WebViewSavePasswordHandler** (new public `@FunctionalInterface`,
+  `src/ca/weblite/webview/WebViewSavePasswordHandler.java`). Single
+  abstract method `SavePasswordDisposition onLoginSubmitted(
+  WebViewSavePasswordEvent event)`, invoked on the EDT. Public static
+  constant `DEFAULT` — an instance whose `onLoginSubmitted` shows a
+  Swing confirm prompt ("Save password for `<origin>`?" plus the
+  username) modal to `SwingUtilities.getWindowAncestor(event.source())`,
+  returning `SAVE` on OK and `DONT_SAVE` on Cancel/close. Class Javadoc
+  documents EDT invocation, that the method must not block on
+  `evalAsync(...).get()` (EDT hazard), and exception isolation.
+
+- **WebViewPasswordCallback** (new public interface,
+  `src/ca/weblite/webview/WebViewPasswordCallback.java`). JNI-facing;
+  invoked from the native message thread. NOT `@FunctionalInterface`
+  (two methods).
+  - `void onLoginSubmitted(String frameUrl, String b64Username, String b64Password)`
+  - `void onFillRequested(String frameUrl)`
+  Class Javadoc: "Invoked from a native thread (AppKit main on macOS,
+  GTK main on Linux, WebView2 worker on Windows). `frameUrl` is the
+  committed URL of the frame that raised the message, read natively —
+  it is the trusted origin source and must not be substituted with any
+  JS-supplied value. Implementations route through `PasswordDispatcher`,
+  which marshals to the EDT / a worker. Not intended for application
+  code — customise via `WebViewComponent`."
+
+- **Origins** (new package-private final utility,
+  `src/ca/weblite/webview/Origins.java`). `static String canonical(String
+  urlOrOrigin)`: parse via `java.net.URI`, lower-case scheme + host,
+  drop the default port for the scheme (`http`→80, `https`→443, `ws`→80,
+  `wss`→443), keep any non-default explicit port, and return
+  `scheme + "://" + host[ + ":" + port]`. Returns `null` for opaque /
+  unparseable / hostless inputs (e.g. `about:blank`, `data:` URLs) so
+  callers skip them. No trailing slash, no path/query/fragment. Used by
+  both stores and by the dispatcher when converting a native `frameUrl`
+  to an origin key.
+
+- **PasswordDispatcher** (new public final class,
+  `src/ca/weblite/webview/PasswordDispatcher.java`). Per-component hub.
+  Public-because-cross-package (matches `DialogDispatcher`). Holds the
+  active store, save-handler, enabled flag; a single-thread executor for
+  store I/O; the shared `SHIM_JS` constant; the native-facing dispatch
+  methods; and the programmatic API the component delegates to.
+  Invariants: constructed once per component, lives for its lifetime;
+  `getStore()`/`getSaveHandler()` never null; `setStore(null)` /
+  `setSaveHandler(null)` restore defaults; disabled ⇒ automatic dispatch
+  is dropped but programmatic methods still work; disposed ⇒ automatic
+  dispatch is dropped.
+
+- **WebViewComponent** (modified;
+  `src/ca/weblite/webview/swing/WebViewComponent.java`). Gains:
+  - `protected final PasswordDispatcher passwordDispatcher = new PasswordDispatcher(this);`
+    (same eager-construction pattern as `dialogDispatcher`).
+  - the nine `final` public methods listed in R, each a thin delegation
+    to `passwordDispatcher`.
+
+- **EmbeddedWebView** / **OffscreenWebView** (modified). Each gains
+  `setPasswordCallback(WebViewPasswordCallback)` mirroring
+  `setDialogCallback`, anchoring the callback in `heap` and calling the
+  new JNI entry point.
+
+- **WebViewNative** (modified). Gains the two `..._set_password_callback`
+  natives and the four `webview_cred_store_*` static natives.
+
+- **`src_c/webview_embed.cpp`** (modified, macOS bodies + non-mac
+  stubs). Gains: `Engine::password_callback` jobject field; a dedicated
+  `WKScriptMessageHandler` registered under name `__webview_pw__` that
+  reads the committed frame URL and calls the Java callback;
+  `cocoa_set_password_callback`; the JNI bridge for the two callback
+  setters; and the macOS Keychain bodies for the four
+  `webview_cred_store_*` primitives (plus non-Apple stub bodies).
+
+- **`windows/webview_embed.cc`** (modified, stubs only in this canvas):
+  stub bodies for the four `webview_cred_store_*` primitives and the two
+  `..._set_password_callback` setters, so the JNI surface links on
+  Windows. Real Windows implementation is canvas 25.
+
+- **`build-mac.sh`** (modified): add `-framework Security`.
+
+- **WebViewPasswordDemo** (new demo,
+  `demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDemo.java`).
+
+- **README.md** (modified): "Password manager" subsection.
+
+- **Tests** (new, under `test/ca/weblite/webview/`):
+  `PasswordDispatcherTest`, `WebViewCredentialTest`,
+  `InMemoryCredentialStoreTest`, `OriginsTest`.
+
+```mermaid
+classDiagram
+direction TB
+
+class WebViewCredential {
+    +origin() String
+    +username() String
+    +password() String
+    +equals(Object) boolean
+    +toString() String
+}
+
+class WebViewCredentialStore {
+    <<interface>>
+    +save(WebViewCredential) void
+    +find(String) Optional~WebViewCredential~
+    +findAll(String) List~WebViewCredential~
+    +delete(String, String) boolean
+}
+
+class NativeCredentialStore {
+    +save(WebViewCredential) void
+    +find(String) Optional~WebViewCredential~
+    +findAll(String) List~WebViewCredential~
+    +delete(String, String) boolean
+}
+
+class InMemoryCredentialStore {
+    +save(WebViewCredential) void
+    +find(String) Optional~WebViewCredential~
+    +findAll(String) List~WebViewCredential~
+    +delete(String, String) boolean
+}
+
+class WebViewSavePasswordEvent {
+    +source() WebViewComponent
+    +origin() String
+    +username() String
+    +password() String
+}
+
+class SavePasswordDisposition {
+    <<enumeration>>
+    SAVE
+    DONT_SAVE
+}
+
+class WebViewSavePasswordHandler {
+    <<interface>>
+    +onLoginSubmitted(WebViewSavePasswordEvent) SavePasswordDisposition
+    +DEFAULT WebViewSavePasswordHandler$
+}
+
+class WebViewPasswordCallback {
+    <<interface>>
+    +onLoginSubmitted(String, String, String) void
+    +onFillRequested(String) void
+}
+
+class Origins {
+    +canonical(String) String$
+}
+
+class PasswordDispatcher {
+    -source WebViewComponent
+    -store WebViewCredentialStore
+    -handler WebViewSavePasswordHandler
+    -enabled boolean
+    -disposed boolean
+    +setEnabled(boolean) void
+    +isEnabled() boolean
+    +setStore(WebViewCredentialStore) void
+    +getStore() WebViewCredentialStore
+    +setHandler(WebViewSavePasswordHandler) void
+    +getHandler() WebViewSavePasswordHandler
+    +saveCredential(WebViewCredential) void
+    +getCredential(String) Optional~WebViewCredential~
+    +getCredentials(String) List~WebViewCredential~
+    +deleteCredential(String, String) boolean
+    +dispatchLoginSubmitted(String, String, String) void
+    +dispatchFillRequested(String) void
+    +disposeAll() void
+    +SHIM_JS String$
+}
+
+class WebViewComponent {
+    #passwordDispatcher PasswordDispatcher
+    +setPasswordManagerEnabled(boolean) WebViewComponent
+    +isPasswordManagerEnabled() boolean
+    +setCredentialStore(WebViewCredentialStore) WebViewComponent
+    +getCredentialStore() WebViewCredentialStore
+    +setSavePasswordHandler(WebViewSavePasswordHandler) WebViewComponent
+    +getSavePasswordHandler() WebViewSavePasswordHandler
+    +saveCredential(WebViewCredential) void
+    +getCredential(String) Optional~WebViewCredential~
+    +getCredentials(String) List~WebViewCredential~
+    +deleteCredential(String, String) boolean
+}
+
+class EmbeddedWebView {
+    +setPasswordCallback(WebViewPasswordCallback) EmbeddedWebView
+}
+
+class OffscreenWebView {
+    +setPasswordCallback(WebViewPasswordCallback) OffscreenWebView
+}
+
+WebViewCredentialStore <|.. NativeCredentialStore
+WebViewCredentialStore <|.. InMemoryCredentialStore
+WebViewComponent "1" *-- "1" PasswordDispatcher : owns
+PasswordDispatcher "1" --> "1" WebViewCredentialStore : reads/writes
+PasswordDispatcher "1" --> "1" WebViewSavePasswordHandler : asks
+PasswordDispatcher ..> WebViewSavePasswordEvent : constructs
+PasswordDispatcher ..> Origins : canonicalises via
+WebViewSavePasswordHandler ..> SavePasswordDisposition : returns
+NativeCredentialStore ..> Origins : canonicalises via
+InMemoryCredentialStore ..> Origins : canonicalises via
+EmbeddedWebView ..> WebViewPasswordCallback : invokes via JNI
+OffscreenWebView ..> WebViewPasswordCallback : invokes via JNI
+WebViewPasswordCallback ..> PasswordDispatcher : delegates to
+```
+
+## A · Approach
+
+1. **Two data flows, both non-blocking:**
+   - **Save (capture → prompt → store):** the injected script posts
+     `S|<b64user>|<b64pass>` on the native password channel. The native
+     message handler reads the committed frame URL and calls
+     `WebViewPasswordCallback.onLoginSubmitted(frameUrl, b64user, b64pass)`.
+     The component's callback adapter delegates to
+     `passwordDispatcher.dispatchLoginSubmitted(frameUrl, b64user, b64pass)`.
+     The dispatcher: drops if disposed / disabled; canonicalises
+     `frameUrl` via `Origins.canonical` (drops if null); base64url-decodes
+     the username/password; then `SwingUtilities.invokeLater` to build a
+     `WebViewSavePasswordEvent` and call the save-handler on the EDT
+     (exception-isolated). If the handler returns `SAVE`, the actual
+     `store.save(...)` is submitted to the dispatcher's single-thread
+     executor (off the EDT, off the engine UI thread).
+   - **Autofill (request → lookup → push):** the injected script posts
+     `F` when the DOM is ready with a login form. The native handler
+     calls `onFillRequested(frameUrl)` → `dispatchFillRequested(frameUrl)`.
+     The dispatcher: drops if disposed / disabled; canonicalises
+     `frameUrl`; submits a task to its executor that calls
+     `store.find(origin)`; on a hit, base64url-encodes username +
+     password and calls `source.eval("window.__webview_pw_fill__('"+b64u+"','"+b64p+"')")`.
+     `eval` enqueues onto the engine UI thread and returns immediately;
+     the injected entrypoint writes the fields and fires `input`/`change`.
+
+2. **Why non-blocking (`invokeLater`), not the dialog's `invokeAndWait`:**
+   A login submission has no synchronous JS contract — the form submits
+   and the page navigates whether or not we save. Parking the native
+   message thread on a modal Swing prompt (as `DialogDispatcher` does for
+   `alert`/`confirm`) would freeze the page mid-navigation and re-introduce
+   the exact `invokeAndWait` deadlock hazards the dialog Safeguards warn
+   about. So `PasswordDispatcher` is modelled on the non-blocking
+   `WebViewMouseDispatcher` / `ConsoleDispatcher` shape: fire-and-forget
+   to the EDT, and store I/O on a worker.
+
+3. **Why the origin is native-stamped and never JS-supplied
+   (security-critical):** the reserved password channel is a real
+   message channel the page can post to directly, bypassing our injected
+   script. If the origin were part of the JS payload, a page at
+   `evil.com` could post a forged `bank.com` origin and either read
+   `bank.com`'s credential (via a fill request) or poison it (via a save)
+   — a cross-origin credential-theft / injection attack. `location.origin`
+   read inside our script is unforgeable, but the *channel* is not, so we
+   do not rely on the script's honesty. The native handler reads the
+   committed frame URL (`message.frameInfo.request.URL` / `webView.URL`)
+   — the browser engine's own record of which document sent the message —
+   and that is the only origin Java ever uses. Any origin-like field in
+   the payload is ignored. The JS payload therefore carries only the
+   username/password (for save) or nothing (for fill request).
+
+4. **Why the fill entrypoint is write-only:**
+   `window.__webview_pw_fill__` is page-visible (any global function we
+   install is). It only *sets* field values and dispatches events; it
+   never reads or returns a credential. A malicious page calling it
+   directly can only fill its own form with attacker-chosen text — a
+   no-op threat. The credential only ever travels Java→page for the
+   single origin-matched entry Java chose to send, so the page cannot use
+   the entrypoint to extract another origin's credential.
+
+5. **Origin canonicalisation (`Origins.canonical`):** `scheme://host`
+   plus a port only when non-default for the scheme; scheme + host
+   lower-cased; no path/query/fragment; `null` for opaque/hostless URLs.
+   This single function is the sole definition of "origin" used by both
+   stores and by the dispatcher, so `https://example.com`,
+   `https://example.com:443`, and `https://EXAMPLE.com/login?x=1` all key
+   to `https://example.com`, while `http://example.com` and
+   `https://example.com:8443` are distinct (satisfies AC6/AC7). Programmatic
+   `saveCredential`/`getCredential` inputs pass through the same function,
+   so a host that stores `https://svc.example.com` and looks up
+   `https://svc.example.com/` gets a hit.
+
+6. **Recency for `find` ordering (AC11):** every stored record carries a
+   `savedAtMillis` set at save time (from `System.currentTimeMillis()`),
+   stored alongside the password in the secret store's value blob so it is
+   uniform across all three platforms regardless of native metadata.
+   `findAll` returns records sorted by `savedAtMillis` descending;
+   `find` returns the first. Ties (same millis) break by username
+   ascending for determinism.
+
+7. **macOS Keychain item model (`SecItem*`):** one
+   `kSecClassGenericPassword` item per `{origin, username}`:
+   - `kSecAttrService` = the library namespace constant
+     `"ca.weblite.webview.passwords"` (isolates from Safari's iCloud
+     Keychain items).
+   - `kSecAttrAccount` = `base64url(origin) + "|" + base64url(username)`
+     (collision-free; the `|` separator never appears in base64url).
+   - `kSecValueData` = UTF-8 of `savedAtMillis + "\n" + password`
+     (millis has no newline; everything after the first newline is the
+     password, so passwords may contain any character including
+     newlines).
+   - `kSecAttrSynchronizable = kCFBooleanFalse` (local item; do not push
+     the library's own items into iCloud Keychain sync).
+   - **save** = query exact account; `SecItemUpdate` the value if present
+     else `SecItemAdd`.
+   - **find** = query `service` + `kSecMatchLimitAll` +
+     `kSecReturnAttributes` + `kSecReturnData`, filter accounts whose
+     decoded origin equals the target, decode username/millis/password,
+     return flat triples sorted by millis desc.
+   - **delete** = `SecItemDelete` with exact account.
+   All four run on the caller's thread (the dispatcher's executor for
+   automatic paths; the caller's thread for the programmatic API — a
+   Keychain call is a fast local IPC, acceptable to run synchronously on
+   the programmatic path so `saveCredential` then `getCredential`
+   round-trips deterministically, per AC8).
+
+8. **macOS injection + capture wiring:** the shared `SHIM_JS` is injected
+   as a document-start user script via the existing `addOnBeforeLoad`
+   path (`cocoa_init_script` → `WKUserScript` at document-start). A
+   dedicated `WKScriptMessageHandler` is registered on the existing
+   `e->manager` (`WKUserContentController`) under name `__webview_pw__`;
+   its `didReceiveScriptMessage:` reads `message.body` (an `NSString`),
+   reads the committed frame URL from `message.frameInfo.request.URL`
+   (fallback `message.webView.URL`), parses the leading tag (`S`/`F`),
+   and invokes the Java callback. Registration and teardown mirror the
+   existing `"external"` handler (`addScriptMessageHandler:name:` at
+   engine create; `removeScriptMessageHandlerForName:` at destroy).
+
+9. **JNI mechanics** copy the `fire_dialog_*` helpers verbatim in shape:
+   defensive `GetEnv`/`AttachCurrentThreadAsDaemon` with symmetric
+   detach; per-call `GetObjectClass` + `GetMethodID`; `Call*Method`; then
+   mandatory `ExceptionCheck` → `ExceptionDescribe` → `ExceptionClear`.
+   `Engine::password_callback` is a global ref created in
+   `cocoa_set_password_callback` (deleting any prior ref) and deleted in
+   the engine destructor.
+
+10. **No JSON parser** (the project has none). The JS→native payload is
+    the pipe-tagged string `S|<b64user>|<b64pass>` or `F`; the native
+    handler splits on the first two `|` and passes the base64url
+    substrings through to Java unchanged. Java (not native) base64url
+    decodes, so native stays free of base64 code. The Java→JS fill call
+    passes base64url strings that JS `atob`-decodes (after url→standard
+    fixup).
+
+11. **Enable/disable and injection:** `SHIM_JS` is injected
+    unconditionally (once, via `addOnBeforeLoad`, replayed per document).
+    The enabled flag is enforced entirely in `PasswordDispatcher`:
+    when disabled, `dispatchLoginSubmitted` / `dispatchFillRequested`
+    return immediately (no prompt, no lookup, no fill), while the
+    programmatic methods ignore the flag. Toggling at runtime therefore
+    takes effect on the next submit / next page load with no re-injection.
+
+12. **Store swap / handler swap** read the `volatile` fields per
+    dispatch, exactly like `DialogDispatcher`'s handler field, so a
+    mid-session `setCredentialStore(...)` affects the next operation.
+
+13. **Demo strategy:** `WebViewPasswordDemo` loads an inline login page
+    (username + password + submit) via `addOnBeforeLoad` + `setUrl`. A
+    `JComboBox` switches store mode (Native Keychain / in-memory) and a
+    checkbox toggles `setPasswordManagerEnabled`. The demo prints capture
+    events (with the password redacted) and provides buttons for
+    programmatic `saveCredential` / `getCredential` / `deleteCredential`
+    so AC8–AC12 are demonstrable interactively. It sets
+    `JPopupMenu.setDefaultLightWeightPopupEnabled(false)` and the tooltip
+    equivalent at startup (heavyweight popup prerequisite).
+
+## S · Structure
+
+### Inheritance Relationships
+1. `WebViewCredentialStore` is a public interface; `NativeCredentialStore`
+   and `InMemoryCredentialStore` are public final classes implementing it.
+2. `WebViewSavePasswordHandler` is a public `@FunctionalInterface` with a
+   single abstract method and a `DEFAULT` static constant.
+3. `WebViewPasswordCallback` is a public interface (two methods; NOT
+   `@FunctionalInterface`).
+4. `WebViewCredential`, `WebViewSavePasswordEvent` are public final
+   value classes (no inheritance), matching the `ConsoleMessage` /
+   `WebViewAlertEvent` POJO house style.
+5. `SavePasswordDisposition` is a public enum.
+6. `Origins` is a package-private final utility (private constructor).
+7. `PasswordDispatcher` is a public final class (matches
+   `DialogDispatcher`).
+8. `WebViewComponent` (existing abstract class) gains a
+   `PasswordDispatcher` field and nine `final` methods; no change to its
+   abstract surface, both subclasses inherit the methods.
+9. `EmbeddedWebView` / `OffscreenWebView` (existing concrete classes)
+   each gain one `setPasswordCallback` method.
+
+### Dependencies
+1. `WebViewSavePasswordHandler.DEFAULT` → `javax.swing.JOptionPane`,
+   `javax.swing.SwingUtilities.getWindowAncestor`, `java.awt.Window`.
+2. `PasswordDispatcher` → `WebViewCredentialStore`,
+   `WebViewSavePasswordHandler`, `WebViewSavePasswordEvent`, `Origins`,
+   `javax.swing.SwingUtilities`, `java.util.Base64`,
+   `java.util.concurrent.Executors` (single-thread executor),
+   `WebViewComponent` (for `eval` on the fill path).
+3. `NativeCredentialStore` / `InMemoryCredentialStore` → `Origins`,
+   `WebViewCredential`, `java.util.Base64`; `NativeCredentialStore` →
+   `WebViewNative.webview_cred_store_*`.
+4. `WebViewComponent` → `PasswordDispatcher` and the public password
+   types.
+5. `WebViewHeavyweightComponent.createPeer()` → `EmbeddedWebView`,
+   `PasswordDispatcher`, `WebViewPasswordCallback`. Injects
+   `PasswordDispatcher.SHIM_JS` via `embedded.addOnBeforeLoad(...)` and
+   installs a `WebViewPasswordCallback` adapter delegating to
+   `passwordDispatcher.dispatch*`.
+6. `WebViewLightweightComponent.addNotify()` → same shape via
+   `OffscreenWebView` (native no-op on macOS; live on Linux in canvas 24).
+7. `EmbeddedWebView.setPasswordCallback` →
+   `WebViewNative.webview_embed_set_password_callback`;
+   `OffscreenWebView.setPasswordCallback` →
+   `WebViewNative.webview_offscreen_set_password_callback`.
+8. `NativeCredentialStore` → the four static `webview_cred_store_*`
+   natives → macOS Keychain (`SecItem*`) in `webview_embed.cpp`.
+9. macOS `__webview_pw__` message handler → `Engine::password_callback`
+   → JNI `CallVoidMethod` → `WebViewPasswordCallback.on*` →
+   `PasswordDispatcher.dispatch*` → EDT (prompt) / executor (store) /
+   `eval` (fill).
+
+### Layered Architecture
+1. **Native engine layer** (`src_c/webview_embed.cpp`): the
+   `__webview_pw__` `WKScriptMessageHandler`, `cocoa_set_password_callback`,
+   the callback-setter JNI bridges, and the macOS Keychain bodies of the
+   four store primitives (plus non-Apple stubs). Engine struct gains
+   `password_callback`.
+2. **JNI surface** (`WebViewNative`): two callback-setter natives + four
+   static store natives.
+3. **Engine wrapper layer** (`EmbeddedWebView` / `OffscreenWebView`):
+   `setPasswordCallback` anchoring in `heap`.
+4. **Store layer** (`NativeCredentialStore`, `InMemoryCredentialStore`,
+   `Origins`): the `WebViewCredentialStore` implementations + origin
+   canonicalisation.
+5. **Dispatcher layer** (`PasswordDispatcher`): per-component hub;
+   enabled flag; EDT marshaling (non-blocking); worker executor for store
+   I/O; the shared `SHIM_JS`; programmatic API.
+6. **Component API layer** (`WebViewComponent`): the nine `final`
+   password methods; owns the dispatcher.
+7. **Public contract layer** (`WebViewCredential`,
+   `WebViewCredentialStore`, `WebViewSavePasswordHandler`,
+   `WebViewSavePasswordEvent`, `SavePasswordDisposition`,
+   `WebViewPasswordCallback`).
+8. **Wiring layer** (`WebViewHeavyweightComponent.createPeer()`,
+   `WebViewLightweightComponent.addNotify()`): inject `SHIM_JS`, install
+   the callback bridge.
+9. **Demo layer** (`demos/WebViewPasswordDemo/`).
+
+## O · Operations
+
+### 1. Create Utility — Origins
+File: `src/ca/weblite/webview/Origins.java`
+
+1. Responsibility: the single definition of "origin" (scheme+host+port,
+   default port dropped) used everywhere in the feature.
+2. Package-private final class, private constructor.
+3. `static String canonical(String urlOrOrigin)`:
+   - Logic: if input null/blank → return null. Parse with `new
+     java.net.URI(input.trim())`. Get `scheme` and `host`; if either
+     null/empty → return null (opaque/hostless, e.g. `about:blank`,
+     `data:`). Lower-case scheme and host. Determine port: `uri.getPort()`
+     (`-1` when absent). Compute the default port for the scheme
+     (`http`/`ws`→80, `https`/`wss`→443, else -1). If port == -1 or port
+     == default → omit; else append `":" + port`. Return
+     `scheme + "://" + host` (+ optional port). Catch
+     `URISyntaxException` → return null.
+4. `static String defaultPort(String scheme)` (private helper) as above.
+5. No logging.
+
+### 2. Create Value Object — WebViewCredential
+File: `src/ca/weblite/webview/WebViewCredential.java`
+
+1. Responsibility: immutable `{origin, username, password}` carrier.
+2. Public constructor `WebViewCredential(String origin, String username,
+   String password)`: null-check all three (NPE naming the parameter);
+   store in `final` ivars verbatim (no normalisation here).
+3. Accessors `origin()`, `username()`, `password()` (no-`get` style).
+4. `equals(Object)` / `hashCode()` on `origin` + `username` only
+   (password excluded, so a re-saved password is "equal" for
+   set/dedup purposes).
+5. `toString()` → `"WebViewCredential[origin=" + origin + ", username="
+   + username + ", password=***]"`. Never emit the password.
+
+### 3. Create Value Object — WebViewSavePasswordEvent
+File: `src/ca/weblite/webview/WebViewSavePasswordEvent.java`
+
+1. Responsibility: immutable captured-submission event handed to the
+   save-handler.
+2. Package-private constructor `(WebViewComponent source, String origin,
+   String username, String password)`: null-check `source` (NPE
+   `"source"`); coerce null `origin`/`username`/`password` to empty.
+3. Accessors `source()`, `origin()`, `username()`, `password()`.
+4. `toString()` redacts the password (as Operation 2).
+
+### 4. Create Enum — SavePasswordDisposition
+File: `src/ca/weblite/webview/SavePasswordDisposition.java`
+
+1. Public enum with constants `SAVE`, `DONT_SAVE`. Javadoc: the
+   save-handler's decision.
+
+### 5. Create Handler Interface — WebViewSavePasswordHandler
+File: `src/ca/weblite/webview/WebViewSavePasswordHandler.java`
+
+1. Public `@FunctionalInterface`.
+2. `SavePasswordDisposition onLoginSubmitted(WebViewSavePasswordEvent event)`
+   — invoked on the EDT.
+3. Public static constant `DEFAULT`:
+   - `WebViewSavePasswordHandler DEFAULT = event -> { ... }`.
+   - Logic: `Window host = SwingUtilities.getWindowAncestor(event.source());`
+     `String msg = "Save the password for " + event.origin() + "?\n\nUsername: " + event.username();`
+     `int r = JOptionPane.showConfirmDialog(host, msg, "Save password?", JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);`
+     `return r == JOptionPane.OK_OPTION ? SavePasswordDisposition.SAVE : SavePasswordDisposition.DONT_SAVE;`.
+   - Never include the password in the dialog text.
+4. Class Javadoc: EDT invocation; must return promptly and must not block
+   on `evalAsync(...).get()`; exceptions are caught by the dispatcher and
+   forwarded to the default uncaught-exception handler; a caller that
+   wants no UI overrides this to return a disposition directly; macOS
+   coverage this iteration (forward-ref canvases 24/25 for Linux/Windows).
+
+### 6. Create Store Interface — WebViewCredentialStore
+File: `src/ca/weblite/webview/WebViewCredentialStore.java`
+
+1. Public interface with the four methods from E. Method Javadoc: `save`
+   is upsert on `{origin, username}`; `find` returns the
+   most-recently-saved for the origin; `findAll` is most-recent-first and
+   unmodifiable; `delete` returns whether a record was removed. Implementations
+   must be safe to call from any thread and should not throw on a missing
+   backend (return empty / false).
+
+### 7. Create Store — NativeCredentialStore
+File: `src/ca/weblite/webview/NativeCredentialStore.java`
+
+1. Responsibility: default OS-backed store via the static JNI primitives.
+2. Public final class; `static final String SERVICE = "ca.weblite.webview.passwords";`.
+3. `save(WebViewCredential c)`:
+   - `String origin = Origins.canonical(c.origin());` if null → return
+     (nothing to key on).
+   - `WebViewNative.webview_cred_store_save(SERVICE, origin, c.username(), c.password(), System.currentTimeMillis());`
+     Wrap in try/catch(Throwable) → swallow (graceful; e.g. store
+     unavailable). Never log the password.
+4. `find(String origin)`: `return findAll(origin).stream().findFirst();`.
+5. `findAll(String origin)`:
+   - `String o = Origins.canonical(origin);` if null → return empty list.
+   - `String[] flat = WebViewNative.webview_cred_store_find(SERVICE, o);`
+     (try/catch → empty). Iterate in triples `[username, millisStr,
+     password]`; build `WebViewCredential(o, username, password)` (the
+     canonical origin); collect with their `millis`. Sort by millis desc,
+     then username asc. Return `Collections.unmodifiableList`.
+   - Native already returns most-recent-first, but Java re-sorts so the
+     ordering contract holds identically across all three platforms.
+6. `delete(String origin, String username)`:
+   - canonicalise; if null → false; else
+     `return WebViewNative.webview_cred_store_delete(SERVICE, o, username);`
+     (try/catch → false).
+7. No password in any log / `toString`.
+
+### 8. Create Store — InMemoryCredentialStore
+File: `src/ca/weblite/webview/InMemoryCredentialStore.java`
+
+1. Responsibility: OS-free store with identical semantics, for tests /
+   hosts.
+2. Public final class. Backing: `ConcurrentHashMap<String,
+   List<Rec>>` keyed by canonical origin, where `Rec` is a private static
+   `{username, savedAtMillis, password}`. All mutations synchronised on
+   the per-origin list.
+3. `save`: canonicalise origin (null → return); remove any existing rec
+   with equal username; add `{username, now, password}`.
+4. `findAll`: canonicalise; copy the list; sort millis desc then username
+   asc; map to `WebViewCredential(origin, username, password)`;
+   unmodifiable.
+5. `find`: first of `findAll`.
+6. `delete`: canonicalise; remove rec by username; return whether
+   removed.
+
+### 9. Create JNI Callback Interface — WebViewPasswordCallback
+File: `src/ca/weblite/webview/WebViewPasswordCallback.java`
+
+1. Public interface, two `void` methods:
+   `onLoginSubmitted(String frameUrl, String b64Username, String b64Password)`,
+   `onFillRequested(String frameUrl)`.
+2. Class Javadoc as in E (native thread; `frameUrl` is the trusted
+   native-stamped origin source; not for application code).
+
+### 10. Create Dispatcher — PasswordDispatcher
+File: `src/ca/weblite/webview/PasswordDispatcher.java`
+
+1. Responsibility: per-component hub — holds store / handler / enabled;
+   receives native captures + fill requests; runs the save prompt on the
+   EDT (non-blocking); runs store I/O on a worker; pushes autofill via
+   `eval`; exposes the programmatic API; owns `SHIM_JS`.
+2. Public final class.
+3. Fields:
+   - `private final WebViewComponent source;`
+   - `private volatile WebViewCredentialStore store = new NativeCredentialStore();`
+   - `private volatile WebViewSavePasswordHandler handler = WebViewSavePasswordHandler.DEFAULT;`
+   - `private volatile boolean enabled = true;`
+   - `private volatile boolean disposed = false;`
+   - `private final java.util.concurrent.ExecutorService io = Executors.newSingleThreadExecutor(r -> { Thread t = new Thread(r, "webview-password-io"); t.setDaemon(true); return t; });`
+4. Constructor `(WebViewComponent source)`: null-check; store.
+5. Setters/getters:
+   - `setEnabled(boolean)`, `isEnabled()`.
+   - `setStore(WebViewCredentialStore s)`: `store = (s == null) ? new NativeCredentialStore() : s;`.
+   - `getStore()` (never null).
+   - `setHandler(WebViewSavePasswordHandler h)`: `handler = (h == null) ? WebViewSavePasswordHandler.DEFAULT : h;`.
+   - `getHandler()` (never null).
+6. Programmatic API (run synchronously on the caller thread so
+   round-trips are deterministic — AC8/AC9/AC10/AC11):
+   - `saveCredential(WebViewCredential c)`: null-check; `store.save(c)`.
+   - `getCredential(String origin)`: `return store.find(origin);`.
+   - `getCredentials(String origin)`: `return store.findAll(origin);`.
+   - `deleteCredential(String origin, String username)`: `return store.delete(origin, username);`.
+7. Native-facing dispatch:
+   - `dispatchLoginSubmitted(String frameUrl, String b64User, String b64Pass)`:
+     - if `disposed || !enabled` → return.
+     - `String origin = Origins.canonical(frameUrl);` if null → return.
+     - decode `user`/`pass` via `base64UrlDecode` (private helper; on
+       `IllegalArgumentException` → return).
+     - `SwingUtilities.invokeLater(() -> runPrompt(origin, user, pass));`
+   - `private void runPrompt(String origin, String user, String pass)`
+     (on EDT):
+     - re-check `disposed || !enabled` → return.
+     - `WebViewSavePasswordEvent ev = new WebViewSavePasswordEvent(source, origin, user, pass);`
+     - `SavePasswordDisposition d;` `try { d = handler.onLoginSubmitted(ev); } catch (Throwable t) { forward(t); return; }`
+     - if `d == SavePasswordDisposition.SAVE` → `io.execute(() -> safeSave(new WebViewCredential(origin, user, pass)));`
+   - `dispatchFillRequested(String frameUrl)`:
+     - if `disposed || !enabled` → return.
+     - `String origin = Origins.canonical(frameUrl);` if null → return.
+     - `io.execute(() -> doFill(origin));`
+   - `private void doFill(String origin)` (on io thread):
+     - `Optional<WebViewCredential> c;` `try { c = store.find(origin); } catch (Throwable t) { forward(t); return; }`
+     - if absent → return (AC19).
+     - `String js = "window.__webview_pw_fill__('" + base64UrlEncode(c.username()) + "','" + base64UrlEncode(c.password()) + "')";`
+     - `try { source.eval(js); } catch (Throwable t) { forward(t); }` — never log `js` (it embeds the password).
+   - `private void safeSave(WebViewCredential c)`: `try { store.save(c); } catch (Throwable t) { forward(t); }`.
+8. `disposeAll()`: `disposed = true; io.shutdownNow();` (idempotent).
+9. Private helpers: `base64UrlEncode(String)` /
+   `base64UrlDecode(String)` (UTF-8 ⇄ `Base64.getUrlEncoder().withoutPadding()`
+   / `Base64.getUrlDecoder()`); `forward(Throwable t)` →
+   `Thread.getDefaultUncaughtExceptionHandler().uncaughtException(Thread.currentThread(), t)`
+   guarded for a null handler.
+10. `public static final String SHIM_JS = "..."` — see Operation 11.
+
+### 11. Author the Shared Detection/Fill Script — PasswordDispatcher.SHIM_JS
+File: `src/ca/weblite/webview/PasswordDispatcher.java` (string constant)
+
+1. An IIFE, guarded so it installs at most once per document
+   (`if (window.__webview_pw_installed__) return; window.__webview_pw_installed__ = true;`).
+2. `post(payload)` helper — sends to the native `__webview_pw__` channel,
+   branching per engine (all branches present so the one string works on
+   every backend; only the matching one exists at runtime):
+   - WebKit (macOS/Linux): `if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.__webview_pw__) window.webkit.messageHandlers.__webview_pw__.postMessage(payload);`
+   - WebView2 (Windows): `else if (window.chrome && window.chrome.webview) window.chrome.webview.postMessage('__webview_pw__:' + payload);`
+3. base64url encode/decode helpers in JS (`b64e`/`b64d`) over UTF-8
+   (`encodeURIComponent`/`unescape` or `TextEncoder`), url-alphabet,
+   padding-tolerant to match Java's `Base64.getUrlDecoder`.
+4. `findFields()` → `{user, pass}` or null:
+   - `pass` = first `input[type=password]` in the document.
+   - if none → return null (a page with no password field never triggers
+     save/fill — Safeguard for the "search form must not prompt" rule).
+   - `user` = within `pass.form` if present: the text/email/tel input
+     immediately preceding `pass` in the form's controls, else the form's
+     first text/email/tel input; if no form: the nearest preceding
+     text/email/tel input in document order. May be null (password-only
+     forms) — then username is treated as empty string.
+5. Save capture:
+   - Attach a capturing `submit` listener on `document` that, when the
+     submitted form contains the password field, reads `user?.value ?? ''`
+     and `pass.value`, and if `pass.value` is non-empty calls
+     `post('S|' + b64e(user) + '|' + b64e(passVal))`.
+   - Best-effort SPA: a capturing `click` listener on `document` for
+     `button, input[type=submit], [role=button]` that, if a password
+     field currently has a non-empty value and there is no enclosing
+     `<form>`, posts the same `S|...`. Debounce so a submit + click do
+     not double-post within a short window.
+6. Fill request:
+   - On `DOMContentLoaded` (or immediately if already interactive), if
+     `findFields()` is non-null, call `post('F')`.
+   - Arm a `MutationObserver` on `document.documentElement`
+     (`childList+subtree`) that, on the first later appearance of a
+     password field (when none existed at ready time), posts `F` once,
+     then disconnects. Also disconnect after a bounded timeout
+     (e.g. 10s) so it never observes indefinitely.
+7. Fill entrypoint:
+   - `window.__webview_pw_fill__ = function(b64u, b64p) { var f = findFields(); if (!f) return; if (f.user && b64u) setVal(f.user, b64d(b64u)); if (f.pass) setVal(f.pass, b64d(b64p)); };`
+   - `setVal(el, v)` sets `el.value = v` via the native value setter
+     (`Object.getOwnPropertyDescriptor(HTMLInputElement.prototype,'value').set.call(el, v)`)
+     then dispatches `new Event('input',{bubbles:true})` and
+     `new Event('change',{bubbles:true})` so React/Vue-style controlled
+     inputs observe the change (AC5).
+8. Wrap everything in `try/catch` so a page that has frozen prototypes
+   or unusual DOM never throws out of the injected script.
+
+### 12. Extend WebViewComponent Base
+File: `src/ca/weblite/webview/swing/WebViewComponent.java`
+
+1. Add field (next to `dialogDispatcher`):
+   `protected final PasswordDispatcher passwordDispatcher = new PasswordDispatcher(this);`.
+2. Add nine `final` methods, each delegating:
+   - `setPasswordManagerEnabled(boolean e)` → `passwordDispatcher.setEnabled(e); return this;`
+   - `isPasswordManagerEnabled()` → `passwordDispatcher.isEnabled();`
+   - `setCredentialStore(WebViewCredentialStore s)` → `passwordDispatcher.setStore(s); return this;`
+   - `getCredentialStore()` → `passwordDispatcher.getStore();`
+   - `setSavePasswordHandler(WebViewSavePasswordHandler h)` → `passwordDispatcher.setHandler(h); return this;`
+   - `getSavePasswordHandler()` → `passwordDispatcher.getHandler();`
+   - `saveCredential(WebViewCredential c)` → `passwordDispatcher.saveCredential(c);`
+   - `getCredential(String origin)` → `passwordDispatcher.getCredential(origin);`
+   - `getCredentials(String origin)` → `passwordDispatcher.getCredentials(origin);`
+   - `deleteCredential(String origin, String u)` → `passwordDispatcher.deleteCredential(origin, u);`
+3. In the existing `dispose()` path, call `passwordDispatcher.disposeAll()`
+   alongside the existing `dialogDispatcher.disposeAll()` (both swing
+   subclasses' dispose already funnels through the base or calls the
+   dispatchers — mirror whatever the dialog dispatcher does).
+4. Javadoc on each method: the manager is enabled by default; origin is
+   canonical scheme+host+port; autofill is exact-origin; passwords go to
+   the OS store; macOS coverage this iteration.
+
+### 13. Extend EmbeddedWebView with setPasswordCallback
+File: `src/ca/weblite/webview/EmbeddedWebView.java`
+
+1. `public EmbeddedWebView setPasswordCallback(WebViewPasswordCallback cb)`
+   mirroring `setDialogCallback` (line 566): anchor `cb` in `heap`
+   (the `IdentityHashMap` that keeps callbacks alive against the native
+   global ref), then call
+   `WebViewNative.webview_embed_set_password_callback(peer, cb);`. Return
+   `this`.
+
+### 14. Extend OffscreenWebView with setPasswordCallback
+File: `src/ca/weblite/webview/OffscreenWebView.java`
+
+1. `public OffscreenWebView setPasswordCallback(WebViewPasswordCallback cb)`
+   mirroring `OffscreenWebView.setDialogCallback` (line 431): anchor in
+   `heap`, call `WebViewNative.webview_offscreen_set_password_callback(peer, cb);`.
+
+### 15. Extend WebViewNative with the new natives
+File: `src/ca/weblite/webview/WebViewNative.java`
+
+1. Add two callback-setter declarations (after the dialog ones):
+   - `native static void webview_embed_set_password_callback(long w, WebViewPasswordCallback cb);`
+   - `native static void webview_offscreen_set_password_callback(long peer, WebViewPasswordCallback cb);`
+2. Add four static store declarations:
+   - `native static boolean webview_cred_store_save(String service, String origin, String username, String password, long savedAtMillis);`
+   - `native static String[] webview_cred_store_find(String service, String origin);`
+   - `native static boolean webview_cred_store_delete(String service, String origin, String username);`
+   - `native static boolean webview_cred_store_available();`
+3. Class-level note that headers are javah-optional; the mangled
+   `JNIEXPORT` functions are implemented directly in the native files.
+
+### 16. Implement macOS native — password channel + Keychain store
+File: `src_c/webview_embed.cpp` (guarded `#if defined(WEBVIEW_COCOA)`)
+
+1. `Engine` struct: add `jobject password_callback = nullptr;` alongside
+   `dialog_callback`.
+2. `cocoa_set_password_callback(Engine* e, JNIEnv* env, jobject cb)`:
+   delete any prior global ref; `e->password_callback = cb ? env->NewGlobalRef(cb) : nullptr;`
+   (mirrors `cocoa_set_dialog_callback`).
+3. Register the message handler: where `"external"` is registered on
+   `e->manager` (~`:5117`), also
+   `addScriptMessageHandler:name:@"__webview_pw__"` on the same
+   controller, using a handler class that implements
+   `WKScriptMessageHandler`. In `userContentController:didReceiveScriptMessage:`:
+   - `id body = msg.body;` → `NSString`. If not a string → return.
+   - Read the committed frame URL: `id frameInfo = [msg frameInfo]; id req = [frameInfo request]; id url = [req URL]; NSString* frameUrl = [url absoluteString];` with a fallback to `[[msg webView] URL] absoluteString]` when nil. (KVC/`@try` guard where a selector may be nil on older SDKs.)
+   - Parse the tag: first char `'S'` → split the remainder on `'|'` into
+     `b64user`, `b64pass`; call `fire_password_submitted(e, frameUrl, b64user, b64pass)`. First char `'F'` → `fire_password_fill_requested(e, frameUrl)`.
+4. `fire_password_submitted` / `fire_password_fill_requested`: copy the
+   `fire_dialog_*` mechanics — defensive attach, `GetObjectClass` +
+   `GetMethodID("onLoginSubmitted","(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V")`
+   / `("onFillRequested","(Ljava/lang/String;)V")`, `CallVoidMethod`,
+   `ExceptionCheck/Describe/Clear`, symmetric detach. No-op if
+   `password_callback` is null.
+5. Teardown: in the destroy path, `removeScriptMessageHandlerForName:@"__webview_pw__"`
+   before releasing, and `DeleteGlobalRef(password_callback)`.
+6. JNI bridges (mangled names) for
+   `webview_embed_set_password_callback` (→ `cocoa_set_password_callback`)
+   and `webview_offscreen_set_password_callback` (no-op stub on macOS).
+7. Keychain store — implement the four primitives (compiled on Apple):
+   - Helper `account = b64url(origin) + "|" + b64url(username)` and its
+     inverse; `service` = the jstring arg.
+   - `webview_cred_store_save`: build a query dict
+     (`kSecClass=kSecClassGenericPassword`, `kSecAttrService`,
+     `kSecAttrAccount`); `SecItemCopyMatching` to test existence; value =
+     UTF-8 of `millis + "\n" + password`; if present `SecItemUpdate`
+     (set `kSecValueData`), else `SecItemAdd` (add `kSecValueData` +
+     `kSecAttrSynchronizable=kCFBooleanFalse`). Return `errSecSuccess`.
+   - `webview_cred_store_find`: query `service` + `kSecMatchLimitAll` +
+     `kSecReturnAttributes=true` + `kSecReturnData=true`; iterate the
+     result array; for each item decode `kSecAttrAccount` → origin,
+     username; if origin == target, split `kSecValueData` on first `\n`
+     into millis + password; collect `[username, millis, password]`.
+     Return a `jobjectArray` of the flat triples (Java sorts). Empty
+     array on `errSecItemNotFound`.
+   - `webview_cred_store_delete`: `SecItemDelete` with exact account;
+     return `errSecSuccess || errSecItemNotFound ? (removed?)` — return
+     `true` only when an item was actually deleted (`errSecSuccess`).
+   - `webview_cred_store_available`: return `true`.
+   - All string↔`CFString` conversions via `CFStringCreateWithCString`
+     UTF-8; release every created CF object; no NSLog of passwords.
+8. Non-Apple compilation of this file (`#else`): stub bodies for the four
+   store primitives (`false` / empty `jobjectArray` / `false`) and the
+   two setters, so the Linux build of `webview_embed.cpp` links until
+   canvas 24 replaces them.
+
+### 17. Windows native stubs
+File: `windows/webview_embed.cc`
+
+1. Add stub `JNIEXPORT` bodies for `webview_embed_set_password_callback`,
+   `webview_offscreen_set_password_callback`, and the four
+   `webview_cred_store_*` primitives (`false` / empty / `false`) so the
+   Windows binary links. Real implementation is canvas 25.
+
+### 18. Wire the bridge — WebViewHeavyweightComponent
+File: `src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java`
+
+1. In `createPeer()`, alongside the existing console / dialog installs
+   (after `embedded.setDialogCallback(...)`, ~`:613`):
+   - `embedded.addOnBeforeLoad(PasswordDispatcher.SHIM_JS);`
+   - `embedded.setPasswordCallback(new WebViewPasswordCallback() {
+        public void onLoginSubmitted(String u, String user, String pass) { passwordDispatcher.dispatchLoginSubmitted(u, user, pass); }
+        public void onFillRequested(String u) { passwordDispatcher.dispatchFillRequested(u); }
+     });`
+   - (first param name `u` = the native-stamped frameUrl.)
+
+### 19. Wire the bridge — WebViewLightweightComponent
+File: `src/ca/weblite/webview/swing/WebViewLightweightComponent.java`
+
+1. In `addNotify()`, in the `engine != null` branch, after the existing
+   dialog install (~`:290`):
+   - `engine.addOnBeforeLoad(PasswordDispatcher.SHIM_JS);`
+   - `engine.setPasswordCallback(...)` delegating to `passwordDispatcher`
+     as in Operation 18.
+2. On macOS the offscreen native setter is a no-op, so this compiles and
+   runs harmlessly; it goes live on Linux in canvas 24.
+
+### 20. Build script — link Security.framework
+File: `build-mac.sh`
+
+1. Add `-framework Security` to the `c++ ... -framework WebKit -framework
+   Cocoa -framework QuartzCore` line.
+
+### 21. Create Demo — WebViewPasswordDemo
+File: `demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDemo.java`
+
+1. Startup: `JPopupMenu.setDefaultLightWeightPopupEnabled(false);` and
+   `ToolTipManager.sharedInstance().setLightWeightPopupEnabled(false);`.
+2. Build a `WebViewComponent.create()`, load an inline login page
+   (`addOnBeforeLoad` a `document.write`-style page or `setUrl` a
+   `data:`/`about:blank`+injected form) with a username input, a
+   `<input type=password>`, and a submit button, at a stable http(s)-ish
+   origin (use a small local `data:` or file page; document that the
+   demo's "origin" is whatever the page loads as).
+3. Controls: a store-mode `JComboBox` (`Native Keychain` /
+   `In-memory`) calling `setCredentialStore(...)`; an "Enabled"
+   `JCheckBox` calling `setPasswordManagerEnabled(...)`; buttons
+   `Save (programmatic)`, `Get`, `Delete` that call the programmatic API
+   for a fixed origin; a log pane that prints capture events and results
+   with passwords redacted.
+4. Comment at top: exercises AC1–AC14 interactively; passwords are never
+   printed.
+
+### 22. Update README
+File: `README.md`
+
+1. New "Password manager" subsection (sibling of "Browser-initiated
+   dialogs"): the `setPasswordManagerEnabled` default-on switch; the
+   store + save-handler seams; origin = scheme+host+port and exact-origin
+   autofill; that credentials live only in the OS store (Keychain on
+   macOS this iteration; libsecret / Credential Manager to follow); the
+   security note that an autofilled value is readable by page scripts
+   (browser-parity) and that the library never logs or files passwords;
+   the macOS-only coverage caveat with a forward reference to the Linux /
+   Windows canvases.
+2. List `WebViewPasswordDemo` under the demos paragraph.
+
+### 23. Unit Tests
+Files under `test/ca/weblite/webview/`:
+
+1. `OriginsTest`: canonicalises `https://example.com`,
+   `https://example.com:443`, `https://EXAMPLE.com/login?x=1` all to
+   `https://example.com`; keeps `:8443`; distinguishes `http` from
+   `https`; returns null for `about:blank` / `data:...` / `""` / null.
+2. `WebViewCredentialTest`: accessors; NPEs on null args; equality on
+   `{origin, username}` ignoring password; `toString` omits the password.
+3. `InMemoryCredentialStoreTest`: save→find; upsert (Operation-10
+   overwrite, single record); multiple usernames retained + `find`
+   returns most-recent (AC11); delete; origin canonicalisation applied on
+   both save and query.
+4. `PasswordDispatcherTest` (no engine, no Keychain — inject an
+   `InMemoryCredentialStore` and a recording handler):
+   - `dispatchLoginSubmitted` with a `SAVE` handler stores the decoded
+     credential under the canonical origin (feed a base64url payload).
+   - `DONT_SAVE` stores nothing.
+   - disabled ⇒ neither prompt nor store touched; programmatic
+     `saveCredential`/`getCredential` still work (AC12).
+   - handler runs on the EDT (record `SwingUtilities.isEventDispatchThread()`).
+   - handler throwing does not propagate and stores nothing (AC20).
+   - `setStore(null)` / `setHandler(null)` restore non-null defaults
+     (AC16/AC17); getters never null.
+   - `dispatchFillRequested` with a stored credential invokes
+     `source.eval(...)` with a `__webview_pw_fill__` call carrying the
+     base64url username/password (use a `WebViewComponent` test double /
+     spy capturing the eval string; assert the raw password is NOT the
+     literal in the string — it is base64url-encoded); with no stored
+     credential, `eval` is never called (AC19).
+   - password never appears in `WebViewCredential.toString()` /
+     `WebViewSavePasswordEvent.toString()` (AC18).
+
+## N · Norms
+
+- **Model `PasswordDispatcher` on the NON-blocking dispatchers.** Follow
+  `WebViewMouseDispatcher` / `ConsoleDispatcher` (`invokeLater`,
+  fan-out), NOT `DialogDispatcher` (`invokeAndWait`). Document the
+  divergence in the class Javadoc: the save prompt must never park the
+  native message thread.
+- **Origin is always canonicalised through `Origins.canonical`, and is
+  only ever taken from the native `frameUrl`.** No code path may accept an
+  origin from a JS payload. Every store call canonicalises its origin
+  argument (both automatic and programmatic paths) so equal origins
+  collapse identically everywhere.
+- **Accessor naming** uses the no-`get` style (`credential.origin()`,
+  `event.username()`), matching `ConsoleMessage` / `WebViewAlertEvent`.
+- **Null discipline.** Value-object string fields with a "no value"
+  semantic use empty string, not null. `WebViewCredential` rejects null
+  `origin`/`username`/`password` (a credential with a null password is
+  meaningless). Getters `getCredentialStore()` / `getSavePasswordHandler()`
+  never return null; `setX(null)` restores the default instance.
+- **`getStore()/getHandler() != null` and `setX(null)==restore-default`
+  are never-relax invariants** — identical discipline to
+  `getDialogHandler()`.
+- **No JSON parser dependency.** The JS↔native payload is the pipe-tagged
+  `S|<b64>|<b64>` / `F` string; base64url decoding happens in Java, not
+  native. Java↔JS fill passes base64url strings. `java.util.Base64` (Java
+  8) is the only codec.
+- **Base64URL, padding-less, both sides.** Java uses
+  `Base64.getUrlEncoder().withoutPadding()` / `getUrlDecoder()`; the JS
+  helpers use the url alphabet and tolerate missing padding. This keeps
+  passwords with `|`, `+`, `/`, newlines, and non-ASCII intact across the
+  channel.
+- **Keychain items are namespaced** to `"ca.weblite.webview.passwords"`
+  and marked non-synchronizable, so the library never collides with or
+  pushes into Safari's iCloud Keychain items.
+- **JNI mechanics mirror `fire_dialog_*` verbatim** — per-call
+  `GetMethodID`, mandatory `ExceptionCheck/Describe/Clear` after every
+  `Call*Method`, symmetric attach/detach, null-callback short-circuit,
+  global-ref lifecycle in the setter + destructor.
+- **`pom.xml` Java 8 target stays in force** — `java.util.Optional`,
+  `java.util.Base64`, `Executors`, lambdas, `@FunctionalInterface`,
+  `Collections.unmodifiableList` are all Java 8.
+- **Store I/O never on the EDT or engine UI thread for automatic paths.**
+  Automatic save/fill run on the dispatcher's `webview-password-io`
+  single-thread executor. The programmatic API runs synchronously on the
+  caller's thread by contract (documented) so round-trips are
+  deterministic.
+- **Demo / test conventions** match the dialog feature: single-source
+  demos under `demos/<Name>/src/...`, no Maven; tests under
+  `test/ca/weblite/webview/`, headless, no `JFrame` shown, EDT via
+  `SwingUtilities.invokeAndWait` in-test.
+- **No automated GUI/native tests** — the 20 ACs are verified via
+  `WebViewPasswordDemo` on macOS; the Java contract is unit-tested with an
+  `InMemoryCredentialStore` and a `WebViewComponent` test double.
+- **macOS-only coverage in this canvas.** On Linux/Windows the shared
+  `SHIM_JS` is injected but no native `__webview_pw__` handler is wired
+  yet, so no capture/fill fires and the store natives are stubs; the
+  programmatic API returns empty / false there until canvases 24 / 25.
+  README documents this; a maintainer removing the restriction updates the
+  docs in lockstep.
+
+## S · Safeguards
+
+- **Password is never logged, printed, or filed.** No `System.out` /
+  `System.err` / `NSLog` / exception message ever contains a password.
+  `WebViewCredential.toString()` and `WebViewSavePasswordEvent.toString()`
+  render `password=***`. The fill `eval` string embeds the password
+  (base64url) and is never logged. Passwords persist only in the OS
+  secret store. Enforced by code review + the `toString` / no-log tests.
+- **Origin is native-stamped; a JS-supplied origin is never trusted.**
+  The `__webview_pw__` handler reads the committed frame URL from the
+  engine; `PasswordDispatcher` derives the origin solely from that. This
+  is the anti-cross-origin-theft/injection invariant — a page can only
+  ever cause its *own* origin's credential to be saved or filled.
+- **Autofill is exact-origin.** `store.find` is keyed by the canonical
+  origin; a credential for `https://example.com` is never offered on
+  `https://evil.com`, `http://example.com`, or
+  `https://example.com:8443` (AC6/AC7).
+- **The fill entrypoint is write-only.** `window.__webview_pw_fill__`
+  sets field values and dispatches events; it never reads or returns a
+  credential. A page invoking it directly can only fill its own form with
+  attacker-chosen text.
+- **No prompt without a password field.** `findFields()` returns null when
+  the document has no `input[type=password]`, so a plain search-form
+  submit never posts `S|...` and never triggers "Save password?"
+  (STORY-006-001 NFE).
+- **Non-blocking dispatch cannot deadlock the engine.** The save prompt
+  runs via `invokeLater`; the native message thread returns immediately.
+  Store I/O runs on a worker. There is no `invokeAndWait` on any password
+  path, so the `evalAsync-in-handler` self-deadlock class does not apply;
+  even so, the save-handler Javadoc documents not to block the EDT.
+- **Save-handler exception isolation.** `runPrompt` wraps the handler call
+  in `try { ... } catch (Throwable t) { forward(t); return; }` and stores
+  nothing on failure; the WebView stays responsive; the host does not
+  crash (AC20). `forward` routes to
+  `Thread.getDefaultUncaughtExceptionHandler()`.
+- **Store exception isolation.** `NativeCredentialStore` and the
+  dispatcher's `safeSave` / `doFill` wrap store calls in
+  `try/catch(Throwable)`; a store that throws (or a Keychain error)
+  degrades to "not saved" / "not filled", never a crash (foundation for
+  the Linux no-keyring AC12 in canvas 24).
+- **Enabled flag gates automatic behaviour only.** When disabled,
+  `dispatchLoginSubmitted` / `dispatchFillRequested` return before any
+  prompt / lookup / fill; `saveCredential` / `getCredential` /
+  `getCredentials` / `deleteCredential` are unaffected (AC12).
+- **`disposeAll()` is idempotent** and stops automatic dispatch;
+  `io.shutdownNow()` releases the worker. In-flight programmatic calls on
+  the caller thread are unaffected.
+- **Keychain item hygiene.** Items are `kSecClassGenericPassword`,
+  namespaced to the library service, `kSecAttrSynchronizable=false`;
+  every created `CFTypeRef` is released; account encoding is
+  base64url(origin)|base64url(username) so any origin/username round-trips
+  without delimiter collisions.
+- **JNI exception sanitisation.** Every `CallVoidMethod` on the password
+  callback is followed by `ExceptionCheck` → `Describe` → `Clear`; a
+  leaked Java exception must never propagate into AppKit.
+- **`AttachCurrentThread`/`DetachCurrentThread` symmetry** on the
+  password fire helpers, exactly as the dialog helpers.
+- **Callback global-ref lifecycle.** `Engine::password_callback` is a
+  global ref set in `cocoa_set_password_callback` (prior ref deleted) and
+  deleted in the engine destructor; the Java callback is anchored in the
+  wrapper's `heap` so the JVM cannot collect it while native holds the
+  ref.
+- **No GUI dependency at construction.** Constructing a
+  `WebViewComponent`, a `PasswordDispatcher`, an `InMemoryCredentialStore`,
+  and calling the setters must work headless (no `HeadlessException`); the
+  default save-handler only touches Swing when actually invoked.
+- **Base64url decode failures are swallowed.** A malformed payload
+  (`IllegalArgumentException` on decode) drops that dispatch silently
+  rather than throwing across the JNI boundary.
+- **`about:blank` / `data:` / hostless pages produce no origin.**
+  `Origins.canonical` returns null and the dispatch is dropped — no save,
+  no fill, no error (AC19-adjacent).
+- **macOS-only wiring this canvas.** Linux/Windows have no native
+  `__webview_pw__` handler and stub store natives; the injected `SHIM_JS`
+  is inert there (its `post` finds no channel / the native handler is
+  absent). Documented in README; canvases 24/25 activate them.

--- a/spdd/prompt/24-202608131545-[Feat]-Webview-Native-Password-Manager-Linux-Coverage.md
+++ b/spdd/prompt/24-202608131545-[Feat]-Webview-Native-Password-Manager-Linux-Coverage.md
@@ -1,0 +1,364 @@
+---
+generated_at: 2026-08-13T15:45:00-07:00
+---
+
+# REASONS Canvas: Password Manager — Linux WebKitGTK + libsecret Coverage
+
+## R · Requirements
+
+- Extend the password manager shipped by canvas 23 (STORY-006-001) to
+  Linux, for both `WebViewHeavyweightComponent` (X11-reparented
+  WebKitGTK) and `WebViewLightweightComponent` (offscreen WebKitGTK).
+  This canvas adds Linux native code only — **no Java or JavaScript
+  changes**: the public API (`WebViewCredential`, `WebViewCredentialStore`,
+  `WebViewSavePasswordHandler`, `PasswordDispatcher`, the `WebViewComponent`
+  methods) and the shared `PasswordDispatcher.SHIM_JS` are reused verbatim
+  from canvas 23.
+- Two native pieces, both living in `src_c/webview_embed.cpp` under the
+  Linux compilation (the same file canvas 23 compiled with non-Apple stub
+  bodies):
+  1. **Password message channel + capture:** register a WebKitGTK
+     script-message handler for name `__webview_pw__` on the engine's
+     `WebKitUserContentManager` (`e->manager`) — the same manager the
+     `external` console/dialog channel uses — for **both** the heavyweight
+     (`gtk_create_engine`) and offscreen (`gtk_off_create_engine`)
+     engines. Its `script-message-received::__webview_pw__` handler reads
+     the message string body, reads the **committed frame URL natively**
+     via `webkit_web_view_get_uri(WEBKIT_WEB_VIEW(e->web))`, parses the
+     `S|<b64user>|<b64pass>` / `F` tag, and invokes the Java
+     `WebViewPasswordCallback` (`onLoginSubmitted` / `onFillRequested`)
+     stored on the engine. Also implement the two callback setters —
+     `webview_embed_set_password_callback` (heavyweight) and
+     `webview_offscreen_set_password_callback` (offscreen) — replacing the
+     canvas-23 Linux stubs, following `gtk_set_dialog_callback`.
+  2. **libsecret credential store:** replace the canvas-23 non-Apple stub
+     bodies of the four `webview_cred_store_*` primitives with a libsecret
+     implementation, matching the macOS Keychain semantics exactly (same
+     `service` namespace, same `savedAtMillis + "\n" + password` value
+     encoding, same origin/username keying, same most-recent-first
+     ordering contract — Java re-sorts regardless).
+- **libsecret is loaded at runtime via `dlopen`**, matching the existing
+  WebKitGTK runtime-load convention (`webkit_loader.cpp`) rather than
+  hard-linking. If `libsecret-1.so.0` is absent, or no Secret Service
+  provider answers, the store degrades gracefully:
+  `webview_cred_store_available()` returns `false`, `save`/`delete` return
+  `false`, `find` returns an empty array — the app never crashes and page
+  load / submission still work (STORY-006-002 AC12).
+- The `SecretSchema` is defined once (file-static), with attributes
+  `service` (string), `origin` (string), `username` (string), all
+  `SECRET_SCHEMA_ATTRIBUTE_STRING`, schema name
+  `"ca.weblite.webview.passwords"`, flags `SECRET_SCHEMA_NONE`. The secret
+  value is the `millis + "\n" + password` string. `find` uses
+  `secret_password_searchv_sync` / `secret_service_search_sync` (or the
+  simpler `secret_password_lookupv_sync` per-account) to enumerate all
+  items whose `service` + `origin` match; the Canvas specifies the
+  enumeration approach in Operations.
+- All libsecret `*_sync` calls run on whatever thread the JNI primitive is
+  invoked on (the Java `NativeCredentialStore` already keeps automatic
+  paths off the EDT / engine UI thread via `PasswordDispatcher`'s
+  executor; the programmatic API runs on the caller's thread by contract).
+  The Secret Service D-Bus round-trip therefore never parks the GTK
+  main-loop thread.
+- The `__webview_pw__` handler runs on the GTK main thread; it calls the
+  Java callback synchronously (void, non-blocking — the callback just
+  hands off to `PasswordDispatcher`, which `invokeLater`s the prompt and
+  offloads store I/O), so the GTK main loop is not parked.
+- Heavyweight and lightweight share the identical handler + store code
+  (one registration site per engine, same callback, same store), so the
+  two modes produce byte-identical captured field values and identical
+  stored/filled values (STORY-006-002 AC11/AC14).
+- Definition of Done:
+  - All 13 STORY-006-002 ACs pass on Linux (a Secret Service provider
+    available for AC1–AC11/AC13; AC12 verified by disabling/removing the
+    provider).
+  - `WebViewPasswordDemo` (from canvas 23) works unchanged on Linux in
+    both modes.
+  - README's "Password manager" subsection updates the coverage note:
+    Linux now supported (heavyweight + lightweight) via libsecret; still
+    pending Windows.
+  - `build-linux.sh` gains no hard link to libsecret (runtime `dlopen`);
+    a build comment documents the `dlopen("libsecret-1.so.0")` dependency.
+- Out of scope (explicit non-goals):
+  - Windows coverage (canvas 25).
+  - macOS — canvas 23.
+  - Any Java or `SHIM_JS` change — the contract is fixed by canvas 23.
+  - Shipping or requiring a specific keyring daemon (GNOME Keyring vs
+    KWallet). The library targets the freedesktop Secret Service via
+    libsecret and works with whichever provider implements it.
+  - A library-provided keyring-unlock UI — if the login keyring is locked,
+    libsecret / the Secret Service prompts per its own policy.
+  - The multi-step-login and heap-zeroisation limitations already
+    documented in canvas 23.
+
+## E · Entities
+
+- **`src_c/webview_embed.cpp`** (modified, Linux compilation). Gains:
+  - `Engine::password_callback` `jobject` field is already declared by
+    canvas 23 (shared struct); Linux now uses it.
+  - A file-static `SecretSchema WEBVIEW_PW_SCHEMA` (Linux-guarded).
+  - `dlopen`'d libsecret function pointers (file-static), resolved once
+    lazily: `secret_password_store_sync`, `secret_password_lookup_sync`,
+    `secret_password_clear_sync`, `secret_password_free`, and the search
+    API used for enumeration (`secret_service_get_sync` +
+    `secret_service_search_sync` + item accessors, OR
+    `secret_password_search_sync`/`secret_password_searchv_sync` per the
+    available libsecret version) — plus `g_free` / GLib helpers already
+    available via the linked GTK stack.
+  - `gtk_set_password_callback(Engine*, JNIEnv*, jobject)` — mirrors
+    `gtk_set_dialog_callback`.
+  - `on_password_message_engine(WebKitUserContentManager*, WebKitJavascriptResult*, gpointer engine)`
+    — the `script-message-received::__webview_pw__` handler.
+  - `fire_password_submitted` / `fire_password_fill_requested` — the
+    JNI fire helpers (shared with macOS in shape; may be defined
+    platform-neutrally once and reused).
+  - libsecret bodies for `webview_cred_store_save/find/delete/available`
+    (replacing the canvas-23 non-Apple stubs).
+  - JNI bridges for `webview_embed_set_password_callback` (→
+    `gtk_set_password_callback` on the heavyweight engine) and
+    `webview_offscreen_set_password_callback` (→ the offscreen engine).
+- **`build-linux.sh`** (modified): a comment documenting the runtime
+  `dlopen` of `libsecret-1.so.0`; no `-lsecret` hard link.
+- **README.md** (modified): coverage-note update.
+
+No new classes; no mermaid diagram change (the class model is canvas 23's).
+
+## A · Approach
+
+1. **Message channel registration (both engines).** In `gtk_create_engine`
+   and `gtk_off_create_engine`, next to the existing
+   `webkit_user_content_manager_register_script_message_handler(e->manager, "external")`
+   and its `script-message-received::external` connect, add:
+   - `g_signal_connect(e->manager, "script-message-received::__webview_pw__", G_CALLBACK(on_password_message_engine), e);`
+   - `webkit_user_content_manager_register_script_message_handler(e->manager, "__webview_pw__");`
+   The shared `SHIM_JS` (injected via `addOnBeforeLoad`) posts to
+   `window.webkit.messageHandlers.__webview_pw__.postMessage(...)`, which
+   this handler receives.
+
+2. **Reading the message + trusted origin.** `on_password_message_engine`:
+   - Extract the JS string from `WebKitJavascriptResult` via
+     `webkit_javascript_result_get_js_value` +
+     `jsc_value_to_string` (the pattern the console/dialog handlers
+     already use for `external`). Free with `g_free`.
+   - Read the committed URI: `const gchar* uri = webkit_web_view_get_uri(WEBKIT_WEB_VIEW(e->web));`
+     — this is the top document's committed URL, the trusted origin
+     source (never the JS payload).
+   - Parse: first char `'S'` → split remainder on the first two `'|'`
+     into `b64user`, `b64pass` → `fire_password_submitted(e, uri, b64user, b64pass)`;
+     first char `'F'` → `fire_password_fill_requested(e, uri)`.
+
+3. **JNI fire helpers** copy the macOS/dialog mechanics: defensive attach,
+   per-call `GetObjectClass` + `GetMethodID`, `CallVoidMethod`,
+   `ExceptionCheck/Describe/Clear`, symmetric detach; no-op if
+   `password_callback` is null. These may be shared with the macOS code
+   (defined without Cocoa dependencies) so both platforms call the same
+   functions; only the message-handler plumbing differs.
+
+4. **libsecret store — lazy dlopen.** A file-static `bool ensure_secret()`
+   `dlopen`s `libsecret-1.so.0` once (`dlopen(..., RTLD_NOW|RTLD_GLOBAL)`),
+   resolves the needed symbols with `dlsym`, and caches a
+   success/failure flag. Every store primitive calls `ensure_secret()`
+   first; on failure it returns the graceful-degradation value.
+   `webview_cred_store_available` returns the cached flag AND (optionally)
+   a cheap probe that the Secret Service answers.
+
+5. **Store semantics (identical to macOS).**
+   - **save**: build the attribute set `{service, origin, username}`;
+     `secret_password_store_sync(&WEBVIEW_PW_SCHEMA, SECRET_COLLECTION_DEFAULT,
+     label, secretValue, NULL, &error, "service", service, "origin",
+     origin, "username", username, NULL)` where `secretValue = millis +
+     "\n" + password` and `label = "WebView password for " + origin`.
+     `store_sync` upserts on matching attributes, so it satisfies the
+     overwrite contract (AC7 of STORY-006-002). Return `error == NULL`.
+   - **find**: enumerate all items with `{service, origin}` (username
+     unbound) via the search API, read each item's secret + `username`
+     attribute, split the secret on the first `\n` into millis + password,
+     emit flat `[username, millis, password]` triples. Java re-sorts.
+     On no match → empty array.
+   - **delete**: `secret_password_clear_sync(&WEBVIEW_PW_SCHEMA, NULL,
+     &error, "service", service, "origin", origin, "username", username,
+     NULL)` → returns whether a secret was removed.
+   - Free every returned secret with `secret_password_free` /
+     `g_error_free` / `g_free`; never log the password.
+
+6. **Threading.** The primitives run on the JNI caller thread. For
+   automatic paths that is `PasswordDispatcher`'s `webview-password-io`
+   executor (off the GTK main loop and off the EDT); for the programmatic
+   API it is the caller's thread. The `*_sync` D-Bus round-trip therefore
+   never blocks the GTK main-loop thread. The `on_password_message_engine`
+   handler itself does no store I/O — it only fires the Java callback,
+   which hands off immediately.
+
+7. **Heavyweight/lightweight parity.** Both engines register the same
+   handler and share the same store code and the same `password_callback`
+   field, so field values and stored/filled values are identical across
+   modes (AC11/AC14).
+
+## S · Structure
+
+### Dependencies
+1. `on_password_message_engine` → `webkit_web_view_get_uri`,
+   `webkit_javascript_result_get_js_value`, `jsc_value_to_string`,
+   `fire_password_submitted` / `fire_password_fill_requested`.
+2. `webview_cred_store_*` (Linux bodies) → the dlopen'd libsecret symbols
+   via `ensure_secret()`.
+3. JNI `webview_embed_set_password_callback` / `_offscreen_...` →
+   `gtk_set_password_callback` on the respective engine.
+4. `gtk_create_engine` / `gtk_off_create_engine` → the new
+   `register_script_message_handler("__webview_pw__")` + signal connect.
+
+### Layered Architecture (Linux additions only)
+1. **Native engine layer** (`webview_embed.cpp`, Linux): the
+   `__webview_pw__` GTK message handler, the callback setter, the fire
+   helpers, and the libsecret store bodies.
+2. All higher layers (JNI surface, wrappers, dispatcher, component API,
+   public contract, wiring, demo) are unchanged from canvas 23 — the Linux
+   wiring in `WebViewLightweightComponent.addNotify()` /
+   `WebViewHeavyweightComponent.createPeer()` (which already call
+   `addOnBeforeLoad(SHIM_JS)` + `setPasswordCallback(...)` from canvas 23)
+   now reaches live native code instead of a stub.
+
+## O · Operations
+
+### 1. Define the SecretSchema and dlopen shim
+File: `src_c/webview_embed.cpp` (Linux-guarded)
+
+1. File-static `const SecretSchema WEBVIEW_PW_SCHEMA` with name
+   `"ca.weblite.webview.passwords"`, `SECRET_SCHEMA_NONE`, attributes
+   `"service"`, `"origin"`, `"username"` each
+   `SECRET_SCHEMA_ATTRIBUTE_STRING`, terminated by `SECRET_SCHEMA_ATTRIBUTE`
+   `NULL`.
+2. File-static function pointers for the libsecret symbols used; a
+   `static bool g_secret_ok = false; static bool g_secret_tried = false;`
+   pair.
+3. `static bool ensure_secret()`: if `g_secret_tried` return `g_secret_ok`;
+   set tried; `void* h = dlopen("libsecret-1.so.0", RTLD_NOW|RTLD_GLOBAL);`
+   if null → `g_secret_ok=false`; else `dlsym` each needed symbol; if any
+   missing → false; else true. Cache and return.
+
+### 2. Implement webview_cred_store_available
+1. Body: `return ensure_secret() ? JNI_TRUE : JNI_FALSE;` (Linux). Callable
+   with no engine.
+
+### 3. Implement webview_cred_store_save
+1. `if (!ensure_secret()) return JNI_FALSE;`
+2. Convert jstrings (service/origin/username/password) to UTF-8 (`GetStringUTFChars`).
+3. Build `std::string value = std::to_string(savedAtMillis) + "\n" + password;`
+4. `GError* err = NULL; gboolean ok = secret_password_store_sync(&WEBVIEW_PW_SCHEMA, SECRET_COLLECTION_DEFAULT, label, value.c_str(), NULL, &err, "service", service, "origin", origin, "username", username, NULL);`
+5. Release jstrings; if `err` → `g_error_free(err)`, return `JNI_FALSE`;
+   return `ok ? JNI_TRUE : JNI_FALSE`. Never log `value`/`password`.
+
+### 4. Implement webview_cred_store_find
+1. `if (!ensure_secret()) return empty jobjectArray;`
+2. Enumerate items matching `{service, origin}` (username unbound) using
+   the resolved search API; for each: read the `username` attribute and
+   the secret string; split the secret on the first `\n` → `millis`,
+   `password`; append `username`, `millis`, `password` to a
+   `std::vector<std::string>`.
+3. Build a `jobjectArray` (`java/lang/String`) of the flat triples; free
+   all libsecret allocations (`secret_password_free`, list frees).
+   Return the array (empty on no match / error). Java sorts + builds
+   credentials.
+
+### 5. Implement webview_cred_store_delete
+1. `if (!ensure_secret()) return JNI_FALSE;`
+2. `gboolean removed = secret_password_clear_sync(&WEBVIEW_PW_SCHEMA, NULL, &err, "service", service, "origin", origin, "username", username, NULL);`
+3. Free jstrings; on `err` → free + `JNI_FALSE`; return
+   `removed ? JNI_TRUE : JNI_FALSE`.
+
+### 6. Implement the password message handler + callback setter
+File: `src_c/webview_embed.cpp` (Linux)
+
+1. `on_password_message_engine(WebKitUserContentManager* m, WebKitJavascriptResult* r, gpointer data)`:
+   - `Engine* e = (Engine*)data;`
+   - Extract JS string (as the `external` handler does); if null → return.
+   - `const gchar* uri = webkit_web_view_get_uri(WEBKIT_WEB_VIEW(e->web));`
+     (may be null → treat as empty; Java's `Origins.canonical` drops it).
+   - Parse tag `S`/`F`; call `fire_password_submitted(e, uri, b64user, b64pass)`
+     or `fire_password_fill_requested(e, uri)`.
+   - `g_free` the extracted string.
+2. `gtk_set_password_callback(Engine* e, JNIEnv* env, jobject cb)`: delete
+   prior global ref; `e->password_callback = cb ? env->NewGlobalRef(cb) : NULL;`.
+3. In `gtk_create_engine` and `gtk_off_create_engine`, after the existing
+   `external` handler registration: connect + register the
+   `__webview_pw__` handler as in Approach §1.
+4. JNI bridges: `Java_..._webview_1embed_1set_1password_1callback` →
+   `gtk_set_password_callback(engine_from_long(w), env, cb)`;
+   `Java_..._webview_1offscreen_1set_1password_1callback` → the offscreen
+   engine variant. Replace the canvas-23 Linux stubs.
+5. Teardown: on engine destroy, `DeleteGlobalRef(password_callback)`
+   (add to the existing Linux destroy path next to the dialog callback
+   cleanup).
+
+### 7. fire helpers (shared)
+1. If canvas 23 defined `fire_password_submitted` /
+   `fire_password_fill_requested` without Cocoa dependencies, reuse them
+   directly. Otherwise define the Linux copies with identical JNI
+   mechanics (per-call `GetMethodID` for
+   `onLoginSubmitted(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V`
+   / `onFillRequested(Ljava/lang/String;)V`, `ExceptionCheck/Clear`,
+   attach/detach symmetry, null-callback short-circuit).
+
+### 8. build-linux.sh comment
+1. Add a comment noting the runtime `dlopen("libsecret-1.so.0")`
+   dependency and that no `-lsecret` link is added (matching the WebKitGTK
+   runtime-load convention). No functional flag change.
+
+### 9. README coverage note
+1. Update the "Password manager" subsection: Linux supported in both
+   heavyweight and lightweight via libsecret (freedesktop Secret Service);
+   graceful no-op when no provider is available; Windows still pending.
+
+## N · Norms
+
+- **No Java / `SHIM_JS` change.** This canvas is native-only; the contract
+  and script are canvas 23's. If a change here would require touching
+  Java, stop — it belongs in a canvas-23 amendment, not here.
+- **Origin from `webkit_web_view_get_uri` only** — never from the JS
+  payload. Same invariant as macOS.
+- **Identical store semantics to macOS**: same `service` namespace, same
+  `millis + "\n" + password` value encoding, same keying, same
+  most-recent-first contract (Java re-sorts). A Linux-stored credential
+  and a macOS-stored credential differ only in the backing store, never in
+  observed Java behaviour.
+- **Runtime `dlopen` for libsecret**, matching `webkit_loader.cpp`; no
+  hard link. Absence degrades gracefully, never fails library load.
+- **`*_sync` calls off the GTK main loop.** They run on the JNI caller
+  thread (the dispatcher's executor for automatic paths). The GTK message
+  handler does no store I/O.
+- **GLib/libsecret memory hygiene**: free every `GError`, secret string,
+  and search-result list; use `secret_password_free` for secrets. Never
+  log a secret.
+- **JNI mechanics mirror the dialog/macOS helpers** (per-call
+  `GetMethodID`, `ExceptionCheck/Clear`, attach/detach symmetry,
+  global-ref lifecycle).
+- **Heavyweight and lightweight share one code path** — one handler, one
+  store, one callback field; no mode-specific divergence.
+
+## S · Safeguards
+
+- **Graceful degradation (STORY-006-002 AC12).** No libsecret / no Secret
+  Service ⇒ `available()` false, `save`/`delete` false, `find` empty; page
+  load and form submission continue to work; no crash, no thrown JNI
+  exception.
+- **Trusted origin** stamped from `webkit_web_view_get_uri`; JS-supplied
+  origin ignored — the anti-cross-origin invariant holds on Linux too.
+- **Password never logged / filed.** libsecret is the only persistence;
+  no `g_print` / stderr of secrets; the value blob is freed after use.
+- **No GTK-main-loop parking.** The `__webview_pw__` handler only fires
+  the Java callback (which hands off); D-Bus `*_sync` store I/O runs on
+  the dispatcher's worker, not the GTK thread.
+- **Parity (AC11/AC14).** Heavyweight and lightweight use identical native
+  code and therefore produce identical captured/stored/filled values.
+- **Memory safety.** Every libsecret / GLib allocation is freed on every
+  path; jstring `GetStringUTFChars` are released; the `jobjectArray` local
+  refs are managed within the JNI frame.
+- **JNI exception sanitisation** after every `CallVoidMethod`; symmetric
+  attach/detach; null-callback short-circuit — identical to the dialog
+  path.
+- **Callback global-ref lifecycle** set in `gtk_set_password_callback`,
+  deleted on engine destroy; the Java callback anchored in the wrapper's
+  `heap` (canvas 23).
+- **No behavioural drift from macOS** — because the Java layer, the shared
+  JS, and the value encoding are shared, the only Linux-specific surface
+  is the store backend and the message-handler plumbing; both conform to
+  the canvas-23 contract.

--- a/spdd/prompt/25-202608131600-[Feat]-Webview-Native-Password-Manager-Windows-Coverage.md
+++ b/spdd/prompt/25-202608131600-[Feat]-Webview-Native-Password-Manager-Windows-Coverage.md
@@ -1,0 +1,323 @@
+---
+generated_at: 2026-08-13T16:00:00-07:00
+---
+
+# REASONS Canvas: Password Manager — Windows WebView2 + Credential Manager Coverage
+
+## R · Requirements
+
+- Extend the password manager shipped by canvas 23 (STORY-006-001) to
+  Windows, where `WebViewHeavyweightComponent` uses Microsoft WebView2
+  (embedded Edge/Chromium). This canvas adds Windows native code only —
+  **no Java or JavaScript changes**: the public API and the shared
+  `PasswordDispatcher.SHIM_JS` are reused verbatim from canvas 23. Windows
+  uses the **library's own** password manager (not Edge's profile store),
+  so behaviour is uniform with macOS and Linux.
+- Three native pieces, all in `windows/webview_embed.cc` (replacing the
+  canvas-23 Windows stub bodies):
+  1. **Password message routing + capture:** the shared `SHIM_JS` posts
+     `window.chrome.webview.postMessage('__webview_pw__:' + payload)`.
+     Extend the existing `MsgHandler` (`ICoreWebView2WebMessageReceivedEventHandler`,
+     already registered via `add_WebMessageReceived`) to recognise
+     messages prefixed `__webview_pw__:`, read the **committed source URL
+     natively** via `ICoreWebView2WebMessageReceivedEventArgs::get_Source`
+     (fallback `ICoreWebView2::get_Source`), parse the
+     `S|<b64user>|<b64pass>` / `F` tag, and invoke the Java
+     `WebViewPasswordCallback`. Implement the callback setter
+     `webview_embed_set_password_callback` (and the offscreen setter as a
+     no-op — Windows has no offscreen engine), following the existing
+     `webview_embed_set_dialog_callback` JNI export.
+  2. **Credential Manager store:** replace the canvas-23 Windows stub
+     bodies of the four `webview_cred_store_*` primitives with a Win32
+     Credential Manager implementation (`CredWriteW` / `CredReadW` /
+     `CredEnumerateW` / `CredDeleteW`, `CRED_TYPE_GENERIC`), matching the
+     macOS/Linux semantics exactly (same value encoding `millis + "\n" +
+     password`, same origin/username keying, same most-recent-first
+     contract — Java re-sorts).
+  3. **Suppress Edge's built-in password autosave** so it never competes
+     with the library's Swing prompt: at engine creation, after acquiring
+     the settings object, `QueryInterface` for `ICoreWebView2Settings4`
+     and call `put_IsPasswordAutosaveEnabled(FALSE)` (it defaults FALSE,
+     but set it explicitly and defensively) and leave
+     `put_IsGeneralAutofillEnabled` untouched.
+- **Target-name encoding for Credential Manager.** Each credential is one
+  `CRED_TYPE_GENERIC` entry whose `TargetName` is
+  `L"ca.weblite.webview.passwords:" + base64url(origin) + "|" + base64url(username)`
+  (the same namespace prefix used as the `service` on the other platforms,
+  followed by the same account encoding). `CredEnumerateW` with filter
+  `L"ca.weblite.webview.passwords:*"` backs `find`. The
+  `CredentialBlob` holds the UTF-8 (or UTF-16) `millis + "\n" + password`
+  bytes; `Persist = CRED_PERSIST_LOCAL_MACHINE` (per-user local; DPAPI
+  protects the blob).
+- The `WebMessageReceived` callback runs on the WebView2 worker thread; it
+  invokes the Java callback synchronously (void, non-blocking — the
+  callback hands off to `PasswordDispatcher`, which `invokeLater`s the
+  prompt and offloads store I/O), so the worker message pump is not parked
+  beyond the immediate hand-off.
+- `<input type="file">`-style limitations do not apply here; the password
+  channel is a `postMessage`, fully available on WebView2. There is **no**
+  WebView2 limitation for this feature (contrast the dialogs feature's
+  file-picker carve-out) — all 13 STORY-006-003 ACs are achievable.
+- Definition of Done:
+  - All 13 STORY-006-003 ACs pass on Windows 11 with the WebView2 Runtime.
+  - `WebViewPasswordDemo` (canvas 23) works unchanged on Windows.
+  - README's "Password manager" subsection updates coverage to
+    all-three-platforms, with the Windows note: the library's own manager
+    is used (not Edge's profile), credentials live in the Windows
+    Credential Manager (DPAPI-protected, per-user), and Edge autosave is
+    disabled.
+  - `windows/script/build.bat` (or the Windows build) links `Advapi32`
+    for the `Cred*` APIs if not already linked.
+- Out of scope (explicit non-goals):
+  - macOS — canvas 23. Linux — canvas 24.
+  - Any Java or `SHIM_JS` change.
+  - Reading / importing Edge's existing saved passwords from the user's
+    Edge profile — the library uses its own Credential-Manager namespace;
+    it neither reads nor writes Edge's store.
+  - Roaming / enterprise credential sync beyond choosing the per-user
+    `CRED_PERSIST_LOCAL_MACHINE` flag.
+  - The multi-step-login and heap-zeroisation limitations documented in
+    canvas 23.
+
+## E · Entities
+
+- **`windows/webview_embed.cc`** (modified). Gains:
+  - `Engine::password_callback` `jobject` field (Windows struct) — mirrors
+    the dialog callback field; global ref set/cleared like the dialog one
+    (`:2376-2381`).
+  - `MsgHandler::Invoke` extension: a `__webview_pw__:` prefix branch that
+    reads `get_Source` and fires the Java callback.
+  - `fire_password_submitted` / `fire_password_fill_requested` (Windows
+    JNI fire helpers; mirror the dialog `onAlert`/`onConfirm` GetMethodID
+    helpers at `:276`/`:318`).
+  - Win32 Credential Manager bodies for the four `webview_cred_store_*`
+    primitives (replacing the canvas-23 Windows stubs).
+  - JNI bridges for `webview_embed_set_password_callback` (→ store the
+    global ref, mirroring the dialog setter at `:2365`) and
+    `webview_offscreen_set_password_callback` (no-op — no offscreen engine
+    on Windows).
+  - At engine creation, the `ICoreWebView2Settings4::put_IsPasswordAutosaveEnabled(FALSE)`
+    call, added next to the existing settings block
+    (`put_AreDefaultScriptDialogsEnabled(FALSE)`, ~`:1633`).
+- **`windows/script/build.bat`** (modified if needed): link `Advapi32.lib`.
+- **README.md** (modified): coverage-note update to all three platforms.
+
+No new classes; the class model is canvas 23's.
+
+## A · Approach
+
+1. **Message routing.** The existing `MsgHandler::Invoke` receives every
+   `postMessage`. The shared `SHIM_JS` prefixes password messages with
+   `__webview_pw__:`. Branch: if the received string begins with
+   `__webview_pw__:`, strip the prefix and treat the remainder as the
+   `S|...` / `F` payload; otherwise fall through to the existing
+   `window.external.invoke` bind dispatch unchanged. (This keeps a single
+   `WebMessageReceived` registration; the codebase already demuxes the
+   single Windows channel by content.)
+
+2. **Trusted origin.** In the password branch, read the source URL from
+   `ICoreWebView2WebMessageReceivedEventArgs::get_Source(&uri)` (a
+   `LPWSTR` of the committed document that sent the message), fallback
+   `webview->get_Source(&uri)`. Convert to UTF-8 and pass as `frameUrl`
+   to the Java callback. Never trust an origin from the payload.
+
+3. **JNI fire helpers** mirror the dialog `onAlert`/`onConfirm` path:
+   attach the worker thread to the JVM if needed, per-call `GetMethodID`
+   for `onLoginSubmitted(...)V` / `onFillRequested(...)V`, `CallVoidMethod`,
+   `ExceptionCheck/Clear`, detach symmetry; no-op if `password_callback`
+   is null.
+
+4. **Credential Manager store.**
+   - **save**: build `TargetName` = namespace prefix + `base64url(origin)`
+     + `L"|"` + `base64url(username)`. Fill a `CREDENTIALW`:
+     `Type=CRED_TYPE_GENERIC`, `TargetName`, `CredentialBlob` = bytes of
+     `millis + "\n" + password`, `CredentialBlobSize`, `Persist =
+     CRED_PERSIST_LOCAL_MACHINE`, `UserName` = the username (informational).
+     `CredWriteW(&cred, 0)` upserts (overwrites an existing target),
+     satisfying the overwrite contract. Return `CredWriteW` success.
+   - **find**: `CredEnumerateW(L"ca.weblite.webview.passwords:*", 0, &count,
+     &creds)`; for each, decode `TargetName` after the prefix into
+     `base64url(origin)|base64url(username)`, base64url-decode both; if
+     origin equals the (canonical) target origin, read the blob, split on
+     the first `\n` → millis, password; emit `[username, millis, password]`.
+     `CredFree(creds)`. Java sorts. Empty on none.
+   - **delete**: reconstruct the exact `TargetName`; `CredDeleteW(target,
+     CRED_TYPE_GENERIC, 0)`; return success (`true` only when actually
+     deleted).
+   - **available**: return `true` (Credential Manager is always present on
+     supported Windows).
+   All wide-string / UTF-8 conversions via `MultiByteToWideChar` /
+   `WideCharToMultiByte`; zero and free the blob buffer after use; never
+   `OutputDebugString` a password.
+
+5. **Edge autosave suppression.** At engine creation, after
+   `get_Settings`, `QueryInterface(IID_PPV_ARGS(&settings4))`; if it
+   succeeds, `settings4->put_IsPasswordAutosaveEnabled(FALSE);
+   settings4->Release();`. Guarded so an older Runtime lacking
+   `ICoreWebView2Settings4` degrades to "no explicit call" (the default is
+   already FALSE). This makes AC10 (no Edge bar) deterministic.
+
+6. **Threading.** The store primitives run on the JNI caller thread — the
+   dispatcher's `webview-password-io` executor for automatic paths, the
+   caller's thread for the programmatic API. `CredRead`/`CredWrite` are
+   fast local calls; they never run on the WebView2 message-pump path (the
+   message handler only fires the Java callback, which hands off).
+
+## S · Structure
+
+### Dependencies
+1. `MsgHandler::Invoke` (password branch) → `get_Source` →
+   `fire_password_submitted` / `fire_password_fill_requested`.
+2. `webview_cred_store_*` (Windows bodies) → `Advapi32` `Cred*` APIs.
+3. JNI `webview_embed_set_password_callback` → the `Engine::password_callback`
+   global ref (the offscreen setter is a no-op).
+4. Engine creation → `ICoreWebView2Settings4::put_IsPasswordAutosaveEnabled(FALSE)`.
+
+### Layered Architecture (Windows additions only)
+1. **Native engine layer** (`windows/webview_embed.cc`): the password
+   branch in `MsgHandler`, the callback setter + fire helpers, the
+   Credential-Manager store bodies, and the Edge-autosave-off setting.
+2. All higher layers are canvas 23's, unchanged. The Windows wiring in
+   `WebViewHeavyweightComponent.createPeer()` (which already injects
+   `SHIM_JS` and calls `setPasswordCallback`) now reaches live native code
+   instead of a stub.
+
+## O · Operations
+
+### 1. Add the Engine password_callback field + setter
+File: `windows/webview_embed.cc`
+
+1. Add `jobject password_callback = nullptr;` to the Windows `Engine`
+   struct (next to the dialog callback field).
+2. JNI export `Java_..._webview_1embed_1set_1password_1callback(JNIEnv* env,
+   jclass, jlong w, jobject cb)`: resolve the engine; delete any prior
+   global ref; `e->password_callback = cb ? env->NewGlobalRef(cb) : nullptr;`
+   (mirror the dialog setter at `:2365-2381`). Marshal onto the engine's
+   worker thread if the codebase requires COM-thread affinity for field
+   writes (follow the dialog setter's threading exactly).
+3. JNI export `Java_..._webview_1offscreen_1set_1password_1callback`:
+   no-op (no offscreen engine on Windows).
+4. In the engine destroy path, `DeleteGlobalRef(password_callback)`.
+
+### 2. Extend MsgHandler with the password branch
+File: `windows/webview_embed.cc` (`MsgHandler::Invoke`, ~`:489-530`)
+
+1. Obtain the message string (`get_WebMessageAsJson` /
+   `TryGetWebMessageAsString` — use whichever the existing handler uses).
+2. If it begins with `L"__webview_pw__:"`: strip the prefix; read the
+   source URL via `args->get_Source(&sourceUri)` (fallback
+   `e->webview->get_Source(&sourceUri)`); convert both payload and URI to
+   UTF-8; parse the `S`/`F` tag; call `fire_password_submitted(e, uri,
+   b64user, b64pass)` or `fire_password_fill_requested(e, uri)`;
+   `CoTaskMemFree(sourceUri)`; return.
+3. Otherwise, fall through to the existing bind dispatch unchanged.
+
+### 3. fire helpers
+File: `windows/webview_embed.cc`
+
+1. `fire_password_submitted(Engine* e, const char* frameUrl, const char* b64user, const char* b64pass)` and
+   `fire_password_fill_requested(Engine* e, const char* frameUrl)`:
+   attach the calling thread to the JVM (defensive), per-call
+   `GetObjectClass` + `GetMethodID`
+   (`onLoginSubmitted(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V`
+   / `onFillRequested(Ljava/lang/String;)V`), build UTF-8 jstrings,
+   `CallVoidMethod`, `ExceptionCheck`→`Describe`→`Clear`, detach if
+   attached; no-op if `password_callback` null. Mirror the dialog
+   `onAlert`/`onConfirm` helpers (`:276`, `:318`).
+
+### 4. Implement webview_cred_store_save
+File: `windows/webview_embed.cc`
+
+1. Build `TargetName` (wide): `L"ca.weblite.webview.passwords:" + b64url(origin) + L"|" + b64url(username)`.
+2. `std::string blob = to_string(savedAtMillis) + "\n" + password;` (UTF-8).
+3. `CREDENTIALW cred = {}; cred.Type = CRED_TYPE_GENERIC; cred.TargetName = target; cred.CredentialBlobSize = (DWORD)blob.size(); cred.CredentialBlob = (LPBYTE)blob.data(); cred.Persist = CRED_PERSIST_LOCAL_MACHINE; cred.UserName = usernameW;`
+4. `BOOL ok = CredWriteW(&cred, 0);` SecureZero the blob buffer; return
+   `ok ? JNI_TRUE : JNI_FALSE`. Never log the blob.
+
+### 5. Implement webview_cred_store_find
+File: `windows/webview_embed.cc`
+
+1. `PCREDENTIALW* creds = nullptr; DWORD count = 0; if (!CredEnumerateW(L"ca.weblite.webview.passwords:*", 0, &count, &creds)) return empty jobjectArray;`
+2. For each `creds[i]`: parse `TargetName` after the prefix into
+   `b64origin|b64username`; base64url-decode → origin, username; if origin
+   equals the (canonicalised) target origin, read the blob
+   (`CredentialBlob`/`CredentialBlobSize`) as UTF-8, split on first `\n` →
+   millis, password; append `username`, `millis`, `password`.
+3. `CredFree(creds);` build + return the flat `jobjectArray` (empty on
+   none). Java sorts.
+
+### 6. Implement webview_cred_store_delete
+File: `windows/webview_embed.cc`
+
+1. Reconstruct the exact wide `TargetName`; `BOOL ok = CredDeleteW(target,
+   CRED_TYPE_GENERIC, 0);` return `ok ? JNI_TRUE : JNI_FALSE` (false when
+   the target did not exist).
+
+### 7. Implement webview_cred_store_available
+1. `return JNI_TRUE;` (Credential Manager always present).
+
+### 8. Disable Edge password autosave
+File: `windows/webview_embed.cc` (engine creation settings block, ~`:1623-1635`)
+
+1. After the existing `ICoreWebView2Settings* settings` block, obtain
+   `ICoreWebView2Settings4* s4` via `settings->QueryInterface(...)`; if
+   `SUCCEEDED`, `s4->put_IsPasswordAutosaveEnabled(FALSE); s4->Release();`.
+   Guarded so a Runtime without `ICoreWebView2Settings4` is a no-op.
+
+### 9. Link Advapi32
+File: `windows/script/build.bat` (or the Windows link step)
+
+1. Ensure `Advapi32.lib` is linked (provides `CredWriteW` / `CredReadW` /
+   `CredEnumerateW` / `CredDeleteW` / `CredFree`). Add if absent.
+
+### 10. README coverage note
+1. Update the "Password manager" subsection to all-three-platforms;
+   Windows note: library's own manager (not Edge's profile), credentials
+   in the Windows Credential Manager (DPAPI, per-user), Edge autosave
+   disabled.
+
+## N · Norms
+
+- **No Java / `SHIM_JS` change.** Native-only; the contract is canvas 23's.
+- **Single `WebMessageReceived` registration, demuxed by content** — the
+  password branch is added inside the existing `MsgHandler`, not a second
+  handler, matching the codebase's single-Windows-channel convention.
+- **Origin from `get_Source` only** — never the payload. Same invariant as
+  the other platforms.
+- **Identical store semantics** to macOS/Linux: same namespace, same
+  `millis + "\n" + password` encoding, same keying, same most-recent-first
+  contract (Java re-sorts).
+- **JNI mechanics mirror the dialog helpers** (per-call `GetMethodID`,
+  `ExceptionCheck/Clear`, attach/detach symmetry, worker-thread affinity
+  for callback-field writes, global-ref lifecycle).
+- **COM/Win32 hygiene**: `CredFree` every enumerate result;
+  `CoTaskMemFree` every `get_Source` URI; `Release` every QI'd interface;
+  SecureZero the blob buffer after use. Never log a password.
+- **Edge autosave stays off** from engine creation (deterministic AC10);
+  do not toggle it mid-session.
+
+## S · Safeguards
+
+- **Edge's built-in save-password bar never appears** — autosave is set
+  FALSE at creation (AC10). The library's Swing prompt is the only save UI.
+- **Trusted origin** from `get_Source`; JS-supplied origin ignored.
+- **Password never logged / filed.** The Credential Manager (DPAPI) is the
+  only persistence; the blob buffer is zeroed after use; no
+  `OutputDebugString` of secrets.
+- **No worker-pump parking.** The password branch only fires the Java
+  callback (hand-off); `Cred*` store I/O runs on the dispatcher's worker.
+- **Credential Manager hygiene**: `CRED_TYPE_GENERIC`, namespaced target,
+  `CRED_PERSIST_LOCAL_MACHINE`; `CredFree` on every enumerate; exact
+  target reconstruction for delete.
+- **JNI exception sanitisation** after every `CallVoidMethod`; symmetric
+  attach/detach; null-callback short-circuit.
+- **Callback global-ref lifecycle** set in the setter, deleted on engine
+  destroy; the Java callback anchored in the wrapper `heap` (canvas 23).
+- **No behavioural drift.** Java layer, shared JS, and value encoding are
+  shared; only the store backend, the message demux branch, and the
+  Edge-autosave setting are Windows-specific — all conforming to the
+  canvas-23 contract.
+- **Graceful QI failure.** A WebView2 Runtime lacking
+  `ICoreWebView2Settings4` simply skips the explicit autosave-off call
+  (default is already FALSE); no crash, no hard dependency on a Runtime
+  version.

--- a/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
+++ b/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
@@ -1026,13 +1026,18 @@ File: `src_c/webview_embed.cpp` (guarded `#if defined(WEBVIEW_COCOA)`)
      UTF-8 of `millis + "\n" + password`; if present `SecItemUpdate`
      (set `kSecValueData`), else `SecItemAdd` (add `kSecValueData` +
      `kSecAttrSynchronizable=kCFBooleanFalse`). Return `errSecSuccess`.
-   - `webview_cred_store_find`: query `service` + `kSecMatchLimitAll` +
-     `kSecReturnAttributes=true` + `kSecReturnData=true`; iterate the
-     result array; for each item decode `kSecAttrAccount` → origin,
-     username; if origin == target, split `kSecValueData` on first `\n`
-     into millis + password; collect `[username, millis, password]`.
-     Return a `jobjectArray` of the flat triples (Java sorts). Empty
-     array on `errSecItemNotFound`.
+   - `webview_cred_store_find`: the macOS keychain rejects
+     `kSecMatchLimitAll` combined with `kSecReturnData` (it returns
+     `errSecParam`, not results), so read in **two phases**. Phase 1 —
+     query `service` + `kSecMatchLimitAll` + `kSecReturnAttributes=true`
+     and **no** `kSecReturnData`, to enumerate every matching item's
+     `kSecAttrAccount` (the username). Phase 2 — for each account from
+     phase 1, issue a second query `service` + `kSecAttrAccount` +
+     `kSecMatchLimitOne` + `kSecReturnData=true` to fetch that one item's
+     `kSecValueData`; split it on the first `\n` into millis + password.
+     Collect `[username, millis, password]` per item. Return a
+     `jobjectArray` of the flat triples (Java sorts). Empty array when
+     phase 1 yields `errSecItemNotFound` or no accounts.
    - `webview_cred_store_delete`: `SecItemDelete` with exact account;
      return `errSecSuccess || errSecItemNotFound ? (removed?)` — return
      `true` only when an item was actually deleted (`errSecSuccess`).
@@ -1106,7 +1111,13 @@ File: `demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDem
    resolve `JAVA_HOME`; build `libwebview.dylib` from
    `src_c/webview_embed.cpp` (only when missing or older than its sources)
    including `-framework Security` for Keychain access alongside the
-   existing WebKit / Cocoa / QuartzCore frameworks; compile the `src`
+   existing WebKit / Cocoa / QuartzCore frameworks. Because a sibling
+   `run-mac-*.sh` may have previously built the dylib **without**
+   `-framework Security` (leaving the Keychain `SecItem*` / `kSec*`
+   symbols unbound so every credential-store call silently fails), also
+   force a rebuild when an existing dylib does not already link Security
+   — detect via `otool -L "$DYLIB" | grep -q Security`, not mtime alone.
+   Then compile the `src`
    Java sources and stage `dist/WebView.jar` with the dylib at the
    architecture-named root; compile
    `demos/WebViewPasswordDemo/src/...WebViewPasswordDemo.java` against that

--- a/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
+++ b/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
@@ -128,7 +128,7 @@ generated_at: 2026-08-13T15:30:00-07:00
     This canvas implements the macOS bodies (Keychain) and provides
     stub bodies (return `false` / empty / `false`) for the non-macOS
     compilation of `webview_embed.cpp` and for `windows/webview_embed.cc`,
-    so the class links on every platform; canvases 24 / 25 fill them in.
+    so the class links on every platform; canvases 27 / 28 fill them in.
 - Add `setPasswordCallback(WebViewPasswordCallback)` to both
   `EmbeddedWebView` and `OffscreenWebView`, mirroring
   `setDialogCallback` (`EmbeddedWebView.java:566`,
@@ -137,7 +137,7 @@ generated_at: 2026-08-13T15:30:00-07:00
   holds a global ref.
 - Add `-framework Security` to `build-mac.sh` (Keychain access). This is
   the only build-script change in this canvas; libsecret / Advapi32
-  linkage is added by canvases 24 / 25.
+  linkage is added by canvases 27 / 28.
 - Definition of Done:
   - All 20 STORY-006-001 ACs pass on macOS with the new code.
   - A `WebViewPasswordDemo` under `demos/` exercises capture + save
@@ -752,7 +752,7 @@ File: `src/ca/weblite/webview/WebViewSavePasswordHandler.java`
    on `evalAsync(...).get()`; exceptions are caught by the dispatcher and
    forwarded to the default uncaught-exception handler; a caller that
    wants no UI overrides this to return a disposition directly; macOS
-   coverage this iteration (forward-ref canvases 24/25 for Linux/Windows).
+   coverage this iteration (forward-ref canvases 27/28 for Linux/Windows).
 
 ### 6. Create Store Interface — WebViewCredentialStore
 File: `src/ca/weblite/webview/WebViewCredentialStore.java`
@@ -1197,7 +1197,7 @@ Files under `test/ca/weblite/webview/`:
 - **macOS-only coverage in this canvas.** On Linux/Windows the shared
   `SHIM_JS` is injected but no native `__webview_pw__` handler is wired
   yet, so no capture/fill fires and the store natives are stubs; the
-  programmatic API returns empty / false there until canvases 24 / 25.
+  programmatic API returns empty / false there until canvases 27 / 28.
   README documents this; a maintainer removing the restriction updates the
   docs in lockstep.
 
@@ -1276,4 +1276,4 @@ Files under `test/ca/weblite/webview/`:
 - **macOS-only wiring this canvas.** Linux/Windows have no native
   `__webview_pw__` handler and stub store natives; the injected `SHIM_JS`
   is inert there (its `post` finds no channel / the native handler is
-  absent). Documented in README; canvases 24/25 activate them.
+  absent). Documented in README; canvases 27/28 activate them.

--- a/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
+++ b/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
@@ -143,9 +143,12 @@ generated_at: 2026-08-13T15:30:00-07:00
   - A `WebViewPasswordDemo` under `demos/` exercises capture + save
     prompt + autofill in default-handler, custom-handler, and
     in-memory-store modes.
-  - A top-level `run-mac-password-demo.sh` builds the macOS native lib
-    and `dist/WebView.jar`, then compiles and launches
-    `WebViewPasswordDemo`, so the demo runs with one command.
+  - Top-level one-command launchers build the native lib and
+    `dist/WebView.jar`, then compile and launch `WebViewPasswordDemo`:
+    `run-mac-password-demo.sh` (Keychain-backed capture/autofill), plus
+    `run-linux-password-demo.sh` and `run-windows-password-demo.bat` for
+    the same demo (programmatic API + in-memory store; native capture/fill
+    pending canvases 27 / 28).
   - README grows a "Password manager" subsection documenting the
     `setPasswordManagerEnabled` / store / save-handler API, the
     origin-keying and origin-exact-match rules, the security notes
@@ -325,6 +328,12 @@ generated_at: 2026-08-13T15:30:00-07:00
 - **`run-mac-password-demo.sh`** (new, repo root): self-contained
   build-and-run launcher for `WebViewPasswordDemo`, mirroring
   `run-mac-download-demo.sh` and adding `-framework Security`.
+
+- **`run-linux-password-demo.sh`** / **`run-windows-password-demo.bat`**
+  (new, repo root): self-contained launchers for the same demo, mirroring
+  the download-demo siblings. Capture/autofill are macOS-only this
+  release; on Linux/Windows the demo runs with the programmatic API and
+  in-memory store working, native capture/fill pending canvases 27 / 28.
 
 - **README.md** (modified): "Password manager" subsection.
 
@@ -1123,6 +1132,19 @@ File: `demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDem
    `demos/WebViewPasswordDemo/src/...WebViewPasswordDemo.java` against that
    jar; and launch the demo's main class. No Ant required (the script is
    self-contained, like the other `run-mac-*-demo.sh` scripts).
+6. Also add Linux and Windows launchers for the same demo —
+   `run-linux-password-demo.sh` and `run-windows-password-demo.bat` —
+   each mirroring its download-demo sibling
+   (`run-linux-download-demo.sh` / `run-windows-download-demo.bat`)
+   verbatim except for targeting
+   `demos/WebViewPasswordDemo/...WebViewPasswordDemo.java` and its main
+   class. No macOS-only `-framework Security` step applies there (that is
+   a Keychain concern). Each header must state the coverage caveat:
+   automatic capture / autofill are macOS-only this release; on Linux and
+   Windows the demo still runs and the programmatic API plus the in-memory
+   store work, but the native capture/fill channel and OS secret store
+   arrive with canvases 27 / 28. The Linux script keeps the
+   heavyweight/lightweight mode selection of its sibling.
 
 ### 22. Update README
 File: `README.md`

--- a/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
+++ b/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
@@ -26,7 +26,9 @@ generated_at: 2026-08-13T15:30:00-07:00
     value object; equality on `{origin, username}` (password excluded);
     `toString()` redacts the password.
   - `WebViewCredentialStore` — the storage seam interface: `save`,
-    `find(origin)`, `findAll(origin)`, `delete(origin, username)`.
+    `find(origin)`, `findAll(origin)`, `findAll()` (no-argument
+    enumerate-all across every origin, most-recently-saved first — added
+    by STORY-006-005), `delete(origin, username)`.
   - `NativeCredentialStore` — the default `WebViewCredentialStore`,
     backed by the OS-native secret store (Keychain on macOS in this
     canvas) through new process-global static JNI primitives.
@@ -41,6 +43,23 @@ generated_at: 2026-08-13T15:30:00-07:00
     `SavePasswordDisposition onLoginSubmitted(WebViewSavePasswordEvent)`,
     invoked on the EDT; `DEFAULT` shows a Swing "Save password?" prompt
     modal to the host `JFrame`.
+  - `FillPasswordDisposition` — enum `{ FILL, DONT_FILL }` (added by
+    STORY-006-004): the autofill-consent decision.
+  - `WebViewFillPasswordEvent` — immutable autofill-consent event
+    (`source`, `origin`, `username`) — deliberately **carries no
+    password** (no password accessor; `toString()` shows origin +
+    username only). Added by STORY-006-004.
+  - `WebViewFillPasswordHandler` — `@FunctionalInterface`,
+    `FillPasswordDisposition onAutofillRequested(WebViewFillPasswordEvent)`,
+    invoked on the EDT before an automatic autofill (added by
+    STORY-006-004). `DEFAULT` returns `FILL` unconditionally (preserves
+    the shipped silent-autofill behaviour — a hard backward-compat
+    requirement); `CONFIRM` is an opt-in instance that shows a Swing
+    "Use the saved password for `<origin>`?" confirm prompt (showing the
+    username, never the password) modal to the host `JFrame`, returning
+    `FILL` on OK and `DONT_FILL` on Cancel/close. A host may install
+    `CONFIRM`, or its own handler that performs an OS biometric /
+    re-authentication check, to gate autofill.
   - `WebViewPasswordCallback` — the JNI-facing callback interface (two
     void methods, invoked from the native message thread), analogous to
     `WebViewDialogCallback`. Application code never implements it; it
@@ -61,11 +80,22 @@ generated_at: 2026-08-13T15:30:00-07:00
     / `WebViewSavePasswordHandler getSavePasswordHandler()` — the
     save-policy seam; `null` reinstalls the default Swing-prompt handler;
     `get` never returns null.
+  - `WebViewComponent setFillPasswordHandler(WebViewFillPasswordHandler)`
+    / `WebViewFillPasswordHandler getFillPasswordHandler()` — the
+    autofill-consent seam (STORY-006-004); `null` reinstalls
+    `WebViewFillPasswordHandler.DEFAULT`; `get` never returns null.
+    Consulted only on the automatic page-load autofill path; the
+    programmatic read methods below are never gated by it.
   - `void saveCredential(WebViewCredential)` — programmatic upsert.
   - `java.util.Optional<WebViewCredential> getCredential(String origin)`
     — programmatic lookup (most-recently-saved for the origin).
   - `java.util.List<WebViewCredential> getCredentials(String origin)` —
     all credentials for the origin, most-recently-saved first.
+  - `java.util.List<WebViewCredential> getAllCredentials()` —
+    programmatic enumerate-all across every origin, most-recently-saved
+    first (STORY-006-005); the primitive a host needs to build a
+    "manage saved passwords" UI. Delegates to the store's no-argument
+    `findAll()`.
   - `boolean deleteCredential(String origin, String username)`.
 - Author the shared detection/fill JavaScript
   (`PasswordDispatcher.SHIM_JS`), injected at document-start on every
@@ -108,6 +138,20 @@ generated_at: 2026-08-13T15:30:00-07:00
 - All secret-store I/O (Keychain reads/writes) runs off the EDT and off
   the engine UI thread, on the dispatcher's single-thread executor. The
   autofill lookup and the post-approval save both run there.
+- **Autofill is gated by a consent handler (STORY-006-004).** After the
+  store lookup finds an origin-matched credential on the worker thread,
+  the dispatcher marshals `{source, origin, username}` (never the
+  password) to the EDT via `SwingUtilities.invokeLater`, re-checks the
+  disposed/enabled flags, and consults `WebViewFillPasswordHandler`. It
+  injects the credential (evals the write-only `__webview_pw_fill__`
+  entrypoint) only when the disposition is `FILL`; `DONT_FILL` skips the
+  injection silently. The default handler returns `FILL`, so the shipped
+  silent-autofill behaviour is unchanged unless a host opts into
+  `CONFIRM` or a custom (e.g. biometric) handler. A handler exception is
+  caught and forwarded to the default uncaught-exception handling;
+  nothing is filled. The keychain read stays on the worker; only the
+  host-controlled consent decision and the fire-and-forget eval run on
+  the EDT.
 - Add new JNI entry points on `WebViewNative`:
   - `webview_embed_set_password_callback(long, WebViewPasswordCallback)`
     and `webview_offscreen_set_password_callback(long, WebViewPasswordCallback)`
@@ -121,6 +165,12 @@ generated_at: 2026-08-13T15:30:00-07:00
     - `String[] webview_cred_store_find(String service, String origin)`
       — flat triples `[username, savedAtMillis, password, ...]`,
       most-recently-saved first; empty array when none / unavailable.
+    - `String[] webview_cred_store_find_all(String service)` — enumerate
+      every credential under the service namespace across all origins, as
+      flat **quads** `[origin, username, savedAtMillis, password, ...]`
+      (origin is included because it is not known a priori); empty array
+      when none / unavailable (STORY-006-005). macOS body here; Linux /
+      Windows bodies in canvases 27 / 28.
     - `boolean webview_cred_store_delete(String service, String origin, String username)`
     - `boolean webview_cred_store_available()` — whether the platform
       secret store is usable (always `true` on macOS; meaningful on
@@ -140,9 +190,28 @@ generated_at: 2026-08-13T15:30:00-07:00
   linkage is added by canvases 27 / 28.
 - Definition of Done:
   - All 20 STORY-006-001 ACs pass on macOS with the new code.
+  - All 11 STORY-006-004 ACs (autofill-consent handler) pass headlessly:
+    default fills with no prompt (no regression), `CONFIRM` shows a
+    password-free confirmation, approve fills / decline fills nothing, a
+    programmatic `DONT_FILL` handler suppresses fill, the fill event
+    exposes no password, the handler runs on the EDT, the getter is
+    never null and `setFillPasswordHandler(null)` restores `DEFAULT`, the
+    programmatic read API is not gated, a disabled manager short-circuits
+    before the handler, and a handler exception does not crash the
+    WebView.
+  - All 10 STORY-006-005 ACs (enumerate-all) pass: `getAllCredentials()`
+    returns every credential across all origins, most-recently-saved
+    first; multiple usernames per origin all appear; an empty store
+    returns an empty (non-null) list; a deletion is reflected; the
+    in-memory store enumerates; passwords never appear in output; page
+    JavaScript cannot reach the enumeration (macOS native round-trip
+    verified via the demo; Linux / Windows native bodies in canvases
+    27 / 28).
   - A `WebViewPasswordDemo` under `demos/` exercises capture + save
     prompt + autofill in default-handler, custom-handler, and
-    in-memory-store modes.
+    in-memory-store modes, plus a fill-consent toggle (install `CONFIRM`)
+    and a "Get All" action that lists every stored credential (username +
+    origin only; passwords never printed).
   - Top-level one-command launchers build the native lib and
     `dist/WebView.jar`, then compile and launch `WebViewPasswordDemo`:
     `run-mac-password-demo.sh` (Keychain-backed capture/autofill) and
@@ -171,8 +240,11 @@ generated_at: 2026-08-13T15:30:00-07:00
     disabling Edge's built-in autosave (canvas 28).
   - The standalone in-process `WebView` class — this canvas only touches
     the embedded `WebViewComponent` surface.
-  - A credential-management UI (a "manage saved passwords" window). Hosts
-    build their own on the programmatic API.
+  - A shipped credential-management UI (a "manage saved passwords"
+    window). Hosts build their own on the programmatic API — and
+    STORY-006-005 now supplies the missing enumerate-all primitive
+    (`getAllCredentials()`) that such a UI needs, so this is achievable;
+    the library still ships no manager window itself.
   - Guaranteed multi-step / identifier-first (split username→password
     page) capture. Best-effort per-page capture is in scope; cross-page
     correlation is a documented limitation.
@@ -180,7 +252,12 @@ generated_at: 2026-08-13T15:30:00-07:00
     metering.
   - Cross-origin / subdomain credential matching, and login inside a
     cross-origin iframe. Matching is exact top-frame origin only.
-  - Biometric / re-auth gating before autofill.
+  - A shipped biometric / OS-credential re-auth *implementation* (Touch
+    ID, Windows Hello, `LAContext`) before autofill. STORY-006-004 now
+    supplies the *decision seam* (`WebViewFillPasswordHandler`) plus a
+    Swing-`CONFIRM` default at which a host performs such a check and
+    returns `DONT_FILL` to decline; the library ships no biometric code
+    of its own.
   - Guaranteed zeroisation of password material on the JVM heap (Java
     `String` immutability prevents a hard guarantee; the library
     minimises retention and never logs — documented limitation).
@@ -210,6 +287,10 @@ generated_at: 2026-08-13T15:30:00-07:00
   - `java.util.List<WebViewCredential> findAll(String origin)` — all
     credentials for the origin, most-recently-saved first
     (unmodifiable list; empty when none).
+  - `java.util.List<WebViewCredential> findAll()` — no-argument
+    enumerate-all: every credential under the library namespace across
+    all origins, most-recently-saved first (unmodifiable list; empty when
+    none / store unavailable). Added by STORY-006-005.
   - `boolean delete(String origin, String username)` — remove one;
     returns whether anything was removed.
   No `DEFAULT` constant on the interface (the default *instance* is a
@@ -219,18 +300,23 @@ generated_at: 2026-08-13T15:30:00-07:00
   `src/ca/weblite/webview/NativeCredentialStore.java`). Default store,
   backed by the OS-native secret store via the static JNI primitives.
   Owns origin canonicalisation (through `Origins`) and translates
-  between `WebViewCredential` and the flat JNI triples. Stateless and
+  between `WebViewCredential` and the flat JNI triples (origin-scoped
+  `find`) / quads (`findAll()` enumerate-all). Stateless and
   thread-safe (the JNI primitives are process-global and serialise
   internally at the OS level). A single library-namespace `service`
-  constant (`"ca.weblite.webview.passwords"`).
+  constant (`"ca.weblite.webview.passwords"`). Its no-argument
+  `findAll()` calls the new `webview_cred_store_find_all` primitive
+  (STORY-006-005).
 
 - **InMemoryCredentialStore** (new public final class,
   `src/ca/weblite/webview/InMemoryCredentialStore.java`). A
   `WebViewCredentialStore` backed by a `ConcurrentHashMap` keyed by
   canonical origin → ordered list of `{username, savedAtMillis,
   password}`. Applies the same canonicalisation and recency ordering as
-  `NativeCredentialStore`, so tests observe identical semantics. Never
-  touches the OS store. Used by tests and available to hosts.
+  `NativeCredentialStore`, so tests observe identical semantics. Its
+  no-argument `findAll()` enumerates the whole map across all origins,
+  most-recently-saved first (STORY-006-005). Never touches the OS store.
+  Used by tests and available to hosts.
 
 - **WebViewSavePasswordEvent** (new public final class,
   `src/ca/weblite/webview/WebViewSavePasswordEvent.java`). Immutable.
@@ -255,6 +341,39 @@ generated_at: 2026-08-13T15:30:00-07:00
   returning `SAVE` on OK and `DONT_SAVE` on Cancel/close. Class Javadoc
   documents EDT invocation, that the method must not block on
   `evalAsync(...).get()` (EDT hazard), and exception isolation.
+
+- **FillPasswordDisposition** (new public enum,
+  `src/ca/weblite/webview/FillPasswordDisposition.java`): `FILL`,
+  `DONT_FILL`. The autofill-consent decision (STORY-006-004).
+
+- **WebViewFillPasswordEvent** (new public final class,
+  `src/ca/weblite/webview/WebViewFillPasswordEvent.java`). Immutable.
+  Package-private constructor `WebViewFillPasswordEvent(WebViewComponent
+  source, String origin, String username)`; `source` non-null (NPE),
+  `origin`/`username` non-null coerced to empty. Accessors `source()`,
+  `origin()`, `username()`. **No password field and no password
+  accessor** — the autofill-consent decision needs only identity, so the
+  password is never handed to host consent code. `toString()` renders
+  `"WebViewFillPasswordEvent[origin=<...>, username=<...>]"`
+  (STORY-006-004).
+
+- **WebViewFillPasswordHandler** (new public `@FunctionalInterface`,
+  `src/ca/weblite/webview/WebViewFillPasswordHandler.java`). Single
+  abstract method `FillPasswordDisposition onAutofillRequested(
+  WebViewFillPasswordEvent event)`, invoked on the EDT before an
+  automatic autofill. Public static constants:
+  - `DEFAULT` — returns `FILL` unconditionally, preserving the shipped
+    silent-autofill behaviour (hard backward-compat requirement); it is
+    the dispatcher's initial handler.
+  - `CONFIRM` — an opt-in instance whose `onAutofillRequested` shows a
+    Swing confirm prompt ("Use the saved password for `<origin>`?" plus
+    the username, **never** the password) modal to
+    `SwingUtilities.getWindowAncestor(event.source())`, returning `FILL`
+    on OK and `DONT_FILL` on Cancel/close.
+  Class Javadoc documents EDT invocation, that the method must not block
+  on `evalAsync(...).get()`, exception isolation, and that a host may
+  install `CONFIRM` or its own handler (e.g. one performing an OS
+  biometric / re-authentication check) to gate autofill (STORY-006-004).
 
 - **WebViewPasswordCallback** (new public interface,
   `src/ca/weblite/webview/WebViewPasswordCallback.java`). JNI-facing;
@@ -284,21 +403,26 @@ generated_at: 2026-08-13T15:30:00-07:00
 - **PasswordDispatcher** (new public final class,
   `src/ca/weblite/webview/PasswordDispatcher.java`). Per-component hub.
   Public-because-cross-package (matches `DialogDispatcher`). Holds the
-  active store, save-handler, enabled flag; a single-thread executor for
-  store I/O; the shared `SHIM_JS` constant; the native-facing dispatch
-  methods; and the programmatic API the component delegates to.
-  Invariants: constructed once per component, lives for its lifetime;
-  `getStore()`/`getSaveHandler()` never null; `setStore(null)` /
-  `setSaveHandler(null)` restore defaults; disabled ⇒ automatic dispatch
-  is dropped but programmatic methods still work; disposed ⇒ automatic
-  dispatch is dropped.
+  active store, save-handler, **fill-handler (STORY-006-004)**, enabled
+  flag; a single-thread executor for store I/O; the shared `SHIM_JS`
+  constant; the native-facing dispatch methods; and the programmatic API
+  the component delegates to (including `getAllCredentials()`,
+  STORY-006-005). Invariants: constructed once per component, lives for
+  its lifetime; `getStore()`/`getSaveHandler()`/`getFillHandler()` never
+  null; `setStore(null)` / `setSaveHandler(null)` / `setFillHandler(null)`
+  restore defaults; disabled ⇒ automatic dispatch is dropped but
+  programmatic methods still work; disposed ⇒ automatic dispatch is
+  dropped. The fill-handler is consulted (on the EDT) only on the
+  automatic autofill path, never on the programmatic read methods.
 
 - **WebViewComponent** (modified;
   `src/ca/weblite/webview/swing/WebViewComponent.java`). Gains:
   - `protected final PasswordDispatcher passwordDispatcher = new PasswordDispatcher(this);`
     (same eager-construction pattern as `dialogDispatcher`).
-  - the nine `final` public methods listed in R, each a thin delegation
-    to `passwordDispatcher`.
+  - the `final` public methods listed in R, each a thin delegation to
+    `passwordDispatcher` — the original nine plus
+    `setFillPasswordHandler` / `getFillPasswordHandler` (STORY-006-004)
+    and `getAllCredentials` (STORY-006-005).
 
 - **EmbeddedWebView** / **OffscreenWebView** (modified). Each gains
   `setPasswordCallback(WebViewPasswordCallback)` mirroring
@@ -306,20 +430,24 @@ generated_at: 2026-08-13T15:30:00-07:00
   new JNI entry point.
 
 - **WebViewNative** (modified). Gains the two `..._set_password_callback`
-  natives and the four `webview_cred_store_*` static natives.
+  natives and the `webview_cred_store_*` static natives — `save`, `find`,
+  `find_all` (STORY-006-005), `delete`, `available` (five total).
 
 - **`src_c/webview_embed.cpp`** (modified, macOS bodies + non-mac
   stubs). Gains: `Engine::password_callback` jobject field; a dedicated
   `WKScriptMessageHandler` registered under name `__webview_pw__` that
   reads the committed frame URL and calls the Java callback;
   `cocoa_set_password_callback`; the JNI bridge for the two callback
-  setters; and the macOS Keychain bodies for the four
-  `webview_cred_store_*` primitives (plus non-Apple stub bodies).
+  setters; and the macOS Keychain bodies for the five
+  `webview_cred_store_*` primitives — including `find_all`
+  (STORY-006-005), the two-phase `SecItemCopyMatching` with
+  `kSecMatchLimitAll` over the service namespace — plus non-Apple stub
+  bodies.
 
 - **`windows/webview_embed.cc`** (modified, stubs only in this canvas):
-  stub bodies for the four `webview_cred_store_*` primitives and the two
-  `..._set_password_callback` setters, so the JNI surface links on
-  Windows. Real Windows implementation is canvas 28.
+  stub bodies for the five `webview_cred_store_*` primitives (including
+  `find_all`) and the two `..._set_password_callback` setters, so the
+  JNI surface links on Windows. Real Windows implementation is canvas 28.
 
 - **`build-mac.sh`** (modified): add `-framework Security`.
 
@@ -360,6 +488,7 @@ class WebViewCredentialStore {
     +save(WebViewCredential) void
     +find(String) Optional~WebViewCredential~
     +findAll(String) List~WebViewCredential~
+    +findAll() List~WebViewCredential~
     +delete(String, String) boolean
 }
 
@@ -367,6 +496,7 @@ class NativeCredentialStore {
     +save(WebViewCredential) void
     +find(String) Optional~WebViewCredential~
     +findAll(String) List~WebViewCredential~
+    +findAll() List~WebViewCredential~
     +delete(String, String) boolean
 }
 
@@ -374,6 +504,7 @@ class InMemoryCredentialStore {
     +save(WebViewCredential) void
     +find(String) Optional~WebViewCredential~
     +findAll(String) List~WebViewCredential~
+    +findAll() List~WebViewCredential~
     +delete(String, String) boolean
 }
 
@@ -396,6 +527,25 @@ class WebViewSavePasswordHandler {
     +DEFAULT WebViewSavePasswordHandler$
 }
 
+class WebViewFillPasswordEvent {
+    +source() WebViewComponent
+    +origin() String
+    +username() String
+}
+
+class FillPasswordDisposition {
+    <<enumeration>>
+    FILL
+    DONT_FILL
+}
+
+class WebViewFillPasswordHandler {
+    <<interface>>
+    +onAutofillRequested(WebViewFillPasswordEvent) FillPasswordDisposition
+    +DEFAULT WebViewFillPasswordHandler$
+    +CONFIRM WebViewFillPasswordHandler$
+}
+
 class WebViewPasswordCallback {
     <<interface>>
     +onLoginSubmitted(String, String, String) void
@@ -410,6 +560,7 @@ class PasswordDispatcher {
     -source WebViewComponent
     -store WebViewCredentialStore
     -handler WebViewSavePasswordHandler
+    -fillHandler WebViewFillPasswordHandler
     -enabled boolean
     -disposed boolean
     +setEnabled(boolean) void
@@ -418,9 +569,12 @@ class PasswordDispatcher {
     +getStore() WebViewCredentialStore
     +setHandler(WebViewSavePasswordHandler) void
     +getHandler() WebViewSavePasswordHandler
+    +setFillHandler(WebViewFillPasswordHandler) void
+    +getFillHandler() WebViewFillPasswordHandler
     +saveCredential(WebViewCredential) void
     +getCredential(String) Optional~WebViewCredential~
     +getCredentials(String) List~WebViewCredential~
+    +getAllCredentials() List~WebViewCredential~
     +deleteCredential(String, String) boolean
     +dispatchLoginSubmitted(String, String, String) void
     +dispatchFillRequested(String) void
@@ -436,9 +590,12 @@ class WebViewComponent {
     +getCredentialStore() WebViewCredentialStore
     +setSavePasswordHandler(WebViewSavePasswordHandler) WebViewComponent
     +getSavePasswordHandler() WebViewSavePasswordHandler
+    +setFillPasswordHandler(WebViewFillPasswordHandler) WebViewComponent
+    +getFillPasswordHandler() WebViewFillPasswordHandler
     +saveCredential(WebViewCredential) void
     +getCredential(String) Optional~WebViewCredential~
     +getCredentials(String) List~WebViewCredential~
+    +getAllCredentials() List~WebViewCredential~
     +deleteCredential(String, String) boolean
 }
 
@@ -455,9 +612,12 @@ WebViewCredentialStore <|.. InMemoryCredentialStore
 WebViewComponent "1" *-- "1" PasswordDispatcher : owns
 PasswordDispatcher "1" --> "1" WebViewCredentialStore : reads/writes
 PasswordDispatcher "1" --> "1" WebViewSavePasswordHandler : asks
+PasswordDispatcher "1" --> "1" WebViewFillPasswordHandler : asks before fill
 PasswordDispatcher ..> WebViewSavePasswordEvent : constructs
+PasswordDispatcher ..> WebViewFillPasswordEvent : constructs
 PasswordDispatcher ..> Origins : canonicalises via
 WebViewSavePasswordHandler ..> SavePasswordDisposition : returns
+WebViewFillPasswordHandler ..> FillPasswordDisposition : returns
 NativeCredentialStore ..> Origins : canonicalises via
 InMemoryCredentialStore ..> Origins : canonicalises via
 EmbeddedWebView ..> WebViewPasswordCallback : invokes via JNI
@@ -772,15 +932,65 @@ File: `src/ca/weblite/webview/WebViewSavePasswordHandler.java`
    wants no UI overrides this to return a disposition directly; macOS
    coverage this iteration (forward-ref canvases 27/28 for Linux/Windows).
 
+### 5a. Create Enum — FillPasswordDisposition
+File: `src/ca/weblite/webview/FillPasswordDisposition.java` (STORY-006-004)
+
+1. Public enum with constants `FILL`, `DONT_FILL`. Javadoc: the
+   autofill-consent handler's decision.
+
+### 5b. Create Value Object — WebViewFillPasswordEvent
+File: `src/ca/weblite/webview/WebViewFillPasswordEvent.java` (STORY-006-004)
+
+1. Responsibility: immutable autofill-consent event handed to the
+   fill-handler. Deliberately **password-free**.
+2. Package-private constructor `(WebViewComponent source, String origin,
+   String username)`: null-check `source` (NPE `"source"`); coerce null
+   `origin`/`username` to empty.
+3. Accessors `source()`, `origin()`, `username()`. **No password
+   accessor and no password field** — the consent decision needs only
+   identity.
+4. `toString()` → `"WebViewFillPasswordEvent[origin=" + origin +
+   ", username=" + username + "]"` (no password to redact — there is
+   none).
+
+### 5c. Create Handler Interface — WebViewFillPasswordHandler
+File: `src/ca/weblite/webview/WebViewFillPasswordHandler.java` (STORY-006-004)
+
+1. Public `@FunctionalInterface`.
+2. `FillPasswordDisposition onAutofillRequested(WebViewFillPasswordEvent event)`
+   — invoked on the EDT before an automatic autofill.
+3. Public static constant `DEFAULT`:
+   - `WebViewFillPasswordHandler DEFAULT = event -> FillPasswordDisposition.FILL;`
+   - Returns `FILL` unconditionally — preserves the shipped
+     silent-autofill behaviour (hard backward-compat requirement) and is
+     the dispatcher's initial handler.
+4. Public static constant `CONFIRM`:
+   - `WebViewFillPasswordHandler CONFIRM = event -> { ... }`.
+   - Logic: `Window host = SwingUtilities.getWindowAncestor(event.source());`
+     `String msg = "Use the saved password for " + event.origin() + "?\n\nUsername: " + event.username();`
+     `int r = JOptionPane.showConfirmDialog(host, msg, "Use saved password?", JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);`
+     `return r == JOptionPane.OK_OPTION ? FillPasswordDisposition.FILL : FillPasswordDisposition.DONT_FILL;`.
+   - Never include a password (the event has none).
+5. Class Javadoc: EDT invocation; must return promptly and must not block
+   on `evalAsync(...).get()`; exceptions are caught by the dispatcher and
+   forwarded to the default uncaught-exception handler; a host installs
+   `CONFIRM` (or a custom handler performing an OS biometric /
+   re-authentication check) to gate autofill and returns `DONT_FILL` to
+   decline; consulted only on automatic autofill, never on the
+   programmatic read API.
+
 ### 6. Create Store Interface — WebViewCredentialStore
 File: `src/ca/weblite/webview/WebViewCredentialStore.java`
 
-1. Public interface with the four methods from E. Method Javadoc: `save`
-   is upsert on `{origin, username}`; `find` returns the
-   most-recently-saved for the origin; `findAll` is most-recent-first and
-   unmodifiable; `delete` returns whether a record was removed. Implementations
-   must be safe to call from any thread and should not throw on a missing
-   backend (return empty / false).
+1. Public interface with the five methods from E. Method Javadoc: `save`
+   is upsert on `{origin, username}`; `find(origin)` returns the
+   most-recently-saved for the origin; `findAll(origin)` is
+   most-recent-first and unmodifiable; the no-argument `findAll()`
+   enumerates every credential under the library namespace across all
+   origins, most-recent-first and unmodifiable (empty when none / store
+   unavailable — STORY-006-005); `delete` returns whether a record was
+   removed. Implementations must be safe to call from any thread and
+   should not throw on a missing backend (return empty / false).
 
 ### 7. Create Store — NativeCredentialStore
 File: `src/ca/weblite/webview/NativeCredentialStore.java`
@@ -803,11 +1013,19 @@ File: `src/ca/weblite/webview/NativeCredentialStore.java`
      then username asc. Return `Collections.unmodifiableList`.
    - Native already returns most-recent-first, but Java re-sorts so the
      ordering contract holds identically across all three platforms.
-6. `delete(String origin, String username)`:
+6. `findAll()` (no argument, STORY-006-005):
+   - `String[] flat = WebViewNative.webview_cred_store_find_all(SERVICE);`
+     (try/catch → empty). Iterate in **quads** `[origin, username,
+     millisStr, password]`; build `WebViewCredential(origin, username,
+     password)` with the origin verbatim from the store (already
+     canonical, since only canonical origins are ever written); collect
+     with their `millis`. Sort by millis desc, then origin asc, then
+     username asc. Return `Collections.unmodifiableList`.
+7. `delete(String origin, String username)`:
    - canonicalise; if null → false; else
      `return WebViewNative.webview_cred_store_delete(SERVICE, o, username);`
      (try/catch → false).
-7. No password in any log / `toString`.
+8. No password in any log / `toString`.
 
 ### 8. Create Store — InMemoryCredentialStore
 File: `src/ca/weblite/webview/InMemoryCredentialStore.java`
@@ -824,7 +1042,11 @@ File: `src/ca/weblite/webview/InMemoryCredentialStore.java`
    asc; map to `WebViewCredential(origin, username, password)`;
    unmodifiable.
 5. `find`: first of `findAll`.
-6. `delete`: canonicalise; remove rec by username; return whether
+6. `findAll()` (no argument, STORY-006-005): iterate every origin's list,
+   flatten all `{origin, username, savedAtMillis, password}` records into
+   one collection, sort millis desc then origin asc then username asc,
+   map to `WebViewCredential(origin, username, password)`; unmodifiable.
+7. `delete`: canonicalise; remove rec by username; return whether
    removed.
 
 ### 9. Create JNI Callback Interface — WebViewPasswordCallback
@@ -848,6 +1070,7 @@ File: `src/ca/weblite/webview/PasswordDispatcher.java`
    - `private final WebViewComponent source;`
    - `private volatile WebViewCredentialStore store = new NativeCredentialStore();`
    - `private volatile WebViewSavePasswordHandler handler = WebViewSavePasswordHandler.DEFAULT;`
+   - `private volatile WebViewFillPasswordHandler fillHandler = WebViewFillPasswordHandler.DEFAULT;` (STORY-006-004)
    - `private volatile boolean enabled = true;`
    - `private volatile boolean disposed = false;`
    - `private final java.util.concurrent.ExecutorService io = Executors.newSingleThreadExecutor(r -> { Thread t = new Thread(r, "webview-password-io"); t.setDaemon(true); return t; });`
@@ -858,11 +1081,15 @@ File: `src/ca/weblite/webview/PasswordDispatcher.java`
    - `getStore()` (never null).
    - `setHandler(WebViewSavePasswordHandler h)`: `handler = (h == null) ? WebViewSavePasswordHandler.DEFAULT : h;`.
    - `getHandler()` (never null).
+   - `setFillHandler(WebViewFillPasswordHandler h)`: `fillHandler = (h == null) ? WebViewFillPasswordHandler.DEFAULT : h;` (STORY-006-004).
+   - `getFillHandler()` (never null).
 6. Programmatic API (run synchronously on the caller thread so
-   round-trips are deterministic — AC8/AC9/AC10/AC11):
+   round-trips are deterministic — AC8/AC9/AC10/AC11). **These are trusted
+   host calls and are never gated by the fill handler**:
    - `saveCredential(WebViewCredential c)`: null-check; `store.save(c)`.
    - `getCredential(String origin)`: `return store.find(origin);`.
    - `getCredentials(String origin)`: `return store.findAll(origin);`.
+   - `getAllCredentials()`: `return store.findAll();` (STORY-006-005).
    - `deleteCredential(String origin, String username)`: `return store.delete(origin, username);`.
 7. Native-facing dispatch:
    - `dispatchLoginSubmitted(String frameUrl, String b64User, String b64Pass)`:
@@ -881,10 +1108,27 @@ File: `src/ca/weblite/webview/PasswordDispatcher.java`
      - if `disposed || !enabled` → return.
      - `String origin = Origins.canonical(frameUrl);` if null → return.
      - `io.execute(() -> doFill(origin));`
-   - `private void doFill(String origin)` (on io thread):
+   - `private void doFill(String origin)` (starts on io thread;
+     STORY-006-004 adds the EDT consent hop):
      - `Optional<WebViewCredential> c;` `try { c = store.find(origin); } catch (Throwable t) { forward(t); return; }`
      - if absent → return (AC19).
-     - `String js = "window.__webview_pw_fill__('" + base64UrlEncode(c.username()) + "','" + base64UrlEncode(c.password()) + "')";`
+     - `final WebViewCredential cred = c.get();`
+     - Marshal the consent decision to the EDT:
+       `SwingUtilities.invokeLater(() -> fillOnEdt(origin, cred));`
+       (the keychain read has already happened off the EDT; only the
+       host-controlled consent decision and the fire-and-forget eval run
+       on the EDT).
+   - `private void fillOnEdt(String origin, WebViewCredential cred)`
+     (on EDT, STORY-006-004):
+     - re-check `disposed || !enabled` → return (AC10: a manager disabled
+       between request and consent still fills nothing).
+     - `FillPasswordDisposition d;`
+       `try { WebViewFillPasswordEvent ev = new WebViewFillPasswordEvent(source, origin, cred.username()); d = fillHandler.onAutofillRequested(ev); } catch (Throwable t) { forward(t); return; }`
+       (the event carries no password — AC6; a handler exception fills
+       nothing and does not crash — AC11).
+     - if `d != FillPasswordDisposition.FILL` → return (DONT_FILL skips
+       silently — AC4/AC5).
+     - `String js = "window.__webview_pw_fill__('" + base64UrlEncode(cred.username()) + "','" + base64UrlEncode(cred.password()) + "')";`
      - `try { source.eval(js); } catch (Throwable t) { forward(t); }` — never log `js` (it embeds the password).
    - `private void safeSave(WebViewCredential c)`: `try { store.save(c); } catch (Throwable t) { forward(t); }`.
 8. `disposeAll()`: `disposed = true; io.shutdownNow();` (idempotent).
@@ -950,16 +1194,21 @@ File: `src/ca/weblite/webview/swing/WebViewComponent.java`
 
 1. Add field (next to `dialogDispatcher`):
    `protected final PasswordDispatcher passwordDispatcher = new PasswordDispatcher(this);`.
-2. Add nine `final` methods, each delegating:
+2. Add the `final` delegating methods (the original nine plus
+   `setFillPasswordHandler`/`getFillPasswordHandler` from STORY-006-004
+   and `getAllCredentials` from STORY-006-005):
    - `setPasswordManagerEnabled(boolean e)` → `passwordDispatcher.setEnabled(e); return this;`
    - `isPasswordManagerEnabled()` → `passwordDispatcher.isEnabled();`
    - `setCredentialStore(WebViewCredentialStore s)` → `passwordDispatcher.setStore(s); return this;`
    - `getCredentialStore()` → `passwordDispatcher.getStore();`
    - `setSavePasswordHandler(WebViewSavePasswordHandler h)` → `passwordDispatcher.setHandler(h); return this;`
    - `getSavePasswordHandler()` → `passwordDispatcher.getHandler();`
+   - `setFillPasswordHandler(WebViewFillPasswordHandler h)` → `passwordDispatcher.setFillHandler(h); return this;` (STORY-006-004)
+   - `getFillPasswordHandler()` → `passwordDispatcher.getFillHandler();` (STORY-006-004)
    - `saveCredential(WebViewCredential c)` → `passwordDispatcher.saveCredential(c);`
    - `getCredential(String origin)` → `passwordDispatcher.getCredential(origin);`
    - `getCredentials(String origin)` → `passwordDispatcher.getCredentials(origin);`
+   - `getAllCredentials()` → `passwordDispatcher.getAllCredentials();` (STORY-006-005)
    - `deleteCredential(String origin, String u)` → `passwordDispatcher.deleteCredential(origin, u);`
 3. In the existing `dispose()` path, call `passwordDispatcher.disposeAll()`
    alongside the existing `dialogDispatcher.disposeAll()` (both swing
@@ -992,9 +1241,13 @@ File: `src/ca/weblite/webview/WebViewNative.java`
 1. Add two callback-setter declarations (after the dialog ones):
    - `native static void webview_embed_set_password_callback(long w, WebViewPasswordCallback cb);`
    - `native static void webview_offscreen_set_password_callback(long peer, WebViewPasswordCallback cb);`
-2. Add four static store declarations:
+2. Add five static store declarations:
    - `native static boolean webview_cred_store_save(String service, String origin, String username, String password, long savedAtMillis);`
    - `native static String[] webview_cred_store_find(String service, String origin);`
+   - `native static String[] webview_cred_store_find_all(String service);`
+     — flat quads `[origin, username, savedAtMillis, password, ...]` across
+     all origins under the namespace; empty when none / unavailable
+     (STORY-006-005).
    - `native static boolean webview_cred_store_delete(String service, String origin, String username);`
    - `native static boolean webview_cred_store_available();`
 3. Class-level note that headers are javah-optional; the mangled
@@ -1049,23 +1302,47 @@ File: `src_c/webview_embed.cpp` (guarded `#if defined(WEBVIEW_COCOA)`)
      Collect `[username, millis, password]` per item. Return a
      `jobjectArray` of the flat triples (Java sorts). Empty array when
      phase 1 yields `errSecItemNotFound` or no accounts.
+   - `webview_cred_store_find_all` (STORY-006-005): the enumerate-all
+     variant of `find`, across every origin. Because each item's
+     `kSecAttrService` is `"<namespace>:<origin>"` (origin embedded in the
+     service, plain username as the account — the encoding `save`/`find`
+     already use), there is no single service value covering all origins,
+     and the Keychain has no prefix query. So enumerate every
+     generic-password item and filter by the `"<service>:"` service
+     prefix in C. Same two-phase discipline (the `kSecMatchLimitAll` +
+     `kSecReturnData` combination still returns `errSecParam`). Phase 1 —
+     query `kSecClass=kSecClassGenericPassword` + `kSecMatchLimitAll` +
+     `kSecReturnAttributes=true` (no `kSecReturnData`, no service filter)
+     to enumerate every item's `kSecAttrService` + `kSecAttrAccount`;
+     keep only items whose service begins with `"<service>:"`, take
+     `origin` = the service text after that prefix and `username` = the
+     account. Phase 2 — for each kept item, issue a single-item
+     `kSecAttrService=<that full service>` + `kSecAttrAccount=<username>`
+     + `kSecMatchLimitOne` + `kSecReturnData=true` query to fetch its
+     `kSecValueData`; split on the first `\n` into millis + password.
+     Emit a flat **quad** `[origin, username, millis, password]` per
+     kept item. Return a `jobjectArray` of the flat quads (Java sorts).
+     Empty array when phase 1 yields `errSecItemNotFound` or no matching
+     items. No `NSLog` of any password.
    - `webview_cred_store_delete`: `SecItemDelete` with exact account;
      return `errSecSuccess || errSecItemNotFound ? (removed?)` — return
      `true` only when an item was actually deleted (`errSecSuccess`).
    - `webview_cred_store_available`: return `true`.
    - All string↔`CFString` conversions via `CFStringCreateWithCString`
      UTF-8; release every created CF object; no NSLog of passwords.
-8. Non-Apple compilation of this file (`#else`): stub bodies for the four
-   store primitives (`false` / empty `jobjectArray` / `false`) and the
-   two setters, so the Linux build of `webview_embed.cpp` links until
-   canvas 27 replaces them.
+8. Non-Apple compilation of this file (`#else`): stub bodies for the five
+   store primitives — `save`→`false`, `find`→empty `jobjectArray`,
+   `find_all`→empty `jobjectArray`, `delete`→`false`,
+   `available`→`false` — and the two setters, so the Linux build of
+   `webview_embed.cpp` links until canvas 27 replaces them.
 
 ### 17. Windows native stubs
 File: `windows/webview_embed.cc`
 
 1. Add stub `JNIEXPORT` bodies for `webview_embed_set_password_callback`,
-   `webview_offscreen_set_password_callback`, and the four
-   `webview_cred_store_*` primitives (`false` / empty / `false`) so the
+   `webview_offscreen_set_password_callback`, and the five
+   `webview_cred_store_*` primitives — `save`→`false`, `find`→empty,
+   `find_all`→empty, `delete`→`false`, `available`→`false` — so the
    Windows binary links. Real implementation is canvas 28.
 
 ### 18. Wire the bridge — WebViewHeavyweightComponent
@@ -1110,12 +1387,18 @@ File: `demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDem
    demo's "origin" is whatever the page loads as).
 3. Controls: a store-mode `JComboBox` (`Native Keychain` /
    `In-memory`) calling `setCredentialStore(...)`; an "Enabled"
-   `JCheckBox` calling `setPasswordManagerEnabled(...)`; buttons
-   `Save (programmatic)`, `Get`, `Delete` that call the programmatic API
-   for a fixed origin; a log pane that prints capture events and results
-   with passwords redacted.
-4. Comment at top: exercises AC1–AC14 interactively; passwords are never
-   printed.
+   `JCheckBox` calling `setPasswordManagerEnabled(...)`; a
+   "Confirm before autofill" `JCheckBox` that installs
+   `WebViewFillPasswordHandler.CONFIRM` when checked and
+   `setFillPasswordHandler(null)` (→ `DEFAULT`) when unchecked
+   (STORY-006-004); buttons `Save (programmatic)`, `Get`, `Delete` that
+   call the programmatic API for a fixed origin, plus a `Get All` button
+   that calls `getAllCredentials()` and lists each stored credential as
+   `origin` + `username` only (STORY-006-005); a log pane that prints
+   capture events and results with passwords redacted.
+4. Comment at top: exercises the STORY-006-001 ACs plus the fill-consent
+   toggle (006-004) and enumerate-all (006-005) interactively; passwords
+   are never printed.
 5. Follow the existing demo layout and the `run-{linux,mac}-*.sh` script
    convention at the repo root; add a top-level `run-mac-password-demo.sh`
    alongside the existing ones. It mirrors `run-mac-download-demo.sh`:
@@ -1154,12 +1437,19 @@ File: `README.md`
 
 1. New "Password manager" subsection (sibling of "Browser-initiated
    dialogs"): the `setPasswordManagerEnabled` default-on switch; the
-   store + save-handler seams; origin = scheme+host+port and exact-origin
+   store + save-handler seams; the **fill-consent seam**
+   (`setFillPasswordHandler`; `WebViewFillPasswordHandler.CONFIRM` for a
+   browser-style "use saved password?" prompt, or a custom handler for an
+   OS biometric / re-auth check before autofill — default is silent
+   autofill, STORY-006-004); the **enumerate-all** method
+   (`getAllCredentials()`) a host uses to build a "manage saved passwords"
+   UI (STORY-006-005); origin = scheme+host+port and exact-origin
    autofill; that credentials live only in the OS store (Keychain on
    macOS this iteration; libsecret / Credential Manager to follow); the
    security note that an autofilled value is readable by page scripts
-   (browser-parity) and that the library never logs or files passwords;
-   the macOS-only coverage caveat with a forward reference to the Linux /
+   (browser-parity), that the fill-consent event never carries the
+   password, and that the library never logs or files passwords; the
+   macOS-only coverage caveat with a forward reference to the Linux /
    Windows canvases.
 2. List `WebViewPasswordDemo` under the demos paragraph.
 
@@ -1175,7 +1465,12 @@ Files under `test/ca/weblite/webview/`:
 3. `InMemoryCredentialStoreTest`: save→find; upsert (Operation-10
    overwrite, single record); multiple usernames retained + `find`
    returns most-recent (AC11); delete; origin canonicalisation applied on
-   both save and query.
+   both save and query. **Enumerate-all (STORY-006-005):** `findAll()`
+   with no argument returns every credential across multiple origins
+   (006-005 AC1), ordered most-recently-saved first (AC2), including
+   multiple usernames on one origin (AC3); an empty store returns an
+   empty non-null list (AC4); a `delete` is reflected in a subsequent
+   `findAll()` (AC5).
 4. `PasswordDispatcherTest` (no engine, no Keychain — inject an
    `InMemoryCredentialStore` and a recording handler):
    - `dispatchLoginSubmitted` with a `SAVE` handler stores the decoded
@@ -1190,11 +1485,31 @@ Files under `test/ca/weblite/webview/`:
    - `dispatchFillRequested` with a stored credential invokes
      `source.eval(...)` with a `__webview_pw_fill__` call carrying the
      base64url username/password (use a `WebViewComponent` test double /
-     spy capturing the eval string; assert the raw password is NOT the
-     literal in the string — it is base64url-encoded); with no stored
-     credential, `eval` is never called (AC19).
+     spy capturing the eval string; because the fill now hops to the EDT
+     for consent, drain the EDT via `SwingUtilities.invokeAndWait(()->{})`
+     before asserting; assert the raw password is NOT the literal in the
+     string — it is base64url-encoded); with no stored credential, `eval`
+     is never called (AC19).
+   - **Fill-consent (STORY-006-004):** with the default fill-handler a
+     stored credential still evals (006-004 AC1 no-regression); with
+     `setFillHandler(e -> FillPasswordDisposition.DONT_FILL)` a stored
+     credential does NOT eval (AC4/AC5); the `WebViewFillPasswordEvent`
+     handed to a recording handler exposes origin + username, has no
+     password accessor, and its `toString()` omits the password (AC6);
+     the fill-handler runs on the EDT (record
+     `SwingUtilities.isEventDispatchThread()`, AC7); a throwing
+     fill-handler does not propagate and evals nothing (AC11);
+     `getFillHandler()` is never null and `setFillHandler(null)` restores
+     `DEFAULT` (AC8); a `DONT_FILL` fill-handler does not gate the
+     programmatic `getCredential` (AC9); a disabled manager evals nothing
+     regardless of the fill-handler (AC10).
+   - **Enumerate-all via dispatcher (STORY-006-005):** with an injected
+     `InMemoryCredentialStore` holding credentials for several origins,
+     `getAllCredentials()` returns them all most-recent-first (006-005
+     AC1/AC2/AC6).
    - password never appears in `WebViewCredential.toString()` /
-     `WebViewSavePasswordEvent.toString()` (AC18).
+     `WebViewSavePasswordEvent.toString()` /
+     `WebViewFillPasswordEvent.toString()` (AC18 / 006-004 AC6).
 
 ## N · Norms
 
@@ -1242,6 +1557,28 @@ Files under `test/ca/weblite/webview/`:
   single-thread executor. The programmatic API runs synchronously on the
   caller's thread by contract (documented) so round-trips are
   deterministic.
+- **The fill-consent handler mirrors the save handler (STORY-006-004).**
+  `WebViewFillPasswordHandler` follows `WebViewSavePasswordHandler`
+  one-for-one: a `@FunctionalInterface`, EDT invocation, a `DEFAULT`
+  constant, a component setter/getter with the never-null +
+  null-restores-default invariant, and dispatcher-level try/catch
+  exception isolation via `forward`. Its `DEFAULT` returns `FILL`, so the
+  shipped autofill behaviour is unchanged unless a host opts in; the
+  keychain read stays on the worker while only the consent decision + the
+  fire-and-forget eval run on the EDT.
+- **The fill-consent event is password-free (STORY-006-004).**
+  `WebViewFillPasswordEvent` exposes only `{source, origin, username}` —
+  no password field, no password accessor. The consent decision needs
+  identity, not the secret; the password is never handed to host consent
+  code. (Contrast `WebViewSavePasswordEvent`, which must expose the
+  captured password so a host can inspect a *newly submitted* credential.)
+- **Enumerate-all reuses the per-origin `findAll` semantics
+  (STORY-006-005).** The no-argument `findAll()` applies the same
+  recency ordering, dedup, unmodifiable-list, and graceful-degradation
+  (empty on unavailable, never throw) contract as origin-scoped
+  `findAll(origin)`, across every origin under the library namespace. The
+  native quad `[origin, username, millis, password]` is the enumerate-all
+  analogue of the origin-scoped triple `[username, millis, password]`.
 - **Demo / test conventions** match the dialog feature: single-source
   demos under `demos/<Name>/src/...`, no Maven; tests under
   `test/ca/weblite/webview/`, headless, no `JFrame` shown, EDT via
@@ -1277,6 +1614,22 @@ Files under `test/ca/weblite/webview/`:
   sets field values and dispatches events; it never reads or returns a
   credential. A page invoking it directly can only fill its own form with
   attacker-chosen text.
+- **Autofill consent gates the automatic path only (STORY-006-004).**
+  `doFill` consults `WebViewFillPasswordHandler` on the EDT before
+  evaling; `DONT_FILL` skips the injection with no side effect. The
+  handler receives a **password-free** `WebViewFillPasswordEvent`
+  (`{source, origin, username}`), so host consent code — including a
+  biometric/re-auth check — never sees the secret. A handler exception is
+  caught and forwarded; nothing is filled. The programmatic read API
+  (`getCredential`/`getCredentials`/`getAllCredentials`) is trusted host
+  code and is deliberately NOT gated by this handler.
+- **Enumerate-all is host-Java-only (STORY-006-005).**
+  `getAllCredentials()` / `WebViewCredentialStore.findAll()` return
+  credentials only to the calling host Java, exactly as origin-scoped
+  `find`/`findAll` already do. No reserved channel or injected global
+  exposes enumeration to page JavaScript; the fill script stays
+  write-only and origin-scoped. Enumerate results are subject to the same
+  no-logging / redacted-`toString` password discipline.
 - **No prompt without a password field.** `findFields()` returns null when
   the document has no `input[type=password]`, so a plain search-form
   submit never posts `S|...` and never triggers "Save password?"

--- a/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
+++ b/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
@@ -1484,12 +1484,19 @@ File: `demos/WebViewPasswordOptInDemo/src/ca/weblite/webview/demos/WebViewPasswo
    input/change dispatch. Cancel fills nothing.
 8. A log pane records each step (focus, chooser shown, unlock approved/
    declined, filled) with passwords always redacted.
-9. Add a top-level `run-mac-password-optin-demo.sh` launcher mirroring
-   `run-mac-password-demo.sh` verbatim except for targeting
+9. Add top-level launchers mirroring the `WebViewPasswordDemo` siblings
+   verbatim except for targeting
    `demos/WebViewPasswordOptInDemo/...WebViewPasswordOptInDemo.java` and
-   its main class (still linking `-framework Security` for a consistent
-   Keychain-capable build even though this demo defaults to the in-memory
-   store).
+   its main class:
+   - `run-mac-password-optin-demo.sh` (mirrors `run-mac-password-demo.sh`;
+     still links `-framework Security` for a consistent Keychain-capable
+     build even though this demo defaults to the in-memory store).
+   - `run-windows-password-optin-demo.bat` (mirrors
+     `run-windows-password-demo.bat`; builds the WebView2 DLL, packages the
+     jar, compiles and launches the opt-in demo). The demo class is
+     platform-neutral, so the flow is identical to macOS — the chooser is
+     anchored under the focused login field and the fill goes through the
+     same `__webview_pw_fill__` entrypoint.
 10. A `demos/WebViewPasswordOptInDemo/README.md` describes the flow and
     notes it is a host-driven pattern over the public API
     (`setFillPasswordHandler` DONT_FILL + `addOnBeforeLoad` +

--- a/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
+++ b/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
@@ -212,6 +212,10 @@ generated_at: 2026-08-13T15:30:00-07:00
     in-memory-store modes, plus a fill-consent toggle (install `CONFIRM`)
     and a "Get All" action that lists every stored credential (username +
     origin only; passwords never printed).
+  - A `WebViewPasswordOptInDemo` under `demos/` shows the Chrome-style
+    field-click opt-in fill: silent autofill suppressed (`DONT_FILL`),
+    an account chooser shown under the focused login field, a simulated
+    unlock, and fill only on explicit selection — all over the public API.
   - Top-level one-command launchers build the native lib and
     `dist/WebView.jar`, then compile and launch `WebViewPasswordDemo`:
     `run-mac-password-demo.sh` (Keychain-backed capture/autofill),
@@ -452,6 +456,16 @@ generated_at: 2026-08-13T15:30:00-07:00
 
 - **WebViewPasswordDemo** (new demo,
   `demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDemo.java`).
+
+- **WebViewPasswordOptInDemo** (new demo,
+  `demos/WebViewPasswordOptInDemo/src/ca/weblite/webview/demos/WebViewPasswordOptInDemo.java`,
+  STORY-006-004). A Chrome-style **field-click opt-in** autofill demo: it
+  suppresses silent autofill with a `DONT_FILL` fill-handler, detects
+  login-field focus via injected JS + a bound callback, shows an account
+  chooser under the field, runs a simulated re-auth, and fills only on the
+  user's explicit selection via the library's `__webview_pw_fill__`
+  entrypoint. Host-driven, over the public API only; paired with
+  `run-mac-password-optin-demo.sh` and a demo README.
 
 - **`run-mac-password-demo.sh`** (new, repo root): self-contained
   build-and-run launcher for `WebViewPasswordDemo`, mirroring
@@ -1430,6 +1444,56 @@ File: `demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDem
    has no available secret store (e.g. a keyring-less Linux session). The
    Linux script keeps the heavyweight/lightweight mode selection of its
    sibling.
+
+### 21c. Create Demo — WebViewPasswordOptInDemo (Chrome-style opt-in fill)
+File: `demos/WebViewPasswordOptInDemo/src/ca/weblite/webview/demos/WebViewPasswordOptInDemo.java` (STORY-006-004)
+
+1. Purpose: demonstrate a **Chrome-style, user-opt-in autofill** built on
+   the public API — fields stay empty until the user focuses a login
+   field, a chooser lists the saved account(s), and the credential is
+   filled only after the user picks one and passes a simulated
+   re-authentication ("unlock") step. This is the field-click opt-in
+   flow (contrast `WebViewPasswordDemo`'s load-time `CONFIRM` prompt).
+2. Serves a login form (username + password) from a loopback `HttpServer`
+   so the page has a real origin, exactly like `WebViewPasswordDemo`.
+3. Store: seed an `InMemoryCredentialStore` (so the demo touches no real
+   OS Keychain and is repeatable) with two accounts for the origin so the
+   chooser shows a multi-account list; install it via `setCredentialStore`.
+4. **Suppress silent autofill** so the flow is genuinely opt-in:
+   `setFillPasswordHandler(event -> FillPasswordDisposition.DONT_FILL)`.
+   This proves the fill-consent seam disables the automatic path; the
+   demo then drives the fill itself on the user's explicit request.
+5. Detect field focus via injected JS (through the existing public
+   `addOnBeforeLoad`): a document-start script installs a capturing
+   `focusin` listener that, for a text/email/password input, base64url
+   encodes `"left|top|width|height|type"` (from `getBoundingClientRect`)
+   and calls a bound callback `window.__optin_focus__(payload)`. The demo
+   registers that callback with `addJavascriptCallback("__optin_focus__",
+   …)`; its `run(String)` receives the bind-shim JSON wrapper, extracts
+   the first arg (base64url, no JSON-special chars), decodes it, and hops
+   to the EDT.
+6. On focus, if `getCredentials(origin)` is non-empty, show a Chrome-like
+   account chooser (a `JPopupMenu` anchored under the focused field using
+   the reported rect, `invoker = the WebView component`); each item shows
+   the username + a masked password (never the real password).
+7. On selecting an account, run a **simulated re-auth** (a Swing
+   "Unlock passwords — use Touch ID / your login password?" confirm), and
+   only on approval fill the fields by evaluating the library's
+   write-only entrypoint `window.__webview_pw_fill__('<b64url user>',
+   '<b64url pass>')` via `eval` — reusing the library's field detection +
+   input/change dispatch. Cancel fills nothing.
+8. A log pane records each step (focus, chooser shown, unlock approved/
+   declined, filled) with passwords always redacted.
+9. Add a top-level `run-mac-password-optin-demo.sh` launcher mirroring
+   `run-mac-password-demo.sh` verbatim except for targeting
+   `demos/WebViewPasswordOptInDemo/...WebViewPasswordOptInDemo.java` and
+   its main class (still linking `-framework Security` for a consistent
+   Keychain-capable build even though this demo defaults to the in-memory
+   store).
+10. A `demos/WebViewPasswordOptInDemo/README.md` describes the flow and
+    notes it is a host-driven pattern over the public API
+    (`setFillPasswordHandler` DONT_FILL + `addOnBeforeLoad` +
+    `addJavascriptCallback` + `getCredentials` + `eval`).
 
 ### 22. Update README
 File: `README.md`

--- a/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
+++ b/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
@@ -129,6 +129,20 @@ generated_at: 2026-08-13T15:30:00-07:00
   value present in the JS payload is ignored. This prevents a page at
   one origin from saving-into or reading another origin's credential by
   posting a forged origin directly to the channel.
+- **No re-prompt for an unchanged credential.** On a captured login
+  submission, before showing the save prompt / invoking the
+  save-handler, the dispatcher looks up the store for the submission's
+  origin: if a credential with the same `{origin, username}` is already
+  stored with the **same password**, the submission is dropped silently
+  (no prompt, no handler call, no store write). Only a **new**
+  `{origin, username}` or a **changed password** for an existing one
+  proceeds to the prompt/handler (where a SAVE upserts/overwrites). This
+  matches every browser's password manager, which offers to save only
+  when the credential is new or changed — so autofilling a stored
+  credential and re-submitting the form never re-asks to save it. The
+  store lookup runs on the dispatcher's `io` worker (off the EDT and the
+  native message thread); a store read that throws fails open (treated as
+  not-stored, so a save is still offered).
 - All save-policy callbacks run on the Swing EDT. The dispatcher
   marshals via `SwingUtilities.invokeLater` (NON-blocking — unlike
   `DialogDispatcher`'s `invokeAndWait`), because a login submission has
@@ -189,7 +203,9 @@ generated_at: 2026-08-13T15:30:00-07:00
   the only build-script change in this canvas; libsecret / Advapi32
   linkage is added by canvases 27 / 28.
 - Definition of Done:
-  - All 20 STORY-006-001 ACs pass on macOS with the new code.
+  - All 22 STORY-006-001 ACs pass on macOS with the new code (AC21/AC22
+    cover the no-re-prompt-for-unchanged / changed-password-still-prompts
+    dedup rule).
   - All 11 STORY-006-004 ACs (autofill-consent handler) pass headlessly:
     default fills with no prompt (no regression), `CONFIRM` shows a
     password-free confirmation, approve fills / decline fills nothing, a
@@ -416,7 +432,11 @@ generated_at: 2026-08-13T15:30:00-07:00
   restore defaults; disabled ⇒ automatic dispatch is dropped but
   programmatic methods still work; disposed ⇒ automatic dispatch is
   dropped. The fill-handler is consulted (on the EDT) only on the
-  automatic autofill path, never on the programmatic read methods.
+  automatic autofill path, never on the programmatic read methods. On a
+  captured submission it first checks the store (on the `io` worker) and
+  drops the submission before any prompt when an identical
+  `{origin, username, password}` credential is already stored (no
+  re-prompt for an unchanged credential).
 
 - **WebViewComponent** (modified;
   `src/ca/weblite/webview/swing/WebViewComponent.java`). Gains:
@@ -1110,7 +1130,24 @@ File: `src/ca/weblite/webview/PasswordDispatcher.java`
      - `String origin = Origins.canonical(frameUrl);` if null → return.
      - decode `user`/`pass` via `base64UrlDecode` (private helper; on
        `IllegalArgumentException` → return).
-     - `SwingUtilities.invokeLater(() -> runPrompt(origin, user, pass));`
+     - `io.execute(() -> maybePrompt(origin, user, pass));` — hand off to
+       the worker so the store dedup check runs off the EDT and the
+       native message thread.
+   - `private void maybePrompt(String origin, String user, String pass)`
+     (on the `io` worker):
+     - re-check `disposed || !enabled` → return.
+     - if `isAlreadyStored(origin, user, pass)` → return (the credential
+       is already stored unchanged; no prompt, no handler, no write).
+     - else `SwingUtilities.invokeLater(() -> runPrompt(origin, user, pass));`
+   - `private boolean isAlreadyStored(String origin, String user, String pass)`
+     (on the `io` worker): iterate `store.findAll(origin)`; return `true`
+     iff some credential has `username.equals(user)` **and**
+     `password.equals(pass)` (note `WebViewCredential.equals` ignores the
+     password, so compare both fields explicitly). Wrap in
+     `try/catch(Throwable)`; on error `forward(t)` and return `false`
+     (fail open — still offer to save). A changed password (same username,
+     different password) and a new username both return `false`, so the
+     prompt proceeds and a SAVE upserts.
    - `private void runPrompt(String origin, String user, String pass)`
      (on EDT):
      - re-check `disposed || !enabled` → return.
@@ -1551,6 +1588,16 @@ Files under `test/ca/weblite/webview/`:
    - `dispatchLoginSubmitted` with a `SAVE` handler stores the decoded
      credential under the canonical origin (feed a base64url payload).
    - `DONT_SAVE` stores nothing.
+   - **No re-prompt for an unchanged credential:** with a credential
+     already in the store, `dispatchLoginSubmitted` for the same
+     `{origin, username, password}` never invokes the save-handler (use a
+     handler that flips a flag / counts calls) and stores nothing extra —
+     the submission is dropped. A submission with the same username but a
+     **changed** password DOES invoke the handler (and a SAVE overwrites);
+     a **new** username also invokes the handler. Assert the dedup check
+     ran off the EDT (the handler, when it is invoked, still records
+     `SwingUtilities.isEventDispatchThread() == true`, but the drop path
+     never reaches the EDT).
    - disabled ⇒ neither prompt nor store touched; programmatic
      `saveCredential`/`getCredential` still work (AC12).
    - handler runs on the EDT (record `SwingUtilities.isEventDispatchThread()`).
@@ -1733,6 +1780,14 @@ Files under `test/ca/weblite/webview/`:
   `try/catch(Throwable)`; a store that throws (or a Keychain error)
   degrades to "not saved" / "not filled", never a crash (foundation for
   the Linux no-keyring AC12 in canvas 27).
+- **No re-prompt for an unchanged credential.** `dispatchLoginSubmitted`
+  drops a captured submission on the `io` worker (before any EDT prompt or
+  handler call) when `isAlreadyStored(origin, user, pass)` finds an
+  identical `{origin, username, password}` already in the store. Only a
+  new `{origin, username}` or a changed password reaches the save-handler;
+  this keeps autofill-then-submit from re-asking to save an unchanged
+  credential. A store read that throws fails open (submission proceeds to
+  the prompt), so a transient store error never silently loses a save.
 - **Enabled flag gates automatic behaviour only.** When disabled,
   `dispatchLoginSubmitted` / `dispatchFillRequested` return before any
   prompt / lookup / fill; `saveCredential` / `getCredential` /

--- a/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
+++ b/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
@@ -143,6 +143,9 @@ generated_at: 2026-08-13T15:30:00-07:00
   - A `WebViewPasswordDemo` under `demos/` exercises capture + save
     prompt + autofill in default-handler, custom-handler, and
     in-memory-store modes.
+  - A top-level `run-mac-password-demo.sh` builds the macOS native lib
+    and `dist/WebView.jar`, then compiles and launches
+    `WebViewPasswordDemo`, so the demo runs with one command.
   - README grows a "Password manager" subsection documenting the
     `setPasswordManagerEnabled` / store / save-handler API, the
     origin-keying and origin-exact-match rules, the security notes
@@ -318,6 +321,10 @@ generated_at: 2026-08-13T15:30:00-07:00
 
 - **WebViewPasswordDemo** (new demo,
   `demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDemo.java`).
+
+- **`run-mac-password-demo.sh`** (new, repo root): self-contained
+  build-and-run launcher for `WebViewPasswordDemo`, mirroring
+  `run-mac-download-demo.sh` and adding `-framework Security`.
 
 - **README.md** (modified): "Password manager" subsection.
 
@@ -1093,6 +1100,18 @@ File: `demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDem
    with passwords redacted.
 4. Comment at top: exercises AC1–AC14 interactively; passwords are never
    printed.
+5. Follow the existing demo layout and the `run-{linux,mac}-*.sh` script
+   convention at the repo root; add a top-level `run-mac-password-demo.sh`
+   alongside the existing ones. It mirrors `run-mac-download-demo.sh`:
+   resolve `JAVA_HOME`; build `libwebview.dylib` from
+   `src_c/webview_embed.cpp` (only when missing or older than its sources)
+   including `-framework Security` for Keychain access alongside the
+   existing WebKit / Cocoa / QuartzCore frameworks; compile the `src`
+   Java sources and stage `dist/WebView.jar` with the dylib at the
+   architecture-named root; compile
+   `demos/WebViewPasswordDemo/src/...WebViewPasswordDemo.java` against that
+   jar; and launch the demo's main class. No Ant required (the script is
+   self-contained, like the other `run-mac-*-demo.sh` scripts).
 
 ### 22. Update README
 File: `README.md`

--- a/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
+++ b/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
@@ -1497,6 +1497,11 @@ File: `demos/WebViewPasswordOptInDemo/src/ca/weblite/webview/demos/WebViewPasswo
      platform-neutral, so the flow is identical to macOS — the chooser is
      anchored under the focused login field and the fill goes through the
      same `__webview_pw_fill__` entrypoint.
+   - `run-linux-password-optin-demo.sh` (mirrors
+     `run-linux-password-demo.sh`; builds the WebKitGTK `libwebview.so`,
+     packages the jar, compiles and launches the opt-in demo, keeping the
+     heavyweight/lightweight mode selection of its sibling). Same
+     platform-neutral demo class and flow.
 10. A `demos/WebViewPasswordOptInDemo/README.md` describes the flow and
     notes it is a host-driven pattern over the public API
     (`setFillPasswordHandler` DONT_FILL + `addOnBeforeLoad` +

--- a/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
+++ b/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
@@ -114,7 +114,7 @@ generated_at: 2026-08-13T15:30:00-07:00
     — mirror the `..._set_dialog_callback` precedent
     (`WebViewNative.java:284, 449`). The offscreen setter is a native
     no-op stub on macOS (offscreen is itself a stub on macOS); Linux
-    lightweight wires it in canvas 24.
+    lightweight wires it in canvas 27.
   - Process-global static store primitives (no engine handle, because
     the OS secret store is process-global):
     - `boolean webview_cred_store_save(String service, String origin, String username, String password, long savedAtMillis)`
@@ -124,7 +124,7 @@ generated_at: 2026-08-13T15:30:00-07:00
     - `boolean webview_cred_store_delete(String service, String origin, String username)`
     - `boolean webview_cred_store_available()` — whether the platform
       secret store is usable (always `true` on macOS; meaningful on
-      Linux in canvas 24).
+      Linux in canvas 27).
     This canvas implements the macOS bodies (Keychain) and provides
     stub bodies (return `false` / empty / `false`) for the non-macOS
     compilation of `webview_embed.cpp` and for `windows/webview_embed.cc`,
@@ -159,9 +159,9 @@ generated_at: 2026-08-13T15:30:00-07:00
     integration-tested via the demo (consistent with the
     no-automated-GUI-tests policy).
 - Out of scope (explicit non-goals):
-  - Linux WebKitGTK message handler + libsecret store (canvas 24).
+  - Linux WebKitGTK message handler + libsecret store (canvas 27).
   - Windows WebView2 message handler + Credential Manager store, and
-    disabling Edge's built-in autosave (canvas 25).
+    disabling Edge's built-in autosave (canvas 28).
   - The standalone in-process `WebView` class — this canvas only touches
     the embedded `WebViewComponent` surface.
   - A credential-management UI (a "manage saved passwords" window). Hosts
@@ -312,7 +312,7 @@ generated_at: 2026-08-13T15:30:00-07:00
 - **`windows/webview_embed.cc`** (modified, stubs only in this canvas):
   stub bodies for the four `webview_cred_store_*` primitives and the two
   `..._set_password_callback` setters, so the JNI surface links on
-  Windows. Real Windows implementation is canvas 25.
+  Windows. Real Windows implementation is canvas 28.
 
 - **`build-mac.sh`** (modified): add `-framework Security`.
 
@@ -644,7 +644,7 @@ WebViewPasswordCallback ..> PasswordDispatcher : delegates to
    installs a `WebViewPasswordCallback` adapter delegating to
    `passwordDispatcher.dispatch*`.
 6. `WebViewLightweightComponent.addNotify()` → same shape via
-   `OffscreenWebView` (native no-op on macOS; live on Linux in canvas 24).
+   `OffscreenWebView` (native no-op on macOS; live on Linux in canvas 27).
 7. `EmbeddedWebView.setPasswordCallback` →
    `WebViewNative.webview_embed_set_password_callback`;
    `OffscreenWebView.setPasswordCallback` →
@@ -1035,7 +1035,7 @@ File: `src_c/webview_embed.cpp` (guarded `#if defined(WEBVIEW_COCOA)`)
 8. Non-Apple compilation of this file (`#else`): stub bodies for the four
    store primitives (`false` / empty `jobjectArray` / `false`) and the
    two setters, so the Linux build of `webview_embed.cpp` links until
-   canvas 24 replaces them.
+   canvas 27 replaces them.
 
 ### 17. Windows native stubs
 File: `windows/webview_embed.cc`
@@ -1043,7 +1043,7 @@ File: `windows/webview_embed.cc`
 1. Add stub `JNIEXPORT` bodies for `webview_embed_set_password_callback`,
    `webview_offscreen_set_password_callback`, and the four
    `webview_cred_store_*` primitives (`false` / empty / `false`) so the
-   Windows binary links. Real implementation is canvas 25.
+   Windows binary links. Real implementation is canvas 28.
 
 ### 18. Wire the bridge — WebViewHeavyweightComponent
 File: `src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java`
@@ -1066,7 +1066,7 @@ File: `src/ca/weblite/webview/swing/WebViewLightweightComponent.java`
    - `engine.setPasswordCallback(...)` delegating to `passwordDispatcher`
      as in Operation 18.
 2. On macOS the offscreen native setter is a no-op, so this compiles and
-   runs harmlessly; it goes live on Linux in canvas 24.
+   runs harmlessly; it goes live on Linux in canvas 27.
 
 ### 20. Build script — link Security.framework
 File: `build-mac.sh`
@@ -1240,7 +1240,7 @@ Files under `test/ca/weblite/webview/`:
   dispatcher's `safeSave` / `doFill` wrap store calls in
   `try/catch(Throwable)`; a store that throws (or a Keychain error)
   degrades to "not saved" / "not filled", never a crash (foundation for
-  the Linux no-keyring AC12 in canvas 24).
+  the Linux no-keyring AC12 in canvas 27).
 - **Enabled flag gates automatic behaviour only.** When disabled,
   `dispatchLoginSubmitted` / `dispatchFillRequested` return before any
   prompt / lookup / fill; `saveCredential` / `getCredential` /

--- a/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
+++ b/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
@@ -1653,6 +1653,15 @@ Files under `test/ca/weblite/webview/`:
   demos under `demos/<Name>/src/...`, no Maven; tests under
   `test/ca/weblite/webview/`, headless, no `JFrame` shown, EDT via
   `SwingUtilities.invokeAndWait` in-test.
+- **Java sources stay ASCII-portable.** The demo launchers compile with
+  the platform `javac` default encoding (UTF-8 on macOS/Linux, but
+  typically Windows-1252 on Windows), so any non-ASCII character in a
+  char/string literal must be written as a `\uXXXX` escape (a bullet as
+  the char literal `'•'`, not the raw glyph), and comments/UI strings
+  use plain ASCII punctuation
+  (`-` not an em-dash). This keeps every demo compilable and correctly
+  rendered under any default encoding — a raw UTF-8 char literal breaks
+  the Windows build with "unclosed character literal".
 - **No automated GUI/native tests** — the 20 ACs are verified via
   `WebViewPasswordDemo` on macOS; the Java contract is unit-tested with an
   `InMemoryCredentialStore` and a `WebViewComponent` test double.

--- a/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
+++ b/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
@@ -214,11 +214,10 @@ generated_at: 2026-08-13T15:30:00-07:00
     origin only; passwords never printed).
   - Top-level one-command launchers build the native lib and
     `dist/WebView.jar`, then compile and launch `WebViewPasswordDemo`:
-    `run-mac-password-demo.sh` (Keychain-backed capture/autofill) and
+    `run-mac-password-demo.sh` (Keychain-backed capture/autofill),
     `run-windows-password-demo.bat` (Credential-Manager-backed
-    capture/autofill), plus `run-linux-password-demo.sh` for the same demo
-    (programmatic API + in-memory store; native capture/fill pending
-    canvas 27).
+    capture/autofill), and `run-linux-password-demo.sh`
+    (libsecret-backed capture/autofill, heavyweight + lightweight).
   - README grows a "Password manager" subsection documenting the
     `setPasswordManagerEnabled` / store / save-handler API, the
     origin-keying and origin-exact-match rules, the security notes
@@ -460,10 +459,10 @@ generated_at: 2026-08-13T15:30:00-07:00
 
 - **`run-linux-password-demo.sh`** / **`run-windows-password-demo.bat`**
   (new, repo root): self-contained launchers for the same demo, mirroring
-  the download-demo siblings. Capture/autofill are wired on macOS
-  (Keychain) and Windows (Credential Manager); on Linux the demo runs with
-  the programmatic API and in-memory store working, native capture/fill
-  pending canvas 27.
+  the download-demo siblings. Capture/autofill are wired on all three
+  platforms — macOS (Keychain), Windows (Credential Manager), and Linux
+  (libsecret) — degrading to a graceful no-op where no secret store is
+  available.
 
 - **README.md** (modified): "Password manager" subsection.
 
@@ -1425,12 +1424,12 @@ File: `demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDem
    `demos/WebViewPasswordDemo/...WebViewPasswordDemo.java` and its main
    class. No macOS-only `-framework Security` step applies there (that is
    a Keychain concern). Each header states the current coverage: automatic
-   capture / autofill are wired on the platforms whose native channel +
-   store have landed (macOS via Keychain, Windows via Credential Manager);
-   the remaining platform's demo still runs with the programmatic API and
-   in-memory store while its native channel + store arrive with its
-   coverage canvas (Linux → canvas 27). The Linux script keeps the
-   heavyweight/lightweight mode selection of its sibling.
+   capture / autofill are wired on all three platforms — macOS via
+   Keychain, Windows via Credential Manager, Linux via libsecret (both
+   heavyweight and lightweight) — with a graceful no-op where a platform
+   has no available secret store (e.g. a keyring-less Linux session). The
+   Linux script keeps the heavyweight/lightweight mode selection of its
+   sibling.
 
 ### 22. Update README
 File: `README.md`

--- a/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
+++ b/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
@@ -145,10 +145,11 @@ generated_at: 2026-08-13T15:30:00-07:00
     in-memory-store modes.
   - Top-level one-command launchers build the native lib and
     `dist/WebView.jar`, then compile and launch `WebViewPasswordDemo`:
-    `run-mac-password-demo.sh` (Keychain-backed capture/autofill), plus
-    `run-linux-password-demo.sh` and `run-windows-password-demo.bat` for
-    the same demo (programmatic API + in-memory store; native capture/fill
-    pending canvases 27 / 28).
+    `run-mac-password-demo.sh` (Keychain-backed capture/autofill) and
+    `run-windows-password-demo.bat` (Credential-Manager-backed
+    capture/autofill), plus `run-linux-password-demo.sh` for the same demo
+    (programmatic API + in-memory store; native capture/fill pending
+    canvas 27).
   - README grows a "Password manager" subsection documenting the
     `setPasswordManagerEnabled` / store / save-handler API, the
     origin-keying and origin-exact-match rules, the security notes
@@ -331,9 +332,10 @@ generated_at: 2026-08-13T15:30:00-07:00
 
 - **`run-linux-password-demo.sh`** / **`run-windows-password-demo.bat`**
   (new, repo root): self-contained launchers for the same demo, mirroring
-  the download-demo siblings. Capture/autofill are macOS-only this
-  release; on Linux/Windows the demo runs with the programmatic API and
-  in-memory store working, native capture/fill pending canvases 27 / 28.
+  the download-demo siblings. Capture/autofill are wired on macOS
+  (Keychain) and Windows (Credential Manager); on Linux the demo runs with
+  the programmatic API and in-memory store working, native capture/fill
+  pending canvas 27.
 
 - **README.md** (modified): "Password manager" subsection.
 
@@ -1139,11 +1141,12 @@ File: `demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDem
    verbatim except for targeting
    `demos/WebViewPasswordDemo/...WebViewPasswordDemo.java` and its main
    class. No macOS-only `-framework Security` step applies there (that is
-   a Keychain concern). Each header must state the coverage caveat:
-   automatic capture / autofill are macOS-only this release; on Linux and
-   Windows the demo still runs and the programmatic API plus the in-memory
-   store work, but the native capture/fill channel and OS secret store
-   arrive with canvases 27 / 28. The Linux script keeps the
+   a Keychain concern). Each header states the current coverage: automatic
+   capture / autofill are wired on the platforms whose native channel +
+   store have landed (macOS via Keychain, Windows via Credential Manager);
+   the remaining platform's demo still runs with the programmatic API and
+   in-memory store while its native channel + store arrive with its
+   coverage canvas (Linux → canvas 27). The Linux script keeps the
    heavyweight/lightweight mode selection of its sibling.
 
 ### 22. Update README

--- a/spdd/prompt/27-202608131545-[Feat]-Webview-Native-Password-Manager-Linux-Coverage.md
+++ b/spdd/prompt/27-202608131545-[Feat]-Webview-Native-Password-Manager-Linux-Coverage.md
@@ -31,12 +31,14 @@ generated_at: 2026-08-13T15:45:00-07:00
      `webview_embed_set_password_callback` (heavyweight) and
      `webview_offscreen_set_password_callback` (offscreen) — replacing the
      canvas-23 Linux stubs, following `gtk_set_dialog_callback`.
-  2. **libsecret credential store:** replace the canvas-23 non-Apple stub
-     bodies of the four `webview_cred_store_*` primitives with a libsecret
-     implementation, matching the macOS Keychain semantics exactly (same
-     `service` namespace, same `savedAtMillis + "\n" + password` value
-     encoding, same origin/username keying, same most-recent-first
-     ordering contract — Java re-sorts regardless).
+  2. **libsecret credential store:** replace the canvas-26 non-Apple stub
+     bodies of the five `webview_cred_store_*` primitives — including
+     `webview_cred_store_find_all` (the no-argument enumerate-all across
+     every origin, STORY-006-005) — with a libsecret implementation,
+     matching the macOS Keychain semantics exactly (same `service`
+     namespace, same `savedAtMillis + "\n" + password` value encoding,
+     same origin/username keying, same most-recent-first ordering
+     contract — Java re-sorts regardless).
 - **libsecret is loaded at runtime via `dlopen`**, matching the existing
   WebKitGTK runtime-load convention (`webkit_loader.cpp`) rather than
   hard-linking. If `libsecret-1.so.0` is absent, or no Secret Service
@@ -71,6 +73,10 @@ generated_at: 2026-08-13T15:45:00-07:00
   - All 13 STORY-006-002 ACs pass on Linux (a Secret Service provider
     available for AC1–AC11/AC13; AC12 verified by disabling/removing the
     provider).
+  - STORY-006-005 AC7/AC8 on Linux: `getAllCredentials()` round-trips
+    every stored credential across origins via the libsecret
+    schema-wide search, and degrades to an empty list when no Secret
+    Service is available.
   - `WebViewPasswordDemo` (from canvas 26) works unchanged on Linux in
     both modes.
   - README's "Password manager" subsection updates the coverage note:
@@ -111,8 +117,10 @@ generated_at: 2026-08-13T15:45:00-07:00
   - `fire_password_submitted` / `fire_password_fill_requested` — the
     JNI fire helpers (shared with macOS in shape; may be defined
     platform-neutrally once and reused).
-  - libsecret bodies for `webview_cred_store_save/find/delete/available`
-    (replacing the canvas-23 non-Apple stubs).
+  - libsecret bodies for
+    `webview_cred_store_save/find/find_all/delete/available`
+    (replacing the canvas-26 non-Apple stubs), where `find_all` is the
+    no-argument enumerate-all across every origin (STORY-006-005).
   - JNI bridges for `webview_embed_set_password_callback` (→
     `gtk_set_password_callback` on the heavyweight engine) and
     `webview_offscreen_set_password_callback` (→ the offscreen engine).
@@ -174,6 +182,13 @@ No new classes; no mermaid diagram change (the class model is canvas 26's).
      attribute, split the secret on the first `\n` into millis + password,
      emit flat `[username, millis, password]` triples. Java re-sorts.
      On no match → empty array.
+   - **find_all** (STORY-006-005): the enumerate-all variant of `find`,
+     bound on `{service}` only (both `origin` and `username` unbound), so
+     the search returns every item under the library namespace across all
+     origins. For each item read its `origin` + `username` attributes and
+     its secret; split the secret into millis + password; emit flat
+     **quads** `[origin, username, millis, password]`. Java re-sorts. On
+     no match / unavailable → empty array.
    - **delete**: `secret_password_clear_sync(&WEBVIEW_PW_SCHEMA, NULL,
      &error, "service", service, "origin", origin, "username", username,
      NULL)` → returns whether a secret was removed.
@@ -259,6 +274,21 @@ File: `src_c/webview_embed.cpp` (Linux-guarded)
    Return the array (empty on no match / error). Java sorts + builds
    credentials.
 
+### 4a. Implement webview_cred_store_find_all (STORY-006-005)
+1. `if (!ensure_secret()) return empty jobjectArray;`
+2. Enumerate items matching `{service}` only (both `origin` and
+   `username` unbound) using the resolved search API
+   (`secret_service_search_sync` / `secret_password_searchv_sync` with
+   only the `service` attribute bound, requesting attributes + secrets);
+   for each item: read the `origin` and `username` attributes and the
+   secret string; split the secret on the first `\n` → `millis`,
+   `password`; append `origin`, `username`, `millis`, `password` to a
+   `std::vector<std::string>`.
+3. Build a `jobjectArray` (`java/lang/String`) of the flat **quads**;
+   free all libsecret allocations (secret + attribute list frees). Return
+   the array (empty on no match / error). Java sorts + builds
+   credentials. Never log the password.
+
 ### 5. Implement webview_cred_store_delete
 1. `if (!ensure_secret()) return JNI_FALSE;`
 2. `gboolean removed = secret_password_clear_sync(&WEBVIEW_PW_SCHEMA, NULL, &err, "service", service, "origin", origin, "username", username, NULL);`
@@ -336,10 +366,10 @@ File: `src_c/webview_embed.cpp` (Linux)
 
 ## S · Safeguards
 
-- **Graceful degradation (STORY-006-002 AC12).** No libsecret / no Secret
-  Service ⇒ `available()` false, `save`/`delete` false, `find` empty; page
-  load and form submission continue to work; no crash, no thrown JNI
-  exception.
+- **Graceful degradation (STORY-006-002 AC12 / STORY-006-005 AC8).** No
+  libsecret / no Secret Service ⇒ `available()` false, `save`/`delete`
+  false, `find` and `find_all` empty; page load and form submission
+  continue to work; no crash, no thrown JNI exception.
 - **Trusted origin** stamped from `webkit_web_view_get_uri`; JS-supplied
   origin ignored — the anti-cross-origin invariant holds on Linux too.
 - **Password never logged / filed.** libsecret is the only persistence;

--- a/spdd/prompt/27-202608131545-[Feat]-Webview-Native-Password-Manager-Linux-Coverage.md
+++ b/spdd/prompt/27-202608131545-[Feat]-Webview-Native-Password-Manager-Linux-Coverage.md
@@ -336,7 +336,8 @@ File: `src_c/webview_embed.cpp` (Linux)
 ### 9. README coverage note
 1. Update the "Password manager" subsection: Linux supported in both
    heavyweight and lightweight via libsecret (freedesktop Secret Service);
-   graceful no-op when no provider is available; Windows still pending.
+   graceful no-op when no provider is available. With macOS and Windows
+   already wired, this completes all-three-platform coverage.
 
 ## N · Norms
 

--- a/spdd/prompt/27-202608131545-[Feat]-Webview-Native-Password-Manager-Linux-Coverage.md
+++ b/spdd/prompt/27-202608131545-[Feat]-Webview-Native-Password-Manager-Linux-Coverage.md
@@ -6,16 +6,16 @@ generated_at: 2026-08-13T15:45:00-07:00
 
 ## R · Requirements
 
-- Extend the password manager shipped by canvas 23 (STORY-006-001) to
+- Extend the password manager shipped by canvas 26 (STORY-006-001) to
   Linux, for both `WebViewHeavyweightComponent` (X11-reparented
   WebKitGTK) and `WebViewLightweightComponent` (offscreen WebKitGTK).
   This canvas adds Linux native code only — **no Java or JavaScript
   changes**: the public API (`WebViewCredential`, `WebViewCredentialStore`,
   `WebViewSavePasswordHandler`, `PasswordDispatcher`, the `WebViewComponent`
   methods) and the shared `PasswordDispatcher.SHIM_JS` are reused verbatim
-  from canvas 23.
+  from canvas 26.
 - Two native pieces, both living in `src_c/webview_embed.cpp` under the
-  Linux compilation (the same file canvas 23 compiled with non-Apple stub
+  Linux compilation (the same file canvas 26 compiled with non-Apple stub
   bodies):
   1. **Password message channel + capture:** register a WebKitGTK
      script-message handler for name `__webview_pw__` on the engine's
@@ -71,7 +71,7 @@ generated_at: 2026-08-13T15:45:00-07:00
   - All 13 STORY-006-002 ACs pass on Linux (a Secret Service provider
     available for AC1–AC11/AC13; AC12 verified by disabling/removing the
     provider).
-  - `WebViewPasswordDemo` (from canvas 23) works unchanged on Linux in
+  - `WebViewPasswordDemo` (from canvas 26) works unchanged on Linux in
     both modes.
   - README's "Password manager" subsection updates the coverage note:
     Linux now supported (heavyweight + lightweight) via libsecret; still
@@ -79,22 +79,22 @@ generated_at: 2026-08-13T15:45:00-07:00
   - `build-linux.sh` gains no hard link to libsecret (runtime `dlopen`);
     a build comment documents the `dlopen("libsecret-1.so.0")` dependency.
 - Out of scope (explicit non-goals):
-  - Windows coverage (canvas 25).
-  - macOS — canvas 23.
-  - Any Java or `SHIM_JS` change — the contract is fixed by canvas 23.
+  - Windows coverage (canvas 28).
+  - macOS — canvas 26.
+  - Any Java or `SHIM_JS` change — the contract is fixed by canvas 26.
   - Shipping or requiring a specific keyring daemon (GNOME Keyring vs
     KWallet). The library targets the freedesktop Secret Service via
     libsecret and works with whichever provider implements it.
   - A library-provided keyring-unlock UI — if the login keyring is locked,
     libsecret / the Secret Service prompts per its own policy.
   - The multi-step-login and heap-zeroisation limitations already
-    documented in canvas 23.
+    documented in canvas 26.
 
 ## E · Entities
 
 - **`src_c/webview_embed.cpp`** (modified, Linux compilation). Gains:
   - `Engine::password_callback` `jobject` field is already declared by
-    canvas 23 (shared struct); Linux now uses it.
+    canvas 26 (shared struct); Linux now uses it.
   - A file-static `SecretSchema WEBVIEW_PW_SCHEMA` (Linux-guarded).
   - `dlopen`'d libsecret function pointers (file-static), resolved once
     lazily: `secret_password_store_sync`, `secret_password_lookup_sync`,
@@ -120,7 +120,7 @@ generated_at: 2026-08-13T15:45:00-07:00
   `dlopen` of `libsecret-1.so.0`; no `-lsecret` hard link.
 - **README.md** (modified): coverage-note update.
 
-No new classes; no mermaid diagram change (the class model is canvas 23's).
+No new classes; no mermaid diagram change (the class model is canvas 26's).
 
 ## A · Approach
 
@@ -211,10 +211,10 @@ No new classes; no mermaid diagram change (the class model is canvas 23's).
    `__webview_pw__` GTK message handler, the callback setter, the fire
    helpers, and the libsecret store bodies.
 2. All higher layers (JNI surface, wrappers, dispatcher, component API,
-   public contract, wiring, demo) are unchanged from canvas 23 — the Linux
+   public contract, wiring, demo) are unchanged from canvas 26 — the Linux
    wiring in `WebViewLightweightComponent.addNotify()` /
    `WebViewHeavyweightComponent.createPeer()` (which already call
-   `addOnBeforeLoad(SHIM_JS)` + `setPasswordCallback(...)` from canvas 23)
+   `addOnBeforeLoad(SHIM_JS)` + `setPasswordCallback(...)` from canvas 26)
    now reaches live native code instead of a stub.
 
 ## O · Operations
@@ -290,7 +290,7 @@ File: `src_c/webview_embed.cpp` (Linux)
    cleanup).
 
 ### 7. fire helpers (shared)
-1. If canvas 23 defined `fire_password_submitted` /
+1. If canvas 26 defined `fire_password_submitted` /
    `fire_password_fill_requested` without Cocoa dependencies, reuse them
    directly. Otherwise define the Linux copies with identical JNI
    mechanics (per-call `GetMethodID` for
@@ -311,7 +311,7 @@ File: `src_c/webview_embed.cpp` (Linux)
 ## N · Norms
 
 - **No Java / `SHIM_JS` change.** This canvas is native-only; the contract
-  and script are canvas 23's. If a change here would require touching
+  and script are canvas 26's. If a change here would require touching
   Java, stop — it belongs in a canvas-23 amendment, not here.
 - **Origin from `webkit_web_view_get_uri` only** — never from the JS
   payload. Same invariant as macOS.
@@ -357,7 +357,7 @@ File: `src_c/webview_embed.cpp` (Linux)
   path.
 - **Callback global-ref lifecycle** set in `gtk_set_password_callback`,
   deleted on engine destroy; the Java callback anchored in the wrapper's
-  `heap` (canvas 23).
+  `heap` (canvas 26).
 - **No behavioural drift from macOS** — because the Java layer, the shared
   JS, and the value encoding are shared, the only Linux-specific surface
   is the store backend and the message-handler plumbing; both conform to

--- a/spdd/prompt/28-202608131600-[Feat]-Webview-Native-Password-Manager-Windows-Coverage.md
+++ b/spdd/prompt/28-202608131600-[Feat]-Webview-Native-Password-Manager-Windows-Coverage.md
@@ -6,11 +6,11 @@ generated_at: 2026-08-13T16:00:00-07:00
 
 ## R · Requirements
 
-- Extend the password manager shipped by canvas 23 (STORY-006-001) to
+- Extend the password manager shipped by canvas 26 (STORY-006-001) to
   Windows, where `WebViewHeavyweightComponent` uses Microsoft WebView2
   (embedded Edge/Chromium). This canvas adds Windows native code only —
   **no Java or JavaScript changes**: the public API and the shared
-  `PasswordDispatcher.SHIM_JS` are reused verbatim from canvas 23. Windows
+  `PasswordDispatcher.SHIM_JS` are reused verbatim from canvas 26. Windows
   uses the **library's own** password manager (not Edge's profile store),
   so behaviour is uniform with macOS and Linux.
 - Three native pieces, all in `windows/webview_embed.cc` (replacing the
@@ -60,7 +60,7 @@ generated_at: 2026-08-13T16:00:00-07:00
   file-picker carve-out) — all 13 STORY-006-003 ACs are achievable.
 - Definition of Done:
   - All 13 STORY-006-003 ACs pass on Windows 11 with the WebView2 Runtime.
-  - `WebViewPasswordDemo` (canvas 23) works unchanged on Windows.
+  - `WebViewPasswordDemo` (canvas 26) works unchanged on Windows.
   - README's "Password manager" subsection updates coverage to
     all-three-platforms, with the Windows note: the library's own manager
     is used (not Edge's profile), credentials live in the Windows
@@ -69,7 +69,7 @@ generated_at: 2026-08-13T16:00:00-07:00
   - `windows/script/build.bat` (or the Windows build) links `Advapi32`
     for the `Cred*` APIs if not already linked.
 - Out of scope (explicit non-goals):
-  - macOS — canvas 23. Linux — canvas 24.
+  - macOS — canvas 26. Linux — canvas 27.
   - Any Java or `SHIM_JS` change.
   - Reading / importing Edge's existing saved passwords from the user's
     Edge profile — the library uses its own Credential-Manager namespace;
@@ -77,7 +77,7 @@ generated_at: 2026-08-13T16:00:00-07:00
   - Roaming / enterprise credential sync beyond choosing the per-user
     `CRED_PERSIST_LOCAL_MACHINE` flag.
   - The multi-step-login and heap-zeroisation limitations documented in
-    canvas 23.
+    canvas 26.
 
 ## E · Entities
 
@@ -102,7 +102,7 @@ generated_at: 2026-08-13T16:00:00-07:00
 - **`windows/script/build.bat`** (modified if needed): link `Advapi32.lib`.
 - **README.md** (modified): coverage-note update to all three platforms.
 
-No new classes; the class model is canvas 23's.
+No new classes; the class model is canvas 26's.
 
 ## A · Approach
 
@@ -177,7 +177,7 @@ No new classes; the class model is canvas 23's.
 1. **Native engine layer** (`windows/webview_embed.cc`): the password
    branch in `MsgHandler`, the callback setter + fire helpers, the
    Credential-Manager store bodies, and the Edge-autosave-off setting.
-2. All higher layers are canvas 23's, unchanged. The Windows wiring in
+2. All higher layers are canvas 26's, unchanged. The Windows wiring in
    `WebViewHeavyweightComponent.createPeer()` (which already injects
    `SHIM_JS` and calls `setPasswordCallback`) now reaches live native code
    instead of a stub.
@@ -278,7 +278,7 @@ File: `windows/script/build.bat` (or the Windows link step)
 
 ## N · Norms
 
-- **No Java / `SHIM_JS` change.** Native-only; the contract is canvas 23's.
+- **No Java / `SHIM_JS` change.** Native-only; the contract is canvas 26's.
 - **Single `WebMessageReceived` registration, demuxed by content** — the
   password branch is added inside the existing `MsgHandler`, not a second
   handler, matching the codebase's single-Windows-channel convention.
@@ -312,7 +312,7 @@ File: `windows/script/build.bat` (or the Windows link step)
 - **JNI exception sanitisation** after every `CallVoidMethod`; symmetric
   attach/detach; null-callback short-circuit.
 - **Callback global-ref lifecycle** set in the setter, deleted on engine
-  destroy; the Java callback anchored in the wrapper `heap` (canvas 23).
+  destroy; the Java callback anchored in the wrapper `heap` (canvas 26).
 - **No behavioural drift.** Java layer, shared JS, and value encoding are
   shared; only the store backend, the message demux branch, and the
   Edge-autosave setting are Windows-specific — all conforming to the

--- a/spdd/prompt/28-202608131600-[Feat]-Webview-Native-Password-Manager-Windows-Coverage.md
+++ b/spdd/prompt/28-202608131600-[Feat]-Webview-Native-Password-Manager-Windows-Coverage.md
@@ -27,13 +27,15 @@ generated_at: 2026-08-13T16:00:00-07:00
      `webview_embed_set_password_callback` (and the offscreen setter as a
      no-op — Windows has no offscreen engine), following the existing
      `webview_embed_set_dialog_callback` JNI export.
-  2. **Credential Manager store:** replace the canvas-23 Windows stub
-     bodies of the four `webview_cred_store_*` primitives with a Win32
-     Credential Manager implementation (`CredWriteW` / `CredReadW` /
-     `CredEnumerateW` / `CredDeleteW`, `CRED_TYPE_GENERIC`), matching the
-     macOS/Linux semantics exactly (same value encoding `millis + "\n" +
-     password`, same origin/username keying, same most-recent-first
-     contract — Java re-sorts).
+  2. **Credential Manager store:** replace the canvas-26 Windows stub
+     bodies of the five `webview_cred_store_*` primitives — including
+     `webview_cred_store_find_all` (the no-argument enumerate-all across
+     every origin, STORY-006-005) — with a Win32 Credential Manager
+     implementation (`CredWriteW` / `CredReadW` / `CredEnumerateW` /
+     `CredDeleteW`, `CRED_TYPE_GENERIC`), matching the macOS/Linux
+     semantics exactly (same value encoding `millis + "\n" + password`,
+     same origin/username keying, same most-recent-first contract — Java
+     re-sorts).
   3. **Suppress Edge's built-in password autosave** so it never competes
      with the library's Swing prompt: at engine creation, after acquiring
      the settings object, `QueryInterface` for `ICoreWebView2Settings4`
@@ -45,7 +47,9 @@ generated_at: 2026-08-13T16:00:00-07:00
   `L"ca.weblite.webview.passwords:" + base64url(origin) + "|" + base64url(username)`
   (the same namespace prefix used as the `service` on the other platforms,
   followed by the same account encoding). `CredEnumerateW` with filter
-  `L"ca.weblite.webview.passwords:*"` backs `find`. The
+  `L"ca.weblite.webview.passwords:*"` backs both `find` (keeping only the
+  matching origin) and `find_all` (keeping every entry and emitting its
+  origin, STORY-006-005). The
   `CredentialBlob` holds the UTF-8 (or UTF-16) `millis + "\n" + password`
   bytes; `Persist = CRED_PERSIST_LOCAL_MACHINE` (per-user local; DPAPI
   protects the blob).
@@ -60,6 +64,9 @@ generated_at: 2026-08-13T16:00:00-07:00
   file-picker carve-out) — all 13 STORY-006-003 ACs are achievable.
 - Definition of Done:
   - All 13 STORY-006-003 ACs pass on Windows 11 with the WebView2 Runtime.
+  - STORY-006-005 AC7 on Windows: `getAllCredentials()` round-trips every
+    stored credential across origins via `CredEnumerateW` over the
+    namespace prefix.
   - `WebViewPasswordDemo` (canvas 26) works unchanged on Windows.
   - README's "Password manager" subsection updates coverage to
     all-three-platforms, with the Windows note: the library's own manager
@@ -90,7 +97,7 @@ generated_at: 2026-08-13T16:00:00-07:00
   - `fire_password_submitted` / `fire_password_fill_requested` (Windows
     JNI fire helpers; mirror the dialog `onAlert`/`onConfirm` GetMethodID
     helpers at `:276`/`:318`).
-  - Win32 Credential Manager bodies for the four `webview_cred_store_*`
+  - Win32 Credential Manager bodies for the five `webview_cred_store_*`
     primitives (replacing the canvas-23 Windows stubs).
   - JNI bridges for `webview_embed_set_password_callback` (→ store the
     global ref, mirroring the dialog setter at `:2365`) and
@@ -141,6 +148,12 @@ No new classes; the class model is canvas 26's.
      origin equals the (canonical) target origin, read the blob, split on
      the first `\n` → millis, password; emit `[username, millis, password]`.
      `CredFree(creds)`. Java sorts. Empty on none.
+   - **find_all** (STORY-006-005): the enumerate-all variant of `find` —
+     the same `CredEnumerateW(L"ca.weblite.webview.passwords:*", ...)`
+     enumeration, but **without** the origin filter: for every entry
+     decode `TargetName` into origin + username, read the blob, split into
+     millis + password, and emit flat **quads** `[origin, username,
+     millis, password]`. `CredFree(creds)`. Java sorts. Empty on none.
    - **delete**: reconstruct the exact `TargetName`; `CredDeleteW(target,
      CRED_TYPE_GENERIC, 0)`; return success (`true` only when actually
      deleted).
@@ -245,6 +258,18 @@ File: `windows/webview_embed.cc`
    millis, password; append `username`, `millis`, `password`.
 3. `CredFree(creds);` build + return the flat `jobjectArray` (empty on
    none). Java sorts.
+
+### 5a. Implement webview_cred_store_find_all (STORY-006-005)
+File: `windows/webview_embed.cc`
+
+1. `PCREDENTIALW* creds = nullptr; DWORD count = 0; if (!CredEnumerateW(L"ca.weblite.webview.passwords:*", 0, &count, &creds)) return empty jobjectArray;`
+2. For each `creds[i]`: parse `TargetName` after the prefix into
+   `b64origin|b64username`; base64url-decode → origin, username (no origin
+   filter — every entry is kept); read the blob
+   (`CredentialBlob`/`CredentialBlobSize`) as UTF-8, split on first `\n` →
+   millis, password; append `origin`, `username`, `millis`, `password`.
+3. `CredFree(creds);` build + return the flat **quad** `jobjectArray`
+   (empty on none). Java sorts. Never log the blob.
 
 ### 6. Implement webview_cred_store_delete
 File: `windows/webview_embed.cc`

--- a/src/ca/weblite/webview/EmbeddedWebView.java
+++ b/src/ca/weblite/webview/EmbeddedWebView.java
@@ -573,6 +573,25 @@ public class EmbeddedWebView {
     }
 
     /**
+     * Register the password-manager callback invoked when the embedded
+     * page's injected detection/fill script reports a login submission or
+     * requests autofill.  Anchored in {@link #heap} so the JVM does not
+     * collect it while the native side holds a global ref, mirroring
+     * {@link #setDialogCallback}.  {@code cb == null} clears the
+     * registration.  On macOS the native side is a dedicated
+     * {@code __webview_pw__} script-message handler (Canvas 23); Linux and
+     * Windows wire theirs in the follow-up canvases.
+     */
+    public EmbeddedWebView setPasswordCallback(WebViewPasswordCallback cb) {
+        checkAlive();
+        if (cb != null) {
+            heap.add(cb);
+        }
+        WebViewNative.webview_embed_set_password_callback(peer, cb);
+        return this;
+    }
+
+    /**
      * Register the popup callback for browser-initiated popups
      * ({@code window.open}, {@code target="_blank"}).  Anchors {@code cb} in
      * {@link #heap} so the JVM does not collect the adapter while the native

--- a/src/ca/weblite/webview/EmbeddedWebView.java
+++ b/src/ca/weblite/webview/EmbeddedWebView.java
@@ -579,7 +579,7 @@ public class EmbeddedWebView {
      * collect it while the native side holds a global ref, mirroring
      * {@link #setDialogCallback}.  {@code cb == null} clears the
      * registration.  On macOS the native side is a dedicated
-     * {@code __webview_pw__} script-message handler (Canvas 23); Linux and
+     * {@code __webview_pw__} script-message handler (Canvas 26); Linux and
      * Windows wire theirs in the follow-up canvases.
      */
     public EmbeddedWebView setPasswordCallback(WebViewPasswordCallback cb) {

--- a/src/ca/weblite/webview/FillPasswordDisposition.java
+++ b/src/ca/weblite/webview/FillPasswordDisposition.java
@@ -1,0 +1,17 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+/**
+ * The decision a {@link WebViewFillPasswordHandler} returns when the
+ * password manager is about to autofill a stored credential.
+ */
+public enum FillPasswordDisposition {
+    /** Inject the stored credential into the detected login fields. */
+    FILL,
+    /** Suppress the autofill; leave the page's fields untouched. */
+    DONT_FILL
+}

--- a/src/ca/weblite/webview/InMemoryCredentialStore.java
+++ b/src/ca/weblite/webview/InMemoryCredentialStore.java
@@ -1,0 +1,126 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A {@link WebViewCredentialStore} that keeps credentials in memory only,
+ * with the same origin-keying and recency semantics as
+ * {@link NativeCredentialStore} but no OS persistence.  Intended for unit
+ * tests and for hosts that do not want credentials written to the OS
+ * secret store.
+ */
+public final class InMemoryCredentialStore implements WebViewCredentialStore {
+
+    private final ConcurrentHashMap<String, List<Rec>> byOrigin =
+        new ConcurrentHashMap<String, List<Rec>>();
+
+    /** Strictly-increasing save clock: guarantees a later save always
+     *  outranks an earlier one even when the wall clock has not advanced
+     *  between them, so recency ordering is deterministic. */
+    private final AtomicLong clock = new AtomicLong(0L);
+
+    private long nextMillis() {
+        long now = System.currentTimeMillis();
+        while (true) {
+            long prev = clock.get();
+            long next = now > prev ? now : prev + 1;
+            if (clock.compareAndSet(prev, next)) return next;
+        }
+    }
+
+    @Override
+    public void save(WebViewCredential credential) {
+        if (credential == null) return;
+        String origin = Origins.canonical(credential.origin());
+        if (origin == null) return;
+        List<Rec> list = byOrigin.get(origin);
+        if (list == null) {
+            list = Collections.synchronizedList(new ArrayList<Rec>());
+            List<Rec> existing = byOrigin.putIfAbsent(origin, list);
+            if (existing != null) list = existing;
+        }
+        synchronized (list) {
+            for (int i = list.size() - 1; i >= 0; i--) {
+                if (list.get(i).username.equals(credential.username())) {
+                    list.remove(i);
+                }
+            }
+            list.add(new Rec(credential.username(),
+                nextMillis(), credential.password()));
+        }
+    }
+
+    @Override
+    public Optional<WebViewCredential> find(String origin) {
+        List<WebViewCredential> all = findAll(origin);
+        return all.isEmpty() ? Optional.<WebViewCredential>empty()
+                             : Optional.of(all.get(0));
+    }
+
+    @Override
+    public List<WebViewCredential> findAll(String origin) {
+        String o = Origins.canonical(origin);
+        if (o == null) return Collections.emptyList();
+        List<Rec> list = byOrigin.get(o);
+        if (list == null) return Collections.emptyList();
+        List<Rec> copy;
+        synchronized (list) {
+            copy = new ArrayList<Rec>(list);
+        }
+        Collections.sort(copy, REC_ORDER);
+        List<WebViewCredential> out = new ArrayList<WebViewCredential>(copy.size());
+        for (Rec r : copy) {
+            out.add(new WebViewCredential(o, r.username, r.password));
+        }
+        return Collections.unmodifiableList(out);
+    }
+
+    @Override
+    public boolean delete(String origin, String username) {
+        String o = Origins.canonical(origin);
+        if (o == null || username == null) return false;
+        List<Rec> list = byOrigin.get(o);
+        if (list == null) return false;
+        synchronized (list) {
+            boolean removed = false;
+            for (int i = list.size() - 1; i >= 0; i--) {
+                if (list.get(i).username.equals(username)) {
+                    list.remove(i);
+                    removed = true;
+                }
+            }
+            return removed;
+        }
+    }
+
+    private static final Comparator<Rec> REC_ORDER = new Comparator<Rec>() {
+        @Override public int compare(Rec a, Rec b) {
+            if (a.savedAtMillis != b.savedAtMillis) {
+                return a.savedAtMillis > b.savedAtMillis ? -1 : 1;
+            }
+            return a.username.compareTo(b.username);
+        }
+    };
+
+    private static final class Rec {
+        final String username;
+        final long savedAtMillis;
+        final String password;
+        Rec(String username, long savedAtMillis, String password) {
+            this.username = username;
+            this.savedAtMillis = savedAtMillis;
+            this.password = password;
+        }
+    }
+}

--- a/src/ca/weblite/webview/InMemoryCredentialStore.java
+++ b/src/ca/weblite/webview/InMemoryCredentialStore.java
@@ -87,6 +87,25 @@ public final class InMemoryCredentialStore implements WebViewCredentialStore {
     }
 
     @Override
+    public List<WebViewCredential> findAll() {
+        List<OriginRec> all = new ArrayList<OriginRec>();
+        for (java.util.Map.Entry<String, List<Rec>> e : byOrigin.entrySet()) {
+            String origin = e.getKey();
+            List<Rec> list = e.getValue();
+            synchronized (list) {
+                for (Rec r : list) all.add(new OriginRec(origin, r));
+            }
+        }
+        Collections.sort(all, ORIGIN_REC_ORDER);
+        List<WebViewCredential> out = new ArrayList<WebViewCredential>(all.size());
+        for (OriginRec or : all) {
+            out.add(new WebViewCredential(or.origin, or.rec.username,
+                or.rec.password));
+        }
+        return Collections.unmodifiableList(out);
+    }
+
+    @Override
     public boolean delete(String origin, String username) {
         String o = Origins.canonical(origin);
         if (o == null || username == null) return false;
@@ -123,4 +142,29 @@ public final class InMemoryCredentialStore implements WebViewCredentialStore {
             this.password = password;
         }
     }
+
+    /** Pairs a {@link Rec} with its origin for the cross-origin
+     *  {@link #findAll()} enumeration. */
+    private static final class OriginRec {
+        final String origin;
+        final Rec rec;
+        OriginRec(String origin, Rec rec) {
+            this.origin = origin;
+            this.rec = rec;
+        }
+    }
+
+    /** Most-recently-saved first across all origins; ties broken by origin
+     *  then username ascending. */
+    private static final Comparator<OriginRec> ORIGIN_REC_ORDER =
+        new Comparator<OriginRec>() {
+            @Override public int compare(OriginRec a, OriginRec b) {
+                if (a.rec.savedAtMillis != b.rec.savedAtMillis) {
+                    return a.rec.savedAtMillis > b.rec.savedAtMillis ? -1 : 1;
+                }
+                int byOrigin = a.origin.compareTo(b.origin);
+                if (byOrigin != 0) return byOrigin;
+                return a.rec.username.compareTo(b.rec.username);
+            }
+        };
 }

--- a/src/ca/weblite/webview/NativeCredentialStore.java
+++ b/src/ca/weblite/webview/NativeCredentialStore.java
@@ -1,0 +1,133 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The default {@link WebViewCredentialStore}, backed by the OS-native
+ * secret store through process-global JNI primitives — macOS Keychain in
+ * this iteration; Linux libsecret and Windows Credential Manager in the
+ * follow-up canvases.
+ *
+ * <p>Credentials are keyed by canonical origin (see {@link Origins}).
+ * Every record carries a {@code savedAtMillis} timestamp stored alongside
+ * the password so recency ordering ({@code find} returns the
+ * most-recently-saved) is uniform across all platforms regardless of what
+ * metadata the native store keeps.
+ *
+ * <p>All operations degrade gracefully: if the native store is
+ * unavailable or errors, {@code save}/{@code delete} become no-ops and
+ * {@code find}/{@code findAll} return empty — never a thrown exception,
+ * never a logged password.
+ */
+public final class NativeCredentialStore implements WebViewCredentialStore {
+
+    /** Library namespace isolating these items from any other secret-store
+     *  entries (e.g. Safari's iCloud Keychain items). */
+    static final String SERVICE = "ca.weblite.webview.passwords";
+
+    /** @return whether the platform secret store is usable. */
+    public boolean isAvailable() {
+        try {
+            return WebViewNative.webview_cred_store_available();
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    @Override
+    public void save(WebViewCredential credential) {
+        if (credential == null) return;
+        String origin = Origins.canonical(credential.origin());
+        if (origin == null) return;
+        try {
+            WebViewNative.webview_cred_store_save(SERVICE, origin,
+                credential.username(), credential.password(),
+                System.currentTimeMillis());
+        } catch (Throwable t) {
+            // Store unavailable / errored: degrade to no-op.  Never log
+            // the password.
+        }
+    }
+
+    @Override
+    public Optional<WebViewCredential> find(String origin) {
+        List<WebViewCredential> all = findAll(origin);
+        return all.isEmpty() ? Optional.<WebViewCredential>empty()
+                             : Optional.of(all.get(0));
+    }
+
+    @Override
+    public List<WebViewCredential> findAll(String origin) {
+        String o = Origins.canonical(origin);
+        if (o == null) return Collections.emptyList();
+        String[] flat;
+        try {
+            flat = WebViewNative.webview_cred_store_find(SERVICE, o);
+        } catch (Throwable t) {
+            return Collections.emptyList();
+        }
+        if (flat == null || flat.length < 3) return Collections.emptyList();
+        List<Row> rows = new ArrayList<Row>(flat.length / 3);
+        for (int i = 0; i + 2 < flat.length; i += 3) {
+            String username = flat[i];
+            long millis = parseMillis(flat[i + 1]);
+            String password = flat[i + 2];
+            if (username == null || password == null) continue;
+            rows.add(new Row(new WebViewCredential(o, username, password),
+                millis));
+        }
+        Collections.sort(rows, ROW_ORDER);
+        List<WebViewCredential> out = new ArrayList<WebViewCredential>(rows.size());
+        for (Row r : rows) out.add(r.credential);
+        return Collections.unmodifiableList(out);
+    }
+
+    @Override
+    public boolean delete(String origin, String username) {
+        String o = Origins.canonical(origin);
+        if (o == null || username == null) return false;
+        try {
+            return WebViewNative.webview_cred_store_delete(SERVICE, o, username);
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    private static long parseMillis(String s) {
+        if (s == null) return 0L;
+        try {
+            return Long.parseLong(s.trim());
+        } catch (NumberFormatException nfe) {
+            return 0L;
+        }
+    }
+
+    /** Most-recently-saved first; ties broken by username ascending for
+     *  deterministic ordering. */
+    private static final Comparator<Row> ROW_ORDER = new Comparator<Row>() {
+        @Override public int compare(Row a, Row b) {
+            if (a.savedAtMillis != b.savedAtMillis) {
+                return a.savedAtMillis > b.savedAtMillis ? -1 : 1;
+            }
+            return a.credential.username().compareTo(b.credential.username());
+        }
+    };
+
+    private static final class Row {
+        final WebViewCredential credential;
+        final long savedAtMillis;
+        Row(WebViewCredential credential, long savedAtMillis) {
+            this.credential = credential;
+            this.savedAtMillis = savedAtMillis;
+        }
+    }
+}

--- a/src/ca/weblite/webview/NativeCredentialStore.java
+++ b/src/ca/weblite/webview/NativeCredentialStore.java
@@ -92,6 +92,31 @@ public final class NativeCredentialStore implements WebViewCredentialStore {
     }
 
     @Override
+    public List<WebViewCredential> findAll() {
+        String[] flat;
+        try {
+            flat = WebViewNative.webview_cred_store_find_all(SERVICE);
+        } catch (Throwable t) {
+            return Collections.emptyList();
+        }
+        if (flat == null || flat.length < 4) return Collections.emptyList();
+        List<Row> rows = new ArrayList<Row>(flat.length / 4);
+        for (int i = 0; i + 3 < flat.length; i += 4) {
+            String origin = flat[i];
+            String username = flat[i + 1];
+            long millis = parseMillis(flat[i + 2]);
+            String password = flat[i + 3];
+            if (origin == null || username == null || password == null) continue;
+            rows.add(new Row(new WebViewCredential(origin, username, password),
+                millis));
+        }
+        Collections.sort(rows, ROW_ORDER);
+        List<WebViewCredential> out = new ArrayList<WebViewCredential>(rows.size());
+        for (Row r : rows) out.add(r.credential);
+        return Collections.unmodifiableList(out);
+    }
+
+    @Override
     public boolean delete(String origin, String username) {
         String o = Origins.canonical(origin);
         if (o == null || username == null) return false;
@@ -111,13 +136,17 @@ public final class NativeCredentialStore implements WebViewCredentialStore {
         }
     }
 
-    /** Most-recently-saved first; ties broken by username ascending for
-     *  deterministic ordering. */
+    /** Most-recently-saved first; ties broken by origin then username
+     *  ascending for deterministic ordering (the origin tie-break is a
+     *  no-op for the origin-scoped {@code findAll(origin)} where every row
+     *  shares one origin, and orders the cross-origin {@code findAll()}). */
     private static final Comparator<Row> ROW_ORDER = new Comparator<Row>() {
         @Override public int compare(Row a, Row b) {
             if (a.savedAtMillis != b.savedAtMillis) {
                 return a.savedAtMillis > b.savedAtMillis ? -1 : 1;
             }
+            int byOrigin = a.credential.origin().compareTo(b.credential.origin());
+            if (byOrigin != 0) return byOrigin;
             return a.credential.username().compareTo(b.credential.username());
         }
     };

--- a/src/ca/weblite/webview/OffscreenWebView.java
+++ b/src/ca/weblite/webview/OffscreenWebView.java
@@ -438,6 +438,24 @@ public class OffscreenWebView {
     }
 
     /**
+     * Register the password-manager callback (login-submission / autofill)
+     * on the offscreen engine.  Anchored in {@link #heap} so the JVM does
+     * not collect it while the native side holds a global ref, mirroring
+     * {@link #setDialogCallback}.  On macOS / Windows, where the offscreen
+     * engine is a stub, this has no effect; Linux lightweight wires the GTK
+     * script-message handler in Canvas 24.  {@code cb == null} clears the
+     * registration.
+     */
+    public OffscreenWebView setPasswordCallback(WebViewPasswordCallback cb) {
+        checkAlive();
+        if (cb != null) {
+            heap.add(cb);
+        }
+        WebViewNative.webview_offscreen_set_password_callback(peer, cb);
+        return this;
+    }
+
+    /**
      * Offscreen counterpart to
      * {@link EmbeddedWebView#setPopupCallback} — bridges
      * {@code window.open} popup requests in the offscreen engine to the

--- a/src/ca/weblite/webview/OffscreenWebView.java
+++ b/src/ca/weblite/webview/OffscreenWebView.java
@@ -443,7 +443,7 @@ public class OffscreenWebView {
      * not collect it while the native side holds a global ref, mirroring
      * {@link #setDialogCallback}.  On macOS / Windows, where the offscreen
      * engine is a stub, this has no effect; Linux lightweight wires the GTK
-     * script-message handler in Canvas 24.  {@code cb == null} clears the
+     * script-message handler in Canvas 27.  {@code cb == null} clears the
      * registration.
      */
     public OffscreenWebView setPasswordCallback(WebViewPasswordCallback cb) {

--- a/src/ca/weblite/webview/Origins.java
+++ b/src/ca/weblite/webview/Origins.java
@@ -1,0 +1,66 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+
+/**
+ * <p><strong>Internal:</strong> the single definition of "origin" used
+ * throughout the password-manager feature.  An origin is
+ * {@code scheme://host} plus a port only when that port is non-default
+ * for the scheme.  Scheme and host are lower-cased; path, query, and
+ * fragment are dropped; there is no trailing slash.
+ *
+ * <p>This is the credential key and the anti-phishing boundary: a
+ * credential stored for one origin is only ever offered on that exact
+ * origin.  Both {@link WebViewCredentialStore} implementations and
+ * {@link PasswordDispatcher} canonicalise through this class so equal
+ * origins collapse identically everywhere.
+ */
+final class Origins {
+
+    private Origins() { }
+
+    /**
+     * Canonicalise a URL or origin string to {@code scheme://host[:port]}.
+     *
+     * @return the canonical origin, or {@code null} when the input is
+     *         null/blank, opaque, or hostless (e.g. {@code about:blank},
+     *         {@code data:...}) — callers skip a null origin.
+     */
+    static String canonical(String urlOrOrigin) {
+        if (urlOrOrigin == null) return null;
+        String trimmed = urlOrOrigin.trim();
+        if (trimmed.isEmpty()) return null;
+        try {
+            URI uri = new URI(trimmed);
+            String scheme = uri.getScheme();
+            String host = uri.getHost();
+            if (scheme == null || host == null) return null;
+            scheme = scheme.toLowerCase(Locale.ROOT);
+            host = host.toLowerCase(Locale.ROOT);
+            if (host.isEmpty()) return null;
+            int port = uri.getPort();
+            int def = defaultPort(scheme);
+            StringBuilder sb = new StringBuilder();
+            sb.append(scheme).append("://").append(host);
+            if (port != -1 && port != def) {
+                sb.append(':').append(port);
+            }
+            return sb.toString();
+        } catch (URISyntaxException ex) {
+            return null;
+        }
+    }
+
+    private static int defaultPort(String scheme) {
+        if ("http".equals(scheme) || "ws".equals(scheme)) return 80;
+        if ("https".equals(scheme) || "wss".equals(scheme)) return 443;
+        return -1;
+    }
+}

--- a/src/ca/weblite/webview/PasswordDispatcher.java
+++ b/src/ca/weblite/webview/PasswordDispatcher.java
@@ -1,0 +1,286 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import ca.weblite.webview.swing.WebViewComponent;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import javax.swing.SwingUtilities;
+
+/**
+ * <p><strong>Internal:</strong> not part of the public API surface.
+ * Drive the password manager via
+ * {@link WebViewComponent#setPasswordManagerEnabled},
+ * {@link WebViewComponent#setCredentialStore},
+ * {@link WebViewComponent#setSavePasswordHandler}, and the
+ * {@code getCredential}/{@code saveCredential}/{@code deleteCredential}
+ * methods.  This class is {@code public} only because the consuming
+ * Swing subclasses live in a different package — the same reason
+ * {@link DialogDispatcher} is public.
+ *
+ * <p>Per-component hub for the password manager.  Holds the active
+ * {@link WebViewCredentialStore}, the {@link WebViewSavePasswordHandler},
+ * and the enabled flag; receives login-submission and fill-request
+ * events the injected {@link #SHIM_JS} raised (via
+ * {@link WebViewPasswordCallback}); shows the save prompt on the EDT and
+ * performs store I/O on a worker; pushes autofill back into the page via
+ * {@code eval}.
+ *
+ * <p><strong>Threading — divergence from {@link DialogDispatcher}.</strong>
+ * A login submission has no synchronous JS contract, so this dispatcher
+ * is NON-blocking: it marshals the save prompt with
+ * {@link SwingUtilities#invokeLater} (never {@code invokeAndWait}) and
+ * runs all secret-store I/O on a private single-thread executor, so the
+ * native message thread and the EDT are never parked on keychain I/O.
+ */
+public final class PasswordDispatcher {
+
+    /**
+     * Shared detection/fill script, injected at document-start on every
+     * backend via {@code addOnBeforeLoad}.  It reports login submissions
+     * and requests autofill over the native {@code __webview_pw__}
+     * channel, and exposes a single write-only fill entrypoint
+     * {@code window.__webview_pw_fill__(b64user, b64pass)}.  It exposes
+     * no way for page script to read a stored credential.
+     */
+    public static final String SHIM_JS =
+        "(function(){\n" +
+        "try{\n" +
+        "if(window.__webview_pw_installed__)return;\n" +
+        "window.__webview_pw_installed__=true;\n" +
+        "function b64e(s){try{var u=unescape(encodeURIComponent(s));var b=btoa(u);" +
+        "return b.replace(/\\+/g,'-').replace(/\\//g,'_').replace(/=+$/,'');}catch(e){return '';}}\n" +
+        "function b64d(s){try{s=s.replace(/-/g,'+').replace(/_/g,'/');" +
+        "while(s.length%4)s+='=';return decodeURIComponent(escape(atob(s)));}catch(e){return '';}}\n" +
+        "function post(p){try{if(window.webkit&&window.webkit.messageHandlers&&" +
+        "window.webkit.messageHandlers.__webview_pw__){window.webkit.messageHandlers.__webview_pw__.postMessage(p);}" +
+        "else if(window.chrome&&window.chrome.webview){window.chrome.webview.postMessage('__webview_pw__:'+p);}}catch(e){}}\n" +
+        "function isTexty(el){if(!el||el.tagName!=='INPUT')return false;" +
+        "var t=(el.type||'text').toLowerCase();return t==='text'||t==='email'||t==='tel'||t==='';}\n" +
+        "function findFields(){var pass=document.querySelector('input[type=password]');if(!pass)return null;" +
+        "var user=null;var form=pass.form;" +
+        "if(form){var els=form.elements;var pi=-1;for(var i=0;i<els.length;i++){if(els[i]===pass){pi=i;break;}}" +
+        "for(var j=pi-1;j>=0;j--){if(isTexty(els[j])){user=els[j];break;}}" +
+        "if(!user){for(var k=0;k<els.length;k++){if(isTexty(els[k])){user=els[k];break;}}}}" +
+        "else{var all=document.querySelectorAll('input');var pidx=-1;for(var a=0;a<all.length;a++){if(all[a]===pass){pidx=a;break;}}" +
+        "for(var b=pidx-1;b>=0;b--){if(isTexty(all[b])){user=all[b];break;}}}" +
+        "return {user:user,pass:pass};}\n" +
+        "function setVal(el,v){try{var d=Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,'value');" +
+        "if(d&&d.set){d.set.call(el,v);}else{el.value=v;}}catch(e){el.value=v;}" +
+        "try{el.dispatchEvent(new Event('input',{bubbles:true}));el.dispatchEvent(new Event('change',{bubbles:true}));}catch(e){}}\n" +
+        "window.__webview_pw_fill__=function(bu,bp){try{var f=findFields();if(!f)return;" +
+        "if(f.user&&bu)setVal(f.user,b64d(bu));if(f.pass)setVal(f.pass,b64d(bp));}catch(e){}};\n" +
+        "var lastPost=0;\n" +
+        "function capture(){try{var f=findFields();if(!f||!f.pass)return;var pv=f.pass.value;if(!pv)return;" +
+        "var now=Date.now();if(now-lastPost<400)return;lastPost=now;" +
+        "var uv=f.user?f.user.value:'';post('S|'+b64e(uv)+'|'+b64e(pv));}catch(e){}}\n" +
+        "document.addEventListener('submit',function(ev){try{var t=ev.target;" +
+        "if(t&&t.querySelector&&t.querySelector('input[type=password]'))capture();}catch(e){}},true);\n" +
+        "document.addEventListener('click',function(ev){try{var el=ev.target;" +
+        "if(!el)return;var tag=(el.tagName||'').toUpperCase();var role=el.getAttribute&&el.getAttribute('role');" +
+        "var isBtn=tag==='BUTTON'||(tag==='INPUT'&&/^(submit|button)$/i.test(el.type||''))||role==='button';" +
+        "if(!isBtn)return;var f=findFields();if(f&&f.pass&&!f.pass.form&&f.pass.value)capture();}catch(e){}},true);\n" +
+        "function requestFill(){try{if(findFields())post('F');}catch(e){}}\n" +
+        "function ready(){requestFill();try{var seen=!!findFields();var mo=new MutationObserver(function(){" +
+        "if(!seen&&findFields()){seen=true;post('F');mo.disconnect();}});" +
+        "mo.observe(document.documentElement,{childList:true,subtree:true});" +
+        "setTimeout(function(){try{mo.disconnect();}catch(e){}},10000);}catch(e){}}\n" +
+        "if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',ready);else ready();\n" +
+        "}catch(e){}\n" +
+        "})();";
+
+    private final WebViewComponent source;
+    private volatile WebViewCredentialStore store = new NativeCredentialStore();
+    private volatile WebViewSavePasswordHandler handler =
+        WebViewSavePasswordHandler.DEFAULT;
+    private volatile boolean enabled = true;
+    private volatile boolean disposed = false;
+    private final ExecutorService io = Executors.newSingleThreadExecutor(
+        new ThreadFactory() {
+            @Override public Thread newThread(Runnable r) {
+                Thread t = new Thread(r, "webview-password-io");
+                t.setDaemon(true);
+                return t;
+            }
+        });
+
+    public PasswordDispatcher(WebViewComponent source) {
+        if (source == null) throw new NullPointerException("source");
+        this.source = source;
+    }
+
+    // ---- enabled / store / handler seams -------------------------------
+
+    public void setEnabled(boolean e) { enabled = e; }
+    public boolean isEnabled() { return enabled; }
+
+    /** Replace the store; {@code null} restores a fresh
+     *  {@link NativeCredentialStore}. */
+    public void setStore(WebViewCredentialStore s) {
+        store = (s == null) ? new NativeCredentialStore() : s;
+    }
+
+    /** @return the active store; never {@code null}. */
+    public WebViewCredentialStore getStore() { return store; }
+
+    /** Replace the save-policy; {@code null} restores
+     *  {@link WebViewSavePasswordHandler#DEFAULT}. */
+    public void setHandler(WebViewSavePasswordHandler h) {
+        handler = (h == null) ? WebViewSavePasswordHandler.DEFAULT : h;
+    }
+
+    /** @return the active save-policy; never {@code null}. */
+    public WebViewSavePasswordHandler getHandler() { return handler; }
+
+    // ---- programmatic API (synchronous on the caller thread) -----------
+
+    public void saveCredential(WebViewCredential c) {
+        if (c == null) throw new NullPointerException("credential");
+        store.save(c);
+    }
+
+    public Optional<WebViewCredential> getCredential(String origin) {
+        return store.find(origin);
+    }
+
+    public List<WebViewCredential> getCredentials(String origin) {
+        return store.findAll(origin);
+    }
+
+    public boolean deleteCredential(String origin, String username) {
+        return store.delete(origin, username);
+    }
+
+    // ---- native-facing dispatch ---------------------------------------
+
+    /** A login form was submitted; {@code frameUrl} is the native-stamped
+     *  trusted origin source, the username/password are base64url. */
+    public void dispatchLoginSubmitted(String frameUrl, String b64User,
+                                       String b64Pass) {
+        if (disposed || !enabled) return;
+        final String origin = Origins.canonical(frameUrl);
+        if (origin == null) return;
+        final String user;
+        final String pass;
+        try {
+            user = base64UrlDecode(b64User);
+            pass = base64UrlDecode(b64Pass);
+        } catch (IllegalArgumentException iae) {
+            return; // malformed payload: drop silently
+        }
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override public void run() { runPrompt(origin, user, pass); }
+        });
+    }
+
+    /** The page requested autofill; {@code frameUrl} is the native-stamped
+     *  trusted origin source. */
+    public void dispatchFillRequested(String frameUrl) {
+        if (disposed || !enabled) return;
+        final String origin = Origins.canonical(frameUrl);
+        if (origin == null) return;
+        io.execute(new Runnable() {
+            @Override public void run() { doFill(origin); }
+        });
+    }
+
+    /** Flip into disposed state; automatic dispatch stops and the worker
+     *  executor is released.  Idempotent. */
+    public void disposeAll() {
+        disposed = true;
+        io.shutdownNow();
+    }
+
+    public boolean isDisposed() { return disposed; }
+
+    // ---- internals ----------------------------------------------------
+
+    private void runPrompt(String origin, String user, String pass) {
+        if (disposed || !enabled) return;
+        WebViewSavePasswordEvent ev =
+            new WebViewSavePasswordEvent(source, origin, user, pass);
+        SavePasswordDisposition d;
+        try {
+            d = handler.onLoginSubmitted(ev);
+        } catch (Throwable t) {
+            forward(t);
+            return;
+        }
+        if (d == SavePasswordDisposition.SAVE) {
+            final WebViewCredential c = new WebViewCredential(origin, user, pass);
+            io.execute(new Runnable() {
+                @Override public void run() { safeSave(c); }
+            });
+        }
+    }
+
+    private void doFill(String origin) {
+        Optional<WebViewCredential> c;
+        try {
+            c = store.find(origin);
+        } catch (Throwable t) {
+            forward(t);
+            return;
+        }
+        if (c == null || !c.isPresent()) return;
+        WebViewCredential cred = c.get();
+        String js = "window.__webview_pw_fill__('"
+            + base64UrlEncode(cred.username()) + "','"
+            + base64UrlEncode(cred.password()) + "')";
+        try {
+            source.eval(js);
+        } catch (Throwable t) {
+            forward(t); // never log js — it embeds the password
+        }
+    }
+
+    private void safeSave(WebViewCredential c) {
+        try {
+            store.save(c);
+        } catch (Throwable t) {
+            forward(t);
+        }
+    }
+
+    private static String base64UrlEncode(String s) {
+        try {
+            return Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(s.getBytes("UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException(e); // UTF-8 always present
+        }
+    }
+
+    private static String base64UrlDecode(String s) {
+        if (s == null) return "";
+        byte[] raw = Base64.getUrlDecoder().decode(s);
+        try {
+            return new String(raw, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static void forward(Throwable t) {
+        try {
+            Thread.UncaughtExceptionHandler h =
+                Thread.getDefaultUncaughtExceptionHandler();
+            if (h != null) {
+                h.uncaughtException(Thread.currentThread(), t);
+            } else {
+                t.printStackTrace();
+            }
+        } catch (Throwable ignored) {
+            try { t.printStackTrace(); } catch (Throwable ignored2) { }
+        }
+    }
+}

--- a/src/ca/weblite/webview/PasswordDispatcher.java
+++ b/src/ca/weblite/webview/PasswordDispatcher.java
@@ -193,9 +193,39 @@ public final class PasswordDispatcher {
         } catch (IllegalArgumentException iae) {
             return; // malformed payload: drop silently
         }
+        // Run the store dedup check off the EDT and the native message
+        // thread; only a new or changed credential reaches the prompt.
+        io.execute(new Runnable() {
+            @Override public void run() { maybePrompt(origin, user, pass); }
+        });
+    }
+
+    /** On the io worker: drop the submission when it is already stored
+     *  unchanged; otherwise marshal the save prompt to the EDT. */
+    private void maybePrompt(String origin, String user, String pass) {
+        if (disposed || !enabled) return;
+        if (isAlreadyStored(origin, user, pass)) return; // unchanged: no prompt
         SwingUtilities.invokeLater(new Runnable() {
             @Override public void run() { runPrompt(origin, user, pass); }
         });
+    }
+
+    /** @return whether an identical {@code {origin, username, password}}
+     *  credential is already stored. Compares username AND password
+     *  explicitly, since {@link WebViewCredential#equals} ignores the
+     *  password. Fails open (returns {@code false}) if the store read
+     *  throws, so a save is still offered on a transient store error. */
+    private boolean isAlreadyStored(String origin, String user, String pass) {
+        try {
+            for (WebViewCredential c : store.findAll(origin)) {
+                if (c.username().equals(user) && c.password().equals(pass)) {
+                    return true;
+                }
+            }
+        } catch (Throwable t) {
+            forward(t);
+        }
+        return false;
     }
 
     /** The page requested autofill; {@code frameUrl} is the native-stamped

--- a/src/ca/weblite/webview/PasswordDispatcher.java
+++ b/src/ca/weblite/webview/PasswordDispatcher.java
@@ -21,11 +21,12 @@ import javax.swing.SwingUtilities;
  * Drive the password manager via
  * {@link WebViewComponent#setPasswordManagerEnabled},
  * {@link WebViewComponent#setCredentialStore},
- * {@link WebViewComponent#setSavePasswordHandler}, and the
- * {@code getCredential}/{@code saveCredential}/{@code deleteCredential}
- * methods.  This class is {@code public} only because the consuming
- * Swing subclasses live in a different package — the same reason
- * {@link DialogDispatcher} is public.
+ * {@link WebViewComponent#setSavePasswordHandler},
+ * {@link WebViewComponent#setFillPasswordHandler}, and the
+ * {@code getCredential}/{@code getAllCredentials}/{@code saveCredential}/
+ * {@code deleteCredential} methods.  This class is {@code public} only
+ * because the consuming Swing subclasses live in a different package —
+ * the same reason {@link DialogDispatcher} is public.
  *
  * <p>Per-component hub for the password manager.  Holds the active
  * {@link WebViewCredentialStore}, the {@link WebViewSavePasswordHandler},
@@ -102,6 +103,8 @@ public final class PasswordDispatcher {
     private volatile WebViewCredentialStore store = new NativeCredentialStore();
     private volatile WebViewSavePasswordHandler handler =
         WebViewSavePasswordHandler.DEFAULT;
+    private volatile WebViewFillPasswordHandler fillHandler =
+        WebViewFillPasswordHandler.DEFAULT;
     private volatile boolean enabled = true;
     private volatile boolean disposed = false;
     private final ExecutorService io = Executors.newSingleThreadExecutor(
@@ -141,6 +144,15 @@ public final class PasswordDispatcher {
     /** @return the active save-policy; never {@code null}. */
     public WebViewSavePasswordHandler getHandler() { return handler; }
 
+    /** Replace the autofill-consent policy; {@code null} restores
+     *  {@link WebViewFillPasswordHandler#DEFAULT}. */
+    public void setFillHandler(WebViewFillPasswordHandler h) {
+        fillHandler = (h == null) ? WebViewFillPasswordHandler.DEFAULT : h;
+    }
+
+    /** @return the active autofill-consent policy; never {@code null}. */
+    public WebViewFillPasswordHandler getFillHandler() { return fillHandler; }
+
     // ---- programmatic API (synchronous on the caller thread) -----------
 
     public void saveCredential(WebViewCredential c) {
@@ -154,6 +166,10 @@ public final class PasswordDispatcher {
 
     public List<WebViewCredential> getCredentials(String origin) {
         return store.findAll(origin);
+    }
+
+    public List<WebViewCredential> getAllCredentials() {
+        return store.findAll();
     }
 
     public boolean deleteCredential(String origin, String username) {
@@ -232,7 +248,27 @@ public final class PasswordDispatcher {
             return;
         }
         if (c == null || !c.isPresent()) return;
-        WebViewCredential cred = c.get();
+        final WebViewCredential cred = c.get();
+        // Marshal the consent decision (and the fire-and-forget eval) to
+        // the EDT.  The keychain read above already ran off the EDT; only
+        // the host-controlled fill policy and the eval run here.
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override public void run() { fillOnEdt(origin, cred); }
+        });
+    }
+
+    private void fillOnEdt(String origin, WebViewCredential cred) {
+        if (disposed || !enabled) return;
+        FillPasswordDisposition d;
+        try {
+            WebViewFillPasswordEvent ev =
+                new WebViewFillPasswordEvent(source, origin, cred.username());
+            d = fillHandler.onAutofillRequested(ev);
+        } catch (Throwable t) {
+            forward(t); // handler threw: fill nothing, stay responsive
+            return;
+        }
+        if (d != FillPasswordDisposition.FILL) return; // DONT_FILL: skip
         String js = "window.__webview_pw_fill__('"
             + base64UrlEncode(cred.username()) + "','"
             + base64UrlEncode(cred.password()) + "')";

--- a/src/ca/weblite/webview/SavePasswordDisposition.java
+++ b/src/ca/weblite/webview/SavePasswordDisposition.java
@@ -1,0 +1,17 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+/**
+ * The decision a {@link WebViewSavePasswordHandler} returns for a
+ * captured login submission.
+ */
+public enum SavePasswordDisposition {
+    /** Store the captured credential in the active credential store. */
+    SAVE,
+    /** Discard the captured credential; store nothing. */
+    DONT_SAVE
+}

--- a/src/ca/weblite/webview/WebViewCredential.java
+++ b/src/ca/weblite/webview/WebViewCredential.java
@@ -1,0 +1,74 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+/**
+ * Immutable {@code {origin, username, password}} credential handled by
+ * the WebView password manager.
+ *
+ * <p>Equality and hashing are on {@code {origin, username}} only — the
+ * password is excluded, so re-saving a new password for the same
+ * {@code {origin, username}} is treated as the same logical credential
+ * (an overwrite, not a duplicate).
+ *
+ * <p>The {@code origin} is stored verbatim as supplied; canonicalisation
+ * (dropping the default port, lower-casing) happens at the store
+ * boundary, so callers may construct a credential with any origin string
+ * and the store normalises it consistently.
+ *
+ * <p>{@link #toString()} never emits the password.
+ */
+public final class WebViewCredential {
+
+    private final String origin;
+    private final String username;
+    private final String password;
+
+    /**
+     * @param origin   the page origin the credential belongs to
+     *                 (scheme+host+port); never {@code null}
+     * @param username the username; never {@code null} (may be empty for
+     *                 password-only forms)
+     * @param password the password; never {@code null}
+     */
+    public WebViewCredential(String origin, String username, String password) {
+        if (origin == null) throw new NullPointerException("origin");
+        if (username == null) throw new NullPointerException("username");
+        if (password == null) throw new NullPointerException("password");
+        this.origin = origin;
+        this.username = username;
+        this.password = password;
+    }
+
+    /** @return the page origin (scheme+host+port). */
+    public String origin() { return origin; }
+
+    /** @return the username. */
+    public String username() { return username; }
+
+    /** @return the password. */
+    public String password() { return password; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof WebViewCredential)) return false;
+        WebViewCredential that = (WebViewCredential) o;
+        return origin.equals(that.origin) && username.equals(that.username);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * origin.hashCode() + username.hashCode();
+    }
+
+    /** @return a debug string that <strong>redacts the password</strong>. */
+    @Override
+    public String toString() {
+        return "WebViewCredential[origin=" + origin
+            + ", username=" + username + ", password=***]";
+    }
+}

--- a/src/ca/weblite/webview/WebViewCredentialStore.java
+++ b/src/ca/weblite/webview/WebViewCredentialStore.java
@@ -1,0 +1,52 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Storage seam for WebView credentials.  The default implementation,
+ * {@link NativeCredentialStore}, is backed by the OS-native secret store
+ * (macOS Keychain, Linux libsecret, Windows Credential Manager).  A host
+ * may install a different implementation — for example
+ * {@link InMemoryCredentialStore} for tests — via
+ * {@link ca.weblite.webview.swing.WebViewComponent#setCredentialStore}.
+ *
+ * <p>Implementations must be safe to call from any thread and must not
+ * throw when the backing store is unavailable — they degrade to
+ * "no result" ({@code find}/{@code findAll} empty, {@code save}/
+ * {@code delete} a no-op) rather than propagating an exception.
+ */
+public interface WebViewCredentialStore {
+
+    /**
+     * Insert or overwrite the credential for its {@code {origin,
+     * username}}.  A previously stored password for the same
+     * {@code {origin, username}} is replaced.
+     */
+    void save(WebViewCredential credential);
+
+    /**
+     * @return the most-recently-saved credential for {@code origin}, or
+     *         empty if none is stored.
+     */
+    Optional<WebViewCredential> find(String origin);
+
+    /**
+     * @return every credential stored for {@code origin},
+     *         most-recently-saved first, as an unmodifiable list (empty
+     *         when none).
+     */
+    List<WebViewCredential> findAll(String origin);
+
+    /**
+     * Remove the credential for {@code {origin, username}}.
+     *
+     * @return whether a credential was actually removed.
+     */
+    boolean delete(String origin, String username);
+}

--- a/src/ca/weblite/webview/WebViewCredentialStore.java
+++ b/src/ca/weblite/webview/WebViewCredentialStore.java
@@ -44,6 +44,18 @@ public interface WebViewCredentialStore {
     List<WebViewCredential> findAll(String origin);
 
     /**
+     * Enumerate every credential this store holds, across all origins,
+     * most-recently-saved first, as an unmodifiable list (empty when none
+     * or when the backing store is unavailable).
+     *
+     * <p>This is the primitive a host needs to build a "manage saved
+     * passwords" UI over the store. Like the origin-scoped reads it
+     * returns full credentials (origin + username + password) to the
+     * calling host code only; it is never reachable from page JavaScript.
+     */
+    List<WebViewCredential> findAll();
+
+    /**
      * Remove the credential for {@code {origin, username}}.
      *
      * @return whether a credential was actually removed.

--- a/src/ca/weblite/webview/WebViewFillPasswordEvent.java
+++ b/src/ca/weblite/webview/WebViewFillPasswordEvent.java
@@ -1,0 +1,54 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import ca.weblite.webview.swing.WebViewComponent;
+
+/**
+ * Immutable event describing an imminent autofill, handed to the
+ * {@link WebViewFillPasswordHandler} to decide whether the stored
+ * credential should be injected into the page.
+ *
+ * <p>The {@code origin} is the canonical scheme+host+port derived
+ * natively from the committed frame URL — never a value supplied by page
+ * JavaScript.
+ *
+ * <p><strong>This event deliberately carries no password.</strong> The
+ * autofill-consent decision needs only the identity being filled
+ * (origin + username), so the secret is never exposed to host consent
+ * code — including a handler that performs an OS biometric /
+ * re-authentication check.
+ */
+public final class WebViewFillPasswordEvent {
+
+    private final WebViewComponent source;
+    private final String origin;
+    private final String username;
+
+    WebViewFillPasswordEvent(WebViewComponent source, String origin,
+                             String username) {
+        if (source == null) throw new NullPointerException("source");
+        this.source = source;
+        this.origin = origin == null ? "" : origin;
+        this.username = username == null ? "" : username;
+    }
+
+    /** @return the component whose page is about to be autofilled. */
+    public WebViewComponent source() { return source; }
+
+    /** @return the canonical origin (scheme+host+port) being filled. */
+    public String origin() { return origin; }
+
+    /** @return the username of the credential being filled (may be empty). */
+    public String username() { return username; }
+
+    /** @return a debug string; there is no password to redact. */
+    @Override
+    public String toString() {
+        return "WebViewFillPasswordEvent[origin=" + origin
+            + ", username=" + username + "]";
+    }
+}

--- a/src/ca/weblite/webview/WebViewFillPasswordHandler.java
+++ b/src/ca/weblite/webview/WebViewFillPasswordHandler.java
@@ -1,0 +1,86 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import java.awt.Window;
+import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
+
+/**
+ * Policy that decides whether the password manager should autofill a
+ * stored credential on page load.  Install one via
+ * {@link ca.weblite.webview.swing.WebViewComponent#setFillPasswordHandler}.
+ *
+ * <p>{@link #onAutofillRequested} is invoked on the Swing Event Dispatch
+ * Thread, after an origin-matched credential has been found (the store
+ * read already happened off the EDT).  It is consulted <strong>only</strong>
+ * on the automatic page-load autofill path — the programmatic read API
+ * ({@code getCredential} / {@code getCredentials} / {@code getAllCredentials})
+ * is trusted host code and is never gated by this handler.
+ *
+ * <p>The {@link #DEFAULT} handler returns {@link FillPasswordDisposition#FILL}
+ * unconditionally, preserving the library's automatic-autofill behaviour;
+ * this is what a host gets if it installs nothing.  The {@link #CONFIRM}
+ * handler shows a browser-style confirmation before filling.  A host that
+ * needs an OS biometric / re-authentication gate (Touch ID, Windows Hello)
+ * installs its own handler that performs the check and returns
+ * {@link FillPasswordDisposition#DONT_FILL} to decline.
+ *
+ * <p>The method should return promptly and MUST NOT block on
+ * {@code evalAsync(js).get()} or any other EDT-scheduled task — the EDT
+ * is busy running the handler.  Exceptions thrown by the handler are
+ * caught by {@link PasswordDispatcher} and forwarded to
+ * {@link Thread#getDefaultUncaughtExceptionHandler()}; nothing is filled
+ * and the WebView stays responsive.
+ *
+ * <p>The event handed to the handler carries only the origin and username
+ * — never the password.
+ */
+@FunctionalInterface
+public interface WebViewFillPasswordHandler {
+
+    /**
+     * Decide whether {@code event}'s origin-matched credential should be
+     * injected into the page.  Invoked on the EDT.
+     */
+    FillPasswordDisposition onAutofillRequested(WebViewFillPasswordEvent event);
+
+    /**
+     * The default handler: autofill unconditionally
+     * ({@link FillPasswordDisposition#FILL}).  Preserves the library's
+     * shipped silent-autofill behaviour and is the initial handler on
+     * every component.
+     */
+    WebViewFillPasswordHandler DEFAULT = new WebViewFillPasswordHandler() {
+        @Override
+        public FillPasswordDisposition onAutofillRequested(
+                WebViewFillPasswordEvent event) {
+            return FillPasswordDisposition.FILL;
+        }
+    };
+
+    /**
+     * An opt-in handler that shows a Swing "Use saved password?" confirm
+     * dialog, modal to the host window, showing the origin and username
+     * (never the password).  OK returns {@link FillPasswordDisposition#FILL};
+     * Cancel/close returns {@link FillPasswordDisposition#DONT_FILL}.
+     */
+    WebViewFillPasswordHandler CONFIRM = new WebViewFillPasswordHandler() {
+        @Override
+        public FillPasswordDisposition onAutofillRequested(
+                WebViewFillPasswordEvent event) {
+            Window host = SwingUtilities.getWindowAncestor(event.source());
+            String msg = "Use the saved password for " + event.origin() + "?\n\n"
+                + "Username: " + event.username();
+            int r = JOptionPane.showConfirmDialog(host, msg,
+                "Use saved password?", JOptionPane.OK_CANCEL_OPTION,
+                JOptionPane.QUESTION_MESSAGE);
+            return r == JOptionPane.OK_OPTION
+                ? FillPasswordDisposition.FILL
+                : FillPasswordDisposition.DONT_FILL;
+        }
+    };
+}

--- a/src/ca/weblite/webview/WebViewNative.java
+++ b/src/ca/weblite/webview/WebViewNative.java
@@ -589,6 +589,11 @@ native static boolean webview_cred_store_save(String service, String origin,
 // (Java re-sorts regardless).  Empty array when none / unavailable.
 native static String[] webview_cred_store_find(String service, String origin);
 
+// Return every credential under {service} across all origins as flat quads
+// [origin, username, savedAtMillisString, password, ...] (Java re-sorts).
+// Empty array when none / unavailable.  Backs enumerate-all (getAllCredentials).
+native static String[] webview_cred_store_find_all(String service);
+
 // Remove the credential for {service, origin, username}.  Returns whether a
 // credential was actually removed.
 native static boolean webview_cred_store_delete(String service, String origin,

--- a/src/ca/weblite/webview/WebViewNative.java
+++ b/src/ca/weblite/webview/WebViewNative.java
@@ -284,6 +284,24 @@ native static void webview_embed_set_attach_callback(long w, Object cb);
 native static void webview_embed_set_dialog_callback(long w, WebViewDialogCallback cb);
 
 // Register (or clear, by passing null) a callback invoked when the
+// embedded page's injected password-manager script reports a login
+// submission or requests autofill.  The callback's frameUrl argument is
+// the committed frame URL read natively from the engine (the trusted
+// origin source); the username/password are base64url strings decoded in
+// Java.  The callback methods are void (non-blocking): the library
+// marshals the save prompt to the EDT via invokeLater and runs store I/O
+// on a worker.  Per-platform delivery:
+//   - macOS:   a dedicated WKScriptMessageHandler named "__webview_pw__"
+//              on the WKUserContentController (Canvas 23).
+//   - Linux:   script-message-received::__webview_pw__ on the
+//              WebKitUserContentManager (Canvas 24).
+//   - Windows: the __webview_pw__: branch of the WebView2
+//              WebMessageReceived handler (Canvas 25).
+// cb may be null to clear the registration.  Passing 0 for w is a
+// silent no-op.  Never throws via JNI.
+native static void webview_embed_set_password_callback(long w, WebViewPasswordCallback cb);
+
+// Register (or clear, by passing null) a callback invoked when the
 // embedded page requests a popup (window.open / target=_blank).  The
 // callback's onPopupRequested returns the allow/deny decision
 // synchronously on the native UI thread; onPopupOpened / onPopupClosed
@@ -490,6 +508,12 @@ native static void webview_offscreen_execute_editing_command(long peer, int cmdI
 // engine on those platforms is itself a stub).  Never throws via JNI.
 native static void webview_offscreen_set_dialog_callback(long peer, WebViewDialogCallback cb);
 
+// Offscreen counterpart to webview_embed_set_password_callback.  A native
+// no-op stub on macOS / Windows (offscreen is itself a stub there); Linux
+// lightweight wires the GTK script-message handler in Canvas 24.  cb may
+// be null to clear.  Never throws via JNI.
+native static void webview_offscreen_set_password_callback(long peer, WebViewPasswordCallback cb);
+
 // Offscreen counterpart to webview_embed_set_popup_callback.  Used by
 // WebViewLightweightComponent on Linux to bridge window.open requests in
 // the offscreen engine to the per-component PopupDispatcher.  macOS /
@@ -538,6 +562,41 @@ native static long webview_offscreen_adopt_popup(int width, int height,
 // `peer` is unused (kept for signature symmetry with the heavyweight bridge).
 // Unknown popupId is a silent no-op.  Never throws via JNI.
 native static void webview_offscreen_discard_popup(long peer, long popupId);
+
+
+// ---------------------------------------------------------------------------
+// Process-global credential store (password manager, Canvas 23+).
+//
+// These primitives are NOT tied to a WebView engine — the OS-native secret
+// store is process-global.  `service` is the library namespace constant
+// isolating these items; `origin` is the canonical scheme+host+port key.
+// The stored value blob encodes `savedAtMillis + "\n" + password` so recency
+// ordering is uniform across platforms regardless of native metadata.
+// Per platform: macOS Keychain (SecItem*, Canvas 23); Linux libsecret
+// (Canvas 24); Windows Credential Manager (Canvas 25).  On a platform whose
+// backend is not yet wired, these return false / an empty array (graceful).
+// Never throw via JNI.
+// ---------------------------------------------------------------------------
+
+// Insert or overwrite the credential for {service, origin, username}.
+// Returns whether the write succeeded.
+native static boolean webview_cred_store_save(String service, String origin,
+                                              String username, String password,
+                                              long savedAtMillis);
+
+// Return every credential for {service, origin} as flat triples
+// [username, savedAtMillisString, password, ...], most-recently-saved first
+// (Java re-sorts regardless).  Empty array when none / unavailable.
+native static String[] webview_cred_store_find(String service, String origin);
+
+// Remove the credential for {service, origin, username}.  Returns whether a
+// credential was actually removed.
+native static boolean webview_cred_store_delete(String service, String origin,
+                                                String username);
+
+// Whether the platform secret store is usable (always true on macOS /
+// Windows; meaningful on Linux where the Secret Service may be absent).
+native static boolean webview_cred_store_available();
 
 
 }

--- a/src/ca/weblite/webview/WebViewNative.java
+++ b/src/ca/weblite/webview/WebViewNative.java
@@ -292,11 +292,11 @@ native static void webview_embed_set_dialog_callback(long w, WebViewDialogCallba
 // marshals the save prompt to the EDT via invokeLater and runs store I/O
 // on a worker.  Per-platform delivery:
 //   - macOS:   a dedicated WKScriptMessageHandler named "__webview_pw__"
-//              on the WKUserContentController (Canvas 23).
+//              on the WKUserContentController (Canvas 26).
 //   - Linux:   script-message-received::__webview_pw__ on the
-//              WebKitUserContentManager (Canvas 24).
+//              WebKitUserContentManager (Canvas 27).
 //   - Windows: the __webview_pw__: branch of the WebView2
-//              WebMessageReceived handler (Canvas 25).
+//              WebMessageReceived handler (Canvas 28).
 // cb may be null to clear the registration.  Passing 0 for w is a
 // silent no-op.  Never throws via JNI.
 native static void webview_embed_set_password_callback(long w, WebViewPasswordCallback cb);
@@ -510,7 +510,7 @@ native static void webview_offscreen_set_dialog_callback(long peer, WebViewDialo
 
 // Offscreen counterpart to webview_embed_set_password_callback.  A native
 // no-op stub on macOS / Windows (offscreen is itself a stub there); Linux
-// lightweight wires the GTK script-message handler in Canvas 24.  cb may
+// lightweight wires the GTK script-message handler in Canvas 27.  cb may
 // be null to clear.  Never throws via JNI.
 native static void webview_offscreen_set_password_callback(long peer, WebViewPasswordCallback cb);
 
@@ -565,15 +565,15 @@ native static void webview_offscreen_discard_popup(long peer, long popupId);
 
 
 // ---------------------------------------------------------------------------
-// Process-global credential store (password manager, Canvas 23+).
+// Process-global credential store (password manager, Canvas 26+).
 //
 // These primitives are NOT tied to a WebView engine — the OS-native secret
 // store is process-global.  `service` is the library namespace constant
 // isolating these items; `origin` is the canonical scheme+host+port key.
 // The stored value blob encodes `savedAtMillis + "\n" + password` so recency
 // ordering is uniform across platforms regardless of native metadata.
-// Per platform: macOS Keychain (SecItem*, Canvas 23); Linux libsecret
-// (Canvas 24); Windows Credential Manager (Canvas 25).  On a platform whose
+// Per platform: macOS Keychain (SecItem*, Canvas 26); Linux libsecret
+// (Canvas 27); Windows Credential Manager (Canvas 28).  On a platform whose
 // backend is not yet wired, these return false / an empty array (graceful).
 // Never throw via JNI.
 // ---------------------------------------------------------------------------

--- a/src/ca/weblite/webview/WebViewPasswordCallback.java
+++ b/src/ca/weblite/webview/WebViewPasswordCallback.java
@@ -1,0 +1,55 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+/**
+ * Internal JNI bridge interface invoked by the native engine when the
+ * password manager's injected script reports a login submission or
+ * requests autofill for the current page.
+ *
+ * <p><strong>Not part of the public application API.</strong>
+ * Application code drives the password manager via
+ * {@link ca.weblite.webview.swing.WebViewComponent} (enable/disable,
+ * store, save-handler, get/save/delete).  This interface is
+ * {@code public} only because the JNI bridge in
+ * {@code src_c/webview_embed.cpp} and {@code windows/webview_embed.cc}
+ * calls methods on instances of it, and Java has no
+ * cross-package-but-non-public access modifier — the same constraint as
+ * {@link WebViewDialogCallback}.
+ *
+ * <p><strong>Trusted origin.</strong>  {@code frameUrl} is the committed
+ * URL of the frame that raised the message, read natively from the
+ * engine — it is the only trusted origin source and is never a value
+ * supplied by page JavaScript.  The username / password are base64url
+ * strings; the library decodes them in Java (native stays free of
+ * base64 code).
+ *
+ * <p><strong>Threading.</strong>  Invoked from the native message thread
+ * (AppKit main on macOS, the GTK main thread on Linux, the WebView2
+ * worker thread on Windows).  The library-provided implementation
+ * delegates to {@link PasswordDispatcher}, which marshals the save
+ * prompt to the EDT and runs store I/O on a worker — it never blocks the
+ * native thread.
+ */
+public interface WebViewPasswordCallback {
+
+    /**
+     * A login form was submitted.
+     *
+     * @param frameUrl    the committed frame URL (trusted origin source)
+     * @param b64Username base64url-encoded username (may decode to empty)
+     * @param b64Password base64url-encoded password
+     */
+    void onLoginSubmitted(String frameUrl, String b64Username,
+                          String b64Password);
+
+    /**
+     * The page is ready with a login form and is requesting autofill.
+     *
+     * @param frameUrl the committed frame URL (trusted origin source)
+     */
+    void onFillRequested(String frameUrl);
+}

--- a/src/ca/weblite/webview/WebViewSavePasswordEvent.java
+++ b/src/ca/weblite/webview/WebViewSavePasswordEvent.java
@@ -1,0 +1,55 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import ca.weblite.webview.swing.WebViewComponent;
+
+/**
+ * Immutable event describing a login submission the password manager
+ * captured inside the embedded page, handed to the
+ * {@link WebViewSavePasswordHandler} to decide whether to save it.
+ *
+ * <p>The {@code origin} is the canonical scheme+host+port derived
+ * natively from the committed frame URL — never a value supplied by page
+ * JavaScript.
+ *
+ * <p>{@link #toString()} never emits the password.
+ */
+public final class WebViewSavePasswordEvent {
+
+    private final WebViewComponent source;
+    private final String origin;
+    private final String username;
+    private final String password;
+
+    WebViewSavePasswordEvent(WebViewComponent source, String origin,
+                             String username, String password) {
+        if (source == null) throw new NullPointerException("source");
+        this.source = source;
+        this.origin = origin == null ? "" : origin;
+        this.username = username == null ? "" : username;
+        this.password = password == null ? "" : password;
+    }
+
+    /** @return the component whose page raised the submission. */
+    public WebViewComponent source() { return source; }
+
+    /** @return the canonical origin (scheme+host+port) of the submission. */
+    public String origin() { return origin; }
+
+    /** @return the captured username (may be empty). */
+    public String username() { return username; }
+
+    /** @return the captured password. */
+    public String password() { return password; }
+
+    /** @return a debug string that <strong>redacts the password</strong>. */
+    @Override
+    public String toString() {
+        return "WebViewSavePasswordEvent[origin=" + origin
+            + ", username=" + username + ", password=***]";
+    }
+}

--- a/src/ca/weblite/webview/WebViewSavePasswordHandler.java
+++ b/src/ca/weblite/webview/WebViewSavePasswordHandler.java
@@ -1,0 +1,62 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import java.awt.Window;
+import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
+
+/**
+ * Policy that decides whether a captured login submission should be
+ * saved.  Install one via
+ * {@link ca.weblite.webview.swing.WebViewComponent#setSavePasswordHandler}.
+ *
+ * <p>{@link #onLoginSubmitted} is invoked on the Swing Event Dispatch
+ * Thread.  The {@link #DEFAULT} handler shows a browser-style
+ * "Save password?" confirm dialog modal to the host window; a custom
+ * handler may decide programmatically (return a disposition without
+ * showing UI) — this is what unit tests and headless environments use.
+ *
+ * <p>The method should return promptly and MUST NOT block on
+ * {@code evalAsync(js).get()} or any other EDT-scheduled task — the EDT
+ * is busy running the handler.  Exceptions thrown by the handler are
+ * caught by {@link PasswordDispatcher} and forwarded to
+ * {@link Thread#getDefaultUncaughtExceptionHandler()}; nothing is stored
+ * and the WebView stays responsive.
+ *
+ * <p>This iteration wires the capture on macOS; Linux and Windows
+ * coverage arrive in the follow-up canvases.
+ */
+@FunctionalInterface
+public interface WebViewSavePasswordHandler {
+
+    /**
+     * Decide whether {@code event}'s captured credential should be saved.
+     * Invoked on the EDT.
+     */
+    SavePasswordDisposition onLoginSubmitted(WebViewSavePasswordEvent event);
+
+    /**
+     * The default handler: a Swing "Save password?" confirm dialog,
+     * modal to the host window, showing the origin and username (never
+     * the password).  OK returns {@link SavePasswordDisposition#SAVE};
+     * Cancel/close returns {@link SavePasswordDisposition#DONT_SAVE}.
+     */
+    WebViewSavePasswordHandler DEFAULT = new WebViewSavePasswordHandler() {
+        @Override
+        public SavePasswordDisposition onLoginSubmitted(
+                WebViewSavePasswordEvent event) {
+            Window host = SwingUtilities.getWindowAncestor(event.source());
+            String msg = "Save the password for " + event.origin() + "?\n\n"
+                + "Username: " + event.username();
+            int r = JOptionPane.showConfirmDialog(host, msg, "Save password?",
+                JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
+            return r == JOptionPane.OK_OPTION
+                ? SavePasswordDisposition.SAVE
+                : SavePasswordDisposition.DONT_SAVE;
+        }
+    };
+}

--- a/src/ca/weblite/webview/swing/WebViewComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewComponent.java
@@ -9,16 +9,22 @@ import ca.weblite.webview.ConsoleDispatcher;
 import ca.weblite.webview.ConsoleListener;
 import ca.weblite.webview.DialogDispatcher;
 import ca.weblite.webview.DownloadDispatcher;
+import ca.weblite.webview.PasswordDispatcher;
 import ca.weblite.webview.PopupDispatcher;
 import ca.weblite.webview.JavaScriptEvalException;
 import ca.weblite.webview.WebView;
+import ca.weblite.webview.WebViewCredential;
+import ca.weblite.webview.WebViewCredentialStore;
 import ca.weblite.webview.WebViewDialogHandler;
 import ca.weblite.webview.WebViewDownloadHandler;
 import ca.weblite.webview.WebViewPopupHandler;
 import ca.weblite.webview.WebViewMouseDispatcher;
 import ca.weblite.webview.WebViewMouseListener;
+import ca.weblite.webview.WebViewSavePasswordHandler;
 
 import java.io.PrintStream;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import javax.swing.JComponent;
@@ -98,6 +104,13 @@ public abstract class WebViewComponent extends JComponent {
      *  native peer at peer-attach time that delegates to this dispatcher's
      *  {@code dispatch*} methods. */
     protected final DownloadDispatcher downloadDispatcher = new DownloadDispatcher(this);
+
+    /** Per-component hub for the password manager (login-submission
+     *  capture + autofill + credential store).  Subclasses inject
+     *  {@link PasswordDispatcher#SHIM_JS} and install a
+     *  {@link ca.weblite.webview.WebViewPasswordCallback} on their native
+     *  peer at peer-attach time that delegates to this dispatcher. */
+    protected final PasswordDispatcher passwordDispatcher = new PasswordDispatcher(this);
 
     /** When non-zero, this component was created via {@link #adoptPopup} and
      *  its peer, at attach time, adopts the pre-existing native popup child
@@ -840,5 +853,102 @@ public abstract class WebViewComponent extends JComponent {
      */
     public final WebViewDownloadHandler getDownloadHandler() {
         return downloadDispatcher.getHandler();
+    }
+
+    // ---------------------------------------------------------------------
+    // Password manager (Canvas 23+).  The manager auto-detects login
+    // submissions and offers to save them, and auto-fills a stored
+    // credential on page load.  Credentials are keyed by page origin
+    // (scheme+host+port) and matched exact-origin only.  Passwords live
+    // only in the OS-native secret store (Keychain on macOS this
+    // iteration; libsecret / Credential Manager to follow).  This
+    // iteration wires the capture/fill on macOS heavyweight; on Linux /
+    // Windows the API works but automatic capture/fill activate in the
+    // follow-up canvases.
+    // ---------------------------------------------------------------------
+
+    /**
+     * Enable or disable the automatic save-prompt and autofill.  Enabled
+     * by default.  When disabled, no prompt appears and no autofill fires,
+     * but the programmatic methods below still work.
+     *
+     * @return {@code this} for chaining
+     */
+    public final WebViewComponent setPasswordManagerEnabled(boolean enabled) {
+        passwordDispatcher.setEnabled(enabled);
+        return this;
+    }
+
+    /** @return whether the automatic password manager is enabled. */
+    public final boolean isPasswordManagerEnabled() {
+        return passwordDispatcher.isEnabled();
+    }
+
+    /**
+     * Replace the credential store.  Passing {@code null} reinstalls the
+     * default {@link ca.weblite.webview.NativeCredentialStore} (the OS
+     * secret store).
+     *
+     * @return {@code this} for chaining
+     */
+    public final WebViewComponent setCredentialStore(WebViewCredentialStore store) {
+        passwordDispatcher.setStore(store);
+        return this;
+    }
+
+    /** @return the active credential store; never {@code null}. */
+    public final WebViewCredentialStore getCredentialStore() {
+        return passwordDispatcher.getStore();
+    }
+
+    /**
+     * Replace the save-password policy.  Passing {@code null} reinstalls
+     * the default {@link WebViewSavePasswordHandler#DEFAULT} (the Swing
+     * "Save password?" prompt).
+     *
+     * @return {@code this} for chaining
+     */
+    public final WebViewComponent setSavePasswordHandler(WebViewSavePasswordHandler handler) {
+        passwordDispatcher.setHandler(handler);
+        return this;
+    }
+
+    /** @return the active save-password policy; never {@code null}. */
+    public final WebViewSavePasswordHandler getSavePasswordHandler() {
+        return passwordDispatcher.getHandler();
+    }
+
+    /**
+     * Programmatically store a credential (bypasses the save prompt).
+     * Overwrites any existing password for the same {@code {origin,
+     * username}}.
+     */
+    public final void saveCredential(WebViewCredential credential) {
+        passwordDispatcher.saveCredential(credential);
+    }
+
+    /**
+     * @return the most-recently-saved credential for {@code origin}, or
+     *         empty if none is stored.
+     */
+    public final Optional<WebViewCredential> getCredential(String origin) {
+        return passwordDispatcher.getCredential(origin);
+    }
+
+    /**
+     * @return every credential stored for {@code origin},
+     *         most-recently-saved first (empty when none).
+     */
+    public final List<WebViewCredential> getCredentials(String origin) {
+        return passwordDispatcher.getCredentials(origin);
+    }
+
+    /**
+     * Delete the stored credential for {@code {origin, username}}.
+     *
+     * @return whether a credential was actually removed
+     */
+    public final boolean deleteCredential(String origin, String username) {
+        return passwordDispatcher.deleteCredential(origin, username);
     }
 }

--- a/src/ca/weblite/webview/swing/WebViewComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewComponent.java
@@ -856,7 +856,7 @@ public abstract class WebViewComponent extends JComponent {
     }
 
     // ---------------------------------------------------------------------
-    // Password manager (Canvas 23+).  The manager auto-detects login
+    // Password manager (Canvas 26+).  The manager auto-detects login
     // submissions and offers to save them, and auto-fills a stored
     // credential on page load.  Credentials are keyed by page origin
     // (scheme+host+port) and matched exact-origin only.  Passwords live

--- a/src/ca/weblite/webview/swing/WebViewComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewComponent.java
@@ -17,6 +17,7 @@ import ca.weblite.webview.WebViewCredential;
 import ca.weblite.webview.WebViewCredentialStore;
 import ca.weblite.webview.WebViewDialogHandler;
 import ca.weblite.webview.WebViewDownloadHandler;
+import ca.weblite.webview.WebViewFillPasswordHandler;
 import ca.weblite.webview.WebViewPopupHandler;
 import ca.weblite.webview.WebViewMouseDispatcher;
 import ca.weblite.webview.WebViewMouseListener;
@@ -919,6 +920,28 @@ public abstract class WebViewComponent extends JComponent {
     }
 
     /**
+     * Replace the autofill-consent policy.  Passing {@code null} reinstalls
+     * the default {@link WebViewFillPasswordHandler#DEFAULT} (autofill
+     * unconditionally).  Install {@link WebViewFillPasswordHandler#CONFIRM}
+     * for a browser-style "use saved password?" confirmation, or a custom
+     * handler that performs an OS biometric / re-authentication check
+     * before autofill.  The handler is consulted only on the automatic
+     * page-load autofill path; the programmatic read methods are never
+     * gated by it.
+     *
+     * @return {@code this} for chaining
+     */
+    public final WebViewComponent setFillPasswordHandler(WebViewFillPasswordHandler handler) {
+        passwordDispatcher.setFillHandler(handler);
+        return this;
+    }
+
+    /** @return the active autofill-consent policy; never {@code null}. */
+    public final WebViewFillPasswordHandler getFillPasswordHandler() {
+        return passwordDispatcher.getFillHandler();
+    }
+
+    /**
      * Programmatically store a credential (bypasses the save prompt).
      * Overwrites any existing password for the same {@code {origin,
      * username}}.
@@ -941,6 +964,15 @@ public abstract class WebViewComponent extends JComponent {
      */
     public final List<WebViewCredential> getCredentials(String origin) {
         return passwordDispatcher.getCredentials(origin);
+    }
+
+    /**
+     * @return every credential stored across all origins,
+     *         most-recently-saved first (empty when none). The primitive
+     *         a host uses to build a "manage saved passwords" UI.
+     */
+    public final List<WebViewCredential> getAllCredentials() {
+        return passwordDispatcher.getAllCredentials();
     }
 
     /**

--- a/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
@@ -9,8 +9,10 @@ import ca.weblite.webview.AsyncJavascriptFunction;
 import ca.weblite.webview.ConsoleDispatcher;
 import ca.weblite.webview.EditingCommand;
 import ca.weblite.webview.EmbeddedWebView;
+import ca.weblite.webview.PasswordDispatcher;
 import ca.weblite.webview.PopupDispatcher;
 import ca.weblite.webview.WebViewDownloadCallback;
+import ca.weblite.webview.WebViewPasswordCallback;
 import ca.weblite.webview.JavascriptFunction;
 import ca.weblite.webview.WebView;
 import ca.weblite.webview.WebViewClickCallback;
@@ -245,6 +247,7 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
         dialogDispatcher.disposeAll();
         popupDispatcher.disposeAll();
         downloadDispatcher.disposeAll();
+        passwordDispatcher.disposeAll();
         if (embedded != null) {
             EmbeddedWebView e = embedded;
             embedded = null;
@@ -651,6 +654,25 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
                                          String frameUrl) {
                 return dialogDispatcher.dispatchFilePicker(
                     multiple, mimeTypes, extensions, pageUrl, frameUrl);
+            }
+        });
+        // Install the password-manager bridge: inject the shared
+        // detection/fill script at document-start and route its native
+        // login-submission / fill-request messages to the per-component
+        // PasswordDispatcher.  The frameUrl arg is the native-stamped
+        // trusted origin.  Anchored in EmbeddedWebView.heap by
+        // setPasswordCallback so the JVM does not collect the lambda while
+        // the native side holds a global ref.
+        embedded.addOnBeforeLoad(PasswordDispatcher.SHIM_JS);
+        embedded.setPasswordCallback(new WebViewPasswordCallback() {
+            @Override
+            public void onLoginSubmitted(String frameUrl, String b64User,
+                                         String b64Pass) {
+                passwordDispatcher.dispatchLoginSubmitted(frameUrl, b64User, b64Pass);
+            }
+            @Override
+            public void onFillRequested(String frameUrl) {
+                passwordDispatcher.dispatchFillRequested(frameUrl);
             }
         });
         // Install the popup bridge so window.open / target=_blank route to

--- a/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
@@ -11,8 +11,10 @@ import ca.weblite.webview.EditingCommand;
 import ca.weblite.webview.GdkInput;
 import ca.weblite.webview.JavascriptFunction;
 import ca.weblite.webview.OffscreenWebView;
+import ca.weblite.webview.PasswordDispatcher;
 import ca.weblite.webview.PopupDispatcher;
 import ca.weblite.webview.WebViewDownloadCallback;
+import ca.weblite.webview.WebViewPasswordCallback;
 import ca.weblite.webview.WebView;
 import ca.weblite.webview.WebViewDialogCallback;
 import ca.weblite.webview.WebViewPopupCallback;
@@ -319,6 +321,24 @@ public class WebViewLightweightComponent extends WebViewComponent {
                     multiple, mimeTypes, extensions, pageUrl, frameUrl);
             }
         });
+        // Install the password-manager bridge: inject the shared
+        // detection/fill script and route native login-submission /
+        // fill-request messages to the PasswordDispatcher.  Canvas 24 wires
+        // the native WebKitGTK __webview_pw__ script-message handler on the
+        // offscreen engine; until then this setPasswordCallback call is a
+        // native-side no-op.
+        engine.addOnBeforeLoad(PasswordDispatcher.SHIM_JS);
+        engine.setPasswordCallback(new WebViewPasswordCallback() {
+            @Override
+            public void onLoginSubmitted(String frameUrl, String b64User,
+                                         String b64Pass) {
+                passwordDispatcher.dispatchLoginSubmitted(frameUrl, b64User, b64Pass);
+            }
+            @Override
+            public void onFillRequested(String frameUrl) {
+                passwordDispatcher.dispatchFillRequested(frameUrl);
+            }
+        });
         // Install the popup bridge (window.open) on the offscreen engine.
         // Linux dispatches via the WebKitGTK create signal; on macOS /
         // Windows the offscreen engine is a stub and this call is a
@@ -464,6 +484,7 @@ public class WebViewLightweightComponent extends WebViewComponent {
         dialogDispatcher.disposeAll();
         popupDispatcher.disposeAll();
         downloadDispatcher.disposeAll();
+        passwordDispatcher.disposeAll();
         if (engine != null) {
             OffscreenWebView ow = engine;
             engine = null;

--- a/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
@@ -323,7 +323,7 @@ public class WebViewLightweightComponent extends WebViewComponent {
         });
         // Install the password-manager bridge: inject the shared
         // detection/fill script and route native login-submission /
-        // fill-request messages to the PasswordDispatcher.  Canvas 24 wires
+        // fill-request messages to the PasswordDispatcher.  Canvas 27 wires
         // the native WebKitGTK __webview_pw__ script-message handler on the
         // offscreen engine; until then this setPasswordCallback call is a
         // native-side no-op.

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -1549,6 +1549,119 @@ static void engine_on_message(Engine *e, const char *msg) {
     if (detach) e->jvm->DetachCurrentThread();
 }
 
+// Password-manager fire helpers (Canvas 27).  Linux copies of the macOS
+// helpers (which live inside the WEBVIEW_COCOA block); identical JNI
+// mechanics -- per-call GetMethodID, ExceptionCheck/Clear, attach/detach
+// symmetry, null-callback short-circuit.  Only one platform is compiled per
+// build, so there is no duplicate-symbol conflict with the Cocoa copies.
+static void fire_password_submitted(JavaVM *jvm, jobject callback,
+                                    const char *frameUrl,
+                                    const char *b64User,
+                                    const char *b64Pass) {
+    if (!jvm || !callback) return;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return;
+        detach = true;
+    }
+    if (!env) { if (detach) jvm->DetachCurrentThread(); return; }
+    jstring jurl = env->NewStringUTF(frameUrl ? frameUrl : "");
+    jstring juser = env->NewStringUTF(b64User ? b64User : "");
+    jstring jpass = env->NewStringUTF(b64Pass ? b64Pass : "");
+    jclass cls = env->GetObjectClass(callback);
+    if (cls) {
+        jmethodID m = env->GetMethodID(
+            cls, "onLoginSubmitted",
+            "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+        if (m) {
+            env->CallVoidMethod(callback, m, jurl, juser, jpass);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (jurl) env->DeleteLocalRef(jurl);
+    if (juser) env->DeleteLocalRef(juser);
+    if (jpass) env->DeleteLocalRef(jpass);
+    if (detach) jvm->DetachCurrentThread();
+}
+
+static void fire_password_fill_requested(JavaVM *jvm, jobject callback,
+                                         const char *frameUrl) {
+    if (!jvm || !callback) return;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return;
+        detach = true;
+    }
+    if (!env) { if (detach) jvm->DetachCurrentThread(); return; }
+    jstring jurl = env->NewStringUTF(frameUrl ? frameUrl : "");
+    jclass cls = env->GetObjectClass(callback);
+    if (cls) {
+        jmethodID m = env->GetMethodID(cls, "onFillRequested",
+                                       "(Ljava/lang/String;)V");
+        if (m) {
+            env->CallVoidMethod(callback, m, jurl);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (jurl) env->DeleteLocalRef(jurl);
+    if (detach) jvm->DetachCurrentThread();
+}
+
+// Parse a "__webview_pw__" payload from `js` and fire the matching callback.
+// Templated over the engine type so the heavyweight Engine and the
+// lightweight OffEngine (both carry web / jvm / password_callback) share one
+// code path.  The origin is stamped natively from webkit_web_view_get_uri,
+// never from the JS payload (anti-cross-origin invariant).
+template <typename E>
+static void gtk_handle_pw_message(E *e, const char *js) {
+    if (!e || !e->password_callback || !js) return;
+    const gchar *uri = webkit_web_view_get_uri(WEBKIT_WEB_VIEW(e->web));
+    std::string frameUrl = uri ? uri : "";
+    std::string payload = js;
+    if (payload.empty()) return;
+    if (payload[0] == 'F') {
+        fire_password_fill_requested(e->jvm, e->password_callback,
+                                     frameUrl.c_str());
+        return;
+    }
+    if (payload.size() >= 2 && payload[0] == 'S' && payload[1] == '|') {
+        size_t p1 = 2;
+        size_t p2 = payload.find('|', p1);
+        std::string b64user = (p2 == std::string::npos)
+            ? payload.substr(p1) : payload.substr(p1, p2 - p1);
+        std::string b64pass = (p2 == std::string::npos)
+            ? std::string() : payload.substr(p2 + 1);
+        fire_password_submitted(e->jvm, e->password_callback,
+                                frameUrl.c_str(), b64user.c_str(),
+                                b64pass.c_str());
+    }
+}
+
+// Register (or clear) the Java WebViewPasswordCallback for an engine
+// (Canvas 27).  Templated over Engine / OffEngine; mirrors
+// gtk_set_dialog_callback.
+template <typename E>
+static void gtk_set_password_callback_impl(E *e, JNIEnv *env, jobject cb) {
+    if (!e) return;
+    if (e->password_callback) {
+        env->DeleteGlobalRef(e->password_callback);
+        e->password_callback = nullptr;
+    }
+    if (cb) e->password_callback = env->NewGlobalRef(cb);
+}
+
 // Build a heavyweight engine embedded in `component`'s realized X11 surface.
 // Canvas 19: when `existing_web` is non-null (the popup-adoption path) the
 // engine REUSES that already-created WebKitWebView instead of allocating a
@@ -1738,6 +1851,22 @@ static Engine *gtk_create_engine(JNIEnv *env, jobject component, jint debug,
             e);
         webkit_user_content_manager_register_script_message_handler(
             e->manager, "external");
+        // Wire the "__webview_pw__" password-manager channel (Canvas 27):
+        // PasswordDispatcher.SHIM_JS (injected by the Java layer) posts to
+        // it; the handler stamps the origin natively and fires the callback.
+        g_signal_connect(
+            e->manager, "script-message-received::__webview_pw__",
+            G_CALLBACK(+[](WebKitUserContentManager *m,
+                           WebKitJavascriptResult *r, gpointer arg) {
+                auto *eng = static_cast<Engine *>(arg);
+                JSCValue *v = webkit_javascript_result_get_js_value(r);
+                char *s = jsc_value_to_string(v);
+                gtk_handle_pw_message(eng, s);
+                g_free(s);
+            }),
+            e);
+        webkit_user_content_manager_register_script_message_handler(
+            e->manager, "__webview_pw__");
         // Install the same external.invoke shim that the existing engine uses.
         webkit_user_content_manager_add_script(
             e->manager,
@@ -1992,6 +2121,18 @@ static void gtk_destroy_engine(Engine *e) {
         }
         if (env) env->DeleteGlobalRef(e->popup_callback);
         e->popup_callback = nullptr;
+        if (detach) e->jvm->DetachCurrentThread();
+    }
+    // Same treatment for the password-callback global ref (Canvas 27).
+    if (e->password_callback) {
+        JNIEnv *env = nullptr;
+        bool detach = false;
+        if (e->jvm && e->jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+            e->jvm->AttachCurrentThread((void **)&env, nullptr);
+            detach = true;
+        }
+        if (env) env->DeleteGlobalRef(e->password_callback);
+        e->password_callback = nullptr;
         if (detach) e->jvm->DetachCurrentThread();
     }
     // Same treatment for the download-callback global ref, plus the
@@ -2786,6 +2927,12 @@ struct OffEngine {
     // URL; a decline falls back to copying the opener's UA.  Deleted on
     // replacement and on engine destroy.
     jobject ua_resolver = nullptr;
+
+    // JNI global ref to the registered WebViewPasswordCallback, or nullptr
+    // (Canvas 27).  Set by the offscreen password-callback setter; cleared
+    // in gtk_off_destroy_engine.  Invoked by the "__webview_pw__"
+    // script-message handler installed in gtk_off_create_engine.
+    jobject password_callback = nullptr;
 };
 
 // Per-OffEngine wrapper for the `script-dialog` signal.  Reads page URL,
@@ -2917,6 +3064,22 @@ static OffEngine *gtk_off_create_engine(JNIEnv *env,
             e);
         webkit_user_content_manager_register_script_message_handler(
             e->manager, "external");
+
+        // Password-manager channel (Canvas 27) -- same handler as the
+        // heavyweight engine, routed through OffEngine.  Registered once.
+        g_signal_connect(
+            e->manager, "script-message-received::__webview_pw__",
+            G_CALLBACK(+[](WebKitUserContentManager *,
+                           WebKitJavascriptResult *r, gpointer arg) {
+                auto *eng = static_cast<OffEngine *>(arg);
+                JSCValue *v = webkit_javascript_result_get_js_value(r);
+                char *s = jsc_value_to_string(v);
+                gtk_handle_pw_message(eng, s);
+                g_free(s);
+            }),
+            e);
+        webkit_user_content_manager_register_script_message_handler(
+            e->manager, "__webview_pw__");
 
         // Wire JS-initiated dialogs to the per-engine Java DialogDispatcher.
         // Same shape as gtk_create_engine; the offscreen variants of the
@@ -3082,6 +3245,18 @@ static void gtk_off_destroy_engine(OffEngine *e) {
         }
         if (env) env->DeleteGlobalRef(e->popup_callback);
         e->popup_callback = nullptr;
+        if (detach) e->jvm->DetachCurrentThread();
+    }
+    // Same treatment for the password-callback global ref (Canvas 27).
+    if (e->password_callback) {
+        JNIEnv *env = nullptr;
+        bool detach = false;
+        if (e->jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+            e->jvm->AttachCurrentThread((void **)&env, nullptr);
+            detach = true;
+        }
+        if (env) env->DeleteGlobalRef(e->password_callback);
+        e->password_callback = nullptr;
         if (detach) e->jvm->DetachCurrentThread();
     }
     for (auto &kv : e->bindings) {
@@ -7815,16 +7990,22 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set
     if (wv == 0) return;
 #if defined(WEBVIEW_COCOA)
     embed::cocoa_set_password_callback((embed::Engine *)wv, env, cb);
+#elif defined(WEBVIEW_GTK)
+    embed::gtk_set_password_callback_impl((embed::Engine *)wv, env, cb);
 #else
-    // Linux GTK password channel wired in Canvas 27.
     (void)env; (void)cb;
 #endif
 }
 
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1set_1password_1callback
   (JNIEnv *env, jclass, jlong peer, jobject cb) {
-    // Linux lightweight wired in Canvas 27; macOS/Windows offscreen is a stub.
+#if defined(WEBVIEW_GTK)
+    if (peer == 0) return;
+    embed::gtk_set_password_callback_impl((embed::OffEngine *)peer, env, cb);
+#else
+    // No offscreen engine on macOS / Windows.
     (void)peer; (void)env; (void)cb;
+#endif
 }
 
 #if defined(WEBVIEW_COCOA)
@@ -7834,6 +8015,95 @@ static CFStringRef pw_cf(const char *s) {
                                      kCFStringEncodingUTF8);
 }
 #endif
+
+#ifdef WEBVIEW_GTK
+// ---------------------------------------------------------------------------
+// libsecret runtime shim (Canvas 27).
+//
+// libsecret is dlopen'd at first use rather than linked, matching the
+// WebKitGTK runtime-load convention in webkit_loader.cpp -- absence of a
+// Secret Service provider degrades gracefully (available/save/delete return
+// false, find returns empty) and never fails library load.  The SecretSchema
+// is caller-owned by design, so we declare the libsecret ABI locally (its
+// public layout is stable) rather than #include <libsecret/secret.h>.
+// GLib symbols (g_*) are already available via the GTK link; only the
+// secret_* symbols are resolved through dlsym.
+// ---------------------------------------------------------------------------
+typedef enum { WV_SECRET_SCHEMA_NONE = 0 } WvSecretSchemaFlags;
+typedef enum { WV_SECRET_SCHEMA_ATTRIBUTE_STRING = 0 } WvSecretSchemaAttributeType;
+typedef struct { const gchar *name; WvSecretSchemaAttributeType type; }
+    WvSecretSchemaAttribute;
+// Mirrors struct _SecretSchema (name, flags, attributes[32], then 8 private
+// reserved slots).  Layout must match libsecret's header exactly.
+typedef struct {
+    const gchar *name;
+    WvSecretSchemaFlags flags;
+    WvSecretSchemaAttribute attributes[32];
+    gint reserved;
+    gpointer reserved1, reserved2, reserved3, reserved4;
+    gpointer reserved5, reserved6, reserved7;
+} WvSecretSchema;
+
+// SecretSearchFlags bits (SECRET_SEARCH_ALL|UNLOCK|LOAD_SECRETS).
+enum { WV_SECRET_SEARCH_ALL = 1 << 1,
+       WV_SECRET_SEARCH_UNLOCK = 1 << 2,
+       WV_SECRET_SEARCH_LOAD_SECRETS = 1 << 3 };
+
+static const WvSecretSchema WEBVIEW_PW_SCHEMA = {
+    "ca.weblite.webview.passwords",
+    WV_SECRET_SCHEMA_NONE,
+    {
+        { "service",  WV_SECRET_SCHEMA_ATTRIBUTE_STRING },
+        { "origin",   WV_SECRET_SCHEMA_ATTRIBUTE_STRING },
+        { "username", WV_SECRET_SCHEMA_ATTRIBUTE_STRING },
+        { NULL, WV_SECRET_SCHEMA_ATTRIBUTE_STRING }
+    },
+    0, NULL, NULL, NULL, NULL, NULL, NULL, NULL
+};
+
+typedef gboolean (*pw_store_sync_fn)(const WvSecretSchema *, const gchar *,
+    const gchar *, const gchar *, void *, GError **, ...);
+typedef gboolean (*pw_clear_sync_fn)(const WvSecretSchema *, void *,
+    GError **, ...);
+typedef GList *(*pw_search_sync_fn)(const WvSecretSchema *, int, void *,
+    GError **, ...);
+typedef GHashTable *(*pw_get_attrs_fn)(void *);
+typedef void *(*pw_retrieve_secret_sync_fn)(void *, void *, GError **);
+typedef const gchar *(*pw_value_get_text_fn)(void *);
+typedef void (*pw_value_unref_fn)(void *);
+
+static pw_store_sync_fn            p_secret_store_sync = nullptr;
+static pw_clear_sync_fn            p_secret_clear_sync = nullptr;
+static pw_search_sync_fn           p_secret_search_sync = nullptr;
+static pw_get_attrs_fn             p_secret_get_attrs = nullptr;
+static pw_retrieve_secret_sync_fn  p_secret_retrieve_secret_sync = nullptr;
+static pw_value_get_text_fn        p_secret_value_get_text = nullptr;
+static pw_value_unref_fn           p_secret_value_unref = nullptr;
+
+static bool g_secret_ok = false;
+static bool g_secret_tried = false;
+
+// Resolve libsecret once; cache the result.  Any missing symbol ⇒ off.
+static bool ensure_secret() {
+    if (g_secret_tried) return g_secret_ok;
+    g_secret_tried = true;
+    void *h = dlopen("libsecret-1.so.0", RTLD_NOW | RTLD_GLOBAL);
+    if (!h) { g_secret_ok = false; return false; }
+    p_secret_store_sync = (pw_store_sync_fn)dlsym(h, "secret_password_store_sync");
+    p_secret_clear_sync = (pw_clear_sync_fn)dlsym(h, "secret_password_clear_sync");
+    p_secret_search_sync = (pw_search_sync_fn)dlsym(h, "secret_password_search_sync");
+    p_secret_get_attrs = (pw_get_attrs_fn)dlsym(h, "secret_retrievable_get_attributes");
+    p_secret_retrieve_secret_sync = (pw_retrieve_secret_sync_fn)
+        dlsym(h, "secret_retrievable_retrieve_secret_sync");
+    p_secret_value_get_text = (pw_value_get_text_fn)dlsym(h, "secret_value_get_text");
+    p_secret_value_unref = (pw_value_unref_fn)dlsym(h, "secret_value_unref");
+    g_secret_ok = p_secret_store_sync && p_secret_clear_sync
+        && p_secret_search_sync && p_secret_get_attrs
+        && p_secret_retrieve_secret_sync && p_secret_value_get_text
+        && p_secret_value_unref;
+    return g_secret_ok;
+}
+#endif // WEBVIEW_GTK
 
 JNIEXPORT jboolean JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1store_1save
   (JNIEnv *env, jclass, jstring jservice, jstring jorigin, jstring juser,
@@ -7879,6 +8149,34 @@ JNIEXPORT jboolean JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1
     if (user) env->ReleaseStringUTFChars(juser, user);
     if (pass) env->ReleaseStringUTFChars(jpass, pass);
     return ok;
+#elif defined(WEBVIEW_GTK)
+    if (!ensure_secret()) {
+        (void)jservice; (void)jorigin; (void)juser; (void)jpass; (void)millis;
+        return JNI_FALSE;
+    }
+    const char *service = env->GetStringUTFChars(jservice, nullptr);
+    const char *origin = env->GetStringUTFChars(jorigin, nullptr);
+    const char *user = env->GetStringUTFChars(juser, nullptr);
+    const char *pass = env->GetStringUTFChars(jpass, nullptr);
+    // Same value encoding as macOS: "<millis>\n<password>".
+    std::string value = std::to_string((long long)millis) + "\n"
+        + (pass ? pass : "");
+    std::string label = std::string("WebView password for ")
+        + (origin ? origin : "");
+    GError *err = nullptr;
+    gboolean ok = p_secret_store_sync(
+        &WEBVIEW_PW_SCHEMA, "default", label.c_str(), value.c_str(),
+        nullptr, &err,
+        "service", service ? service : "",
+        "origin", origin ? origin : "",
+        "username", user ? user : "",
+        (const char *)nullptr);
+    if (service) env->ReleaseStringUTFChars(jservice, service);
+    if (origin) env->ReleaseStringUTFChars(jorigin, origin);
+    if (user) env->ReleaseStringUTFChars(juser, user);
+    if (pass) env->ReleaseStringUTFChars(jpass, pass);
+    if (err) { g_error_free(err); return JNI_FALSE; }
+    return ok ? JNI_TRUE : JNI_FALSE;
 #else
     (void)env; (void)jservice; (void)jorigin; (void)juser; (void)jpass;
     (void)millis;
@@ -7959,6 +8257,69 @@ JNIEXPORT jobjectArray JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cr
     }
     if (listResult) CFRelease(listResult);
     CFRelease(q1); CFRelease(cfSvc);
+    if (service) env->ReleaseStringUTFChars(jservice, service);
+    if (origin) env->ReleaseStringUTFChars(jorigin, origin);
+    jobjectArray out =
+        env->NewObjectArray((jsize)triples.size(), strCls, nullptr);
+    for (size_t i = 0; i < triples.size(); i++) {
+        jstring js = env->NewStringUTF(triples[i].c_str());
+        env->SetObjectArrayElement(out, (jsize)i, js);
+        env->DeleteLocalRef(js);
+    }
+    return out;
+#elif defined(WEBVIEW_GTK)
+    if (!ensure_secret()) {
+        (void)jservice; (void)jorigin;
+        return env->NewObjectArray(0, strCls, nullptr);
+    }
+    const char *service = env->GetStringUTFChars(jservice, nullptr);
+    const char *origin = env->GetStringUTFChars(jorigin, nullptr);
+    std::vector<std::string> triples;
+    GError *err = nullptr;
+    // Search all items matching {service, origin} (username unbound) with
+    // secrets loaded; libsecret filters by the schema attributes.
+    GList *items = p_secret_search_sync(
+        &WEBVIEW_PW_SCHEMA,
+        WV_SECRET_SEARCH_ALL | WV_SECRET_SEARCH_UNLOCK
+            | WV_SECRET_SEARCH_LOAD_SECRETS,
+        nullptr, &err,
+        "service", service ? service : "",
+        "origin", origin ? origin : "",
+        (const char *)nullptr);
+    if (err) { g_error_free(err); err = nullptr; }
+    for (GList *l = items; l != nullptr; l = l->next) {
+        void *item = l->data;
+        if (!item) continue;
+        std::string username, millisStr = "0", password;
+        GHashTable *attrs = p_secret_get_attrs(item);
+        if (attrs) {
+            const char *uname =
+                (const char *)g_hash_table_lookup(attrs, (gpointer)"username");
+            if (uname) username = uname;
+        }
+        GError *e2 = nullptr;
+        void *val = p_secret_retrieve_secret_sync(item, nullptr, &e2);
+        if (e2) { g_error_free(e2); e2 = nullptr; }
+        if (val) {
+            const char *text = p_secret_value_get_text(val);
+            if (text) {
+                std::string blob(text);
+                size_t nl = blob.find('\n');
+                if (nl != std::string::npos) {
+                    millisStr = blob.substr(0, nl);
+                    password = blob.substr(nl + 1);
+                } else {
+                    password = blob;
+                }
+            }
+            p_secret_value_unref(val);
+        }
+        if (attrs) g_hash_table_unref(attrs);
+        triples.push_back(username);
+        triples.push_back(millisStr);
+        triples.push_back(password);
+    }
+    if (items) g_list_free_full(items, g_object_unref);
     if (service) env->ReleaseStringUTFChars(jservice, service);
     if (origin) env->ReleaseStringUTFChars(jorigin, origin);
     jobjectArray out =
@@ -8073,6 +8434,70 @@ JNIEXPORT jobjectArray JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cr
         env->DeleteLocalRef(js);
     }
     return out;
+#elif defined(WEBVIEW_GTK)
+    if (!ensure_secret()) {
+        (void)jservice;
+        return env->NewObjectArray(0, strCls, nullptr);
+    }
+    const char *service = env->GetStringUTFChars(jservice, nullptr);
+    std::vector<std::string> quads;
+    GError *err = nullptr;
+    // Enumerate every item in our namespace: bind only "service", leaving
+    // origin and username unbound (STORY-006-005).
+    GList *items = p_secret_search_sync(
+        &WEBVIEW_PW_SCHEMA,
+        WV_SECRET_SEARCH_ALL | WV_SECRET_SEARCH_UNLOCK
+            | WV_SECRET_SEARCH_LOAD_SECRETS,
+        nullptr, &err,
+        "service", service ? service : "",
+        (const char *)nullptr);
+    if (err) { g_error_free(err); err = nullptr; }
+    for (GList *l = items; l != nullptr; l = l->next) {
+        void *item = l->data;
+        if (!item) continue;
+        std::string origin, username, millisStr = "0", password;
+        GHashTable *attrs = p_secret_get_attrs(item);
+        if (attrs) {
+            const char *o =
+                (const char *)g_hash_table_lookup(attrs, (gpointer)"origin");
+            const char *u =
+                (const char *)g_hash_table_lookup(attrs, (gpointer)"username");
+            if (o) origin = o;
+            if (u) username = u;
+        }
+        GError *e2 = nullptr;
+        void *val = p_secret_retrieve_secret_sync(item, nullptr, &e2);
+        if (e2) { g_error_free(e2); e2 = nullptr; }
+        if (val) {
+            const char *text = p_secret_value_get_text(val);
+            if (text) {
+                std::string blob(text);
+                size_t nl = blob.find('\n');
+                if (nl != std::string::npos) {
+                    millisStr = blob.substr(0, nl);
+                    password = blob.substr(nl + 1);
+                } else {
+                    password = blob;
+                }
+            }
+            p_secret_value_unref(val);
+        }
+        if (attrs) g_hash_table_unref(attrs);
+        quads.push_back(origin);
+        quads.push_back(username);
+        quads.push_back(millisStr);
+        quads.push_back(password);
+    }
+    if (items) g_list_free_full(items, g_object_unref);
+    if (service) env->ReleaseStringUTFChars(jservice, service);
+    jobjectArray out =
+        env->NewObjectArray((jsize)quads.size(), strCls, nullptr);
+    for (size_t i = 0; i < quads.size(); i++) {
+        jstring js = env->NewStringUTF(quads[i].c_str());
+        env->SetObjectArrayElement(out, (jsize)i, js);
+        env->DeleteLocalRef(js);
+    }
+    return out;
 #else
     (void)jservice;
     return env->NewObjectArray(0, strCls, nullptr);
@@ -8099,6 +8524,26 @@ JNIEXPORT jboolean JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1
     if (origin) env->ReleaseStringUTFChars(jorigin, origin);
     if (user) env->ReleaseStringUTFChars(juser, user);
     return (st == errSecSuccess) ? JNI_TRUE : JNI_FALSE;
+#elif defined(WEBVIEW_GTK)
+    if (!ensure_secret()) {
+        (void)jservice; (void)jorigin; (void)juser;
+        return JNI_FALSE;
+    }
+    const char *service = env->GetStringUTFChars(jservice, nullptr);
+    const char *origin = env->GetStringUTFChars(jorigin, nullptr);
+    const char *user = env->GetStringUTFChars(juser, nullptr);
+    GError *err = nullptr;
+    gboolean removed = p_secret_clear_sync(
+        &WEBVIEW_PW_SCHEMA, nullptr, &err,
+        "service", service ? service : "",
+        "origin", origin ? origin : "",
+        "username", user ? user : "",
+        (const char *)nullptr);
+    if (service) env->ReleaseStringUTFChars(jservice, service);
+    if (origin) env->ReleaseStringUTFChars(jorigin, origin);
+    if (user) env->ReleaseStringUTFChars(juser, user);
+    if (err) { g_error_free(err); return JNI_FALSE; }
+    return removed ? JNI_TRUE : JNI_FALSE;
 #else
     (void)env; (void)jservice; (void)jorigin; (void)juser;
     return JNI_FALSE;
@@ -8110,6 +8555,8 @@ JNIEXPORT jboolean JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1
     (void)env;
 #if defined(WEBVIEW_COCOA)
     return JNI_TRUE;
+#elif defined(WEBVIEW_GTK)
+    return ensure_secret() ? JNI_TRUE : JNI_FALSE;
 #else
     return JNI_FALSE;
 #endif

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -7895,36 +7895,50 @@ JNIEXPORT jobjectArray JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cr
     std::string svc = std::string(service ? service : "") + ":"
         + (origin ? origin : "");
     CFStringRef cfSvc = pw_cf(svc.c_str());
-    const void *qk[] = { kSecClass, kSecAttrService, kSecMatchLimit,
-                         kSecReturnAttributes, kSecReturnData };
-    const void *qv[] = { kSecClassGenericPassword, cfSvc, kSecMatchLimitAll,
-                         kCFBooleanTrue, kCFBooleanTrue };
-    CFDictionaryRef query = CFDictionaryCreate(kCFAllocatorDefault, qk, qv, 5,
-        &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
-    CFTypeRef result = nullptr;
-    OSStatus st = SecItemCopyMatching(query, &result);
     std::vector<std::string> triples;
-    if (st == errSecSuccess && result) {
-        CFArrayRef arr = (CFArrayRef)result;
+    // The macOS keychain rejects kSecMatchLimitAll combined with
+    // kSecReturnData (errSecParam), so read in two phases: phase 1
+    // enumerates the matching accounts (attributes only, no data); phase 2
+    // fetches each account's secret with a single-item, data-returning
+    // query.
+    const void *q1k[] = { kSecClass, kSecAttrService, kSecMatchLimit,
+                          kSecReturnAttributes };
+    const void *q1v[] = { kSecClassGenericPassword, cfSvc, kSecMatchLimitAll,
+                          kCFBooleanTrue };
+    CFDictionaryRef q1 = CFDictionaryCreate(kCFAllocatorDefault, q1k, q1v, 4,
+        &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFTypeRef listResult = nullptr;
+    OSStatus st = SecItemCopyMatching(q1, &listResult);
+    if (st == errSecSuccess && listResult) {
+        CFArrayRef arr = (CFArrayRef)listResult;
         CFIndex n = CFArrayGetCount(arr);
         for (CFIndex i = 0; i < n; i++) {
             CFDictionaryRef item =
                 (CFDictionaryRef)CFArrayGetValueAtIndex(arr, i);
             CFStringRef acct =
                 (CFStringRef)CFDictionaryGetValue(item, kSecAttrAccount);
-            CFDataRef data =
-                (CFDataRef)CFDictionaryGetValue(item, kSecValueData);
+            if (!acct) continue;
             std::string username, millisStr = "0", password;
-            if (acct) {
-                CFIndex maxlen = CFStringGetMaximumSizeForEncoding(
-                    CFStringGetLength(acct), kCFStringEncodingUTF8) + 1;
-                std::vector<char> buf((size_t)maxlen);
-                if (CFStringGetCString(acct, buf.data(), maxlen,
-                                       kCFStringEncodingUTF8)) {
-                    username = buf.data();
-                }
+            CFIndex maxlen = CFStringGetMaximumSizeForEncoding(
+                CFStringGetLength(acct), kCFStringEncodingUTF8) + 1;
+            std::vector<char> buf((size_t)maxlen);
+            if (!CFStringGetCString(acct, buf.data(), maxlen,
+                                    kCFStringEncodingUTF8)) {
+                continue;
             }
-            if (data) {
+            username = buf.data();
+            // Phase 2: fetch this account's secret.
+            const void *q2k[] = { kSecClass, kSecAttrService, kSecAttrAccount,
+                                  kSecMatchLimit, kSecReturnData };
+            const void *q2v[] = { kSecClassGenericPassword, cfSvc, acct,
+                                  kSecMatchLimitOne, kCFBooleanTrue };
+            CFDictionaryRef q2 = CFDictionaryCreate(kCFAllocatorDefault,
+                q2k, q2v, 5, &kCFTypeDictionaryKeyCallBacks,
+                &kCFTypeDictionaryValueCallBacks);
+            CFTypeRef dataResult = nullptr;
+            if (SecItemCopyMatching(q2, &dataResult) == errSecSuccess
+                    && dataResult) {
+                CFDataRef data = (CFDataRef)dataResult;
                 const UInt8 *bytes = CFDataGetBytePtr(data);
                 CFIndex len = CFDataGetLength(data);
                 std::string blob((const char *)bytes, (size_t)len);
@@ -7936,13 +7950,15 @@ JNIEXPORT jobjectArray JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cr
                     password = blob;
                 }
             }
+            if (dataResult) CFRelease(dataResult);
+            CFRelease(q2);
             triples.push_back(username);
             triples.push_back(millisStr);
             triples.push_back(password);
         }
     }
-    if (result) CFRelease(result);
-    CFRelease(query); CFRelease(cfSvc);
+    if (listResult) CFRelease(listResult);
+    CFRelease(q1); CFRelease(cfSvc);
     if (service) env->ReleaseStringUTFChars(jservice, service);
     if (origin) env->ReleaseStringUTFChars(jorigin, origin);
     jobjectArray out =

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -50,6 +50,8 @@
 
 #ifdef WEBVIEW_COCOA
 #include <CoreGraphics/CoreGraphics.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
 #include <dispatch/dispatch.h>
 #include <objc/objc-runtime.h>
 #include <objc/runtime.h>
@@ -434,6 +436,14 @@ struct Engine {
     // URL; a decline falls back to copying the opener's UA.  Deleted on
     // replacement and on engine destroy.
     jobject ua_resolver = nullptr;
+
+    // JNI global ref to the registered WebViewPasswordCallback, or
+    // nullptr.  Set by cocoa_set_password_callback / gtk_set_password_callback
+    // and cleared on engine destroy.  Invoked by the __webview_pw__
+    // script-message handler (login submission / autofill request) that
+    // the injected PasswordDispatcher.SHIM_JS posts to (Canvas 23 macOS;
+    // Canvas 24 Linux).
+    jobject password_callback = nullptr;
 
     Engine() {}
     ~Engine() {}
@@ -3791,6 +3801,12 @@ struct Engine {
     // field instead of a freed ref.
     jobject dialog_callback = nullptr;
 
+    // JNI global ref to the registered WebViewPasswordCallback, or
+    // nullptr.  Read by the __webview_pw__ WKScriptMessageHandler on each
+    // login-submission / fill-request message.  Set by
+    // cocoa_set_password_callback; cleared in cocoa_destroy_engine.
+    jobject password_callback = nullptr;
+
     // Per-engine WKUIDelegate instance assigned to e->webview via
     // setUIDelegate:.  Retained by us (we hold the only strong ref);
     // released in cocoa_destroy_engine after we clear the WKWebView's
@@ -5744,6 +5760,162 @@ static void cocoa_set_dialog_callback(Engine *e, JNIEnv *env, jobject cb) {
 }
 
 // ---------------------------------------------------------------------------
+// Password-manager bridge (Canvas 23).
+//
+// The injected PasswordDispatcher.SHIM_JS posts to the reserved
+// "__webview_pw__" script-message channel:
+//   "S|<b64user>|<b64pass>"  a login form was submitted
+//   "F"                      the page is ready and requests autofill
+// A dedicated WKScriptMessageHandler reads the committed frame URL
+// natively (message.frameInfo / webView.URL) -- the trusted origin source,
+// never a value from the JS payload -- and invokes the Java
+// WebViewPasswordCallback.  The callback is void (non-blocking): the Java
+// PasswordDispatcher marshals the save prompt to the EDT and runs store
+// I/O on a worker, so AppKit main is not parked.
+//
+// The two fire helpers use pure JNI (no Cocoa/GLib) and mirror
+// fire_dialog_alert's shape: defensive attach + detach-if-attached,
+// per-call GetMethodID, ExceptionCheck/Clear after Call*Method.
+// ---------------------------------------------------------------------------
+
+static void fire_password_submitted(JavaVM *jvm, jobject callback,
+                                    const char *frameUrl,
+                                    const char *b64User,
+                                    const char *b64Pass) {
+    if (!jvm || !callback) return;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env) {
+            return;
+        }
+        detach = true;
+    }
+    if (!env) { if (detach) jvm->DetachCurrentThread(); return; }
+    jstring jurl = env->NewStringUTF(frameUrl ? frameUrl : "");
+    jstring juser = env->NewStringUTF(b64User ? b64User : "");
+    jstring jpass = env->NewStringUTF(b64Pass ? b64Pass : "");
+    jclass cls = env->GetObjectClass(callback);
+    if (cls) {
+        jmethodID m = env->GetMethodID(
+            cls, "onLoginSubmitted",
+            "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+        if (m) {
+            env->CallVoidMethod(callback, m, jurl, juser, jpass);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (jurl) env->DeleteLocalRef(jurl);
+    if (juser) env->DeleteLocalRef(juser);
+    if (jpass) env->DeleteLocalRef(jpass);
+    if (detach) jvm->DetachCurrentThread();
+}
+
+static void fire_password_fill_requested(JavaVM *jvm, jobject callback,
+                                         const char *frameUrl) {
+    if (!jvm || !callback) return;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env) {
+            return;
+        }
+        detach = true;
+    }
+    if (!env) { if (detach) jvm->DetachCurrentThread(); return; }
+    jstring jurl = env->NewStringUTF(frameUrl ? frameUrl : "");
+    jclass cls = env->GetObjectClass(callback);
+    if (cls) {
+        jmethodID m = env->GetMethodID(cls, "onFillRequested",
+                                       "(Ljava/lang/String;)V");
+        if (m) {
+            env->CallVoidMethod(callback, m, jurl);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (jurl) env->DeleteLocalRef(jurl);
+    if (detach) jvm->DetachCurrentThread();
+}
+
+// Parse a "__webview_pw__" payload and fire the matching callback.  The
+// origin comes from frameUrl (native-stamped), never the payload.
+static void handle_password_message(Engine *e, const std::string &payload,
+                                    const std::string &frameUrl) {
+    if (!e || !e->password_callback) return;
+    if (payload.empty()) return;
+    if (payload[0] == 'F') {
+        fire_password_fill_requested(e->jvm, e->password_callback,
+                                     frameUrl.c_str());
+        return;
+    }
+    if (payload.size() >= 2 && payload[0] == 'S' && payload[1] == '|') {
+        size_t p1 = 2;
+        size_t p2 = payload.find('|', p1);
+        std::string b64user = (p2 == std::string::npos)
+            ? payload.substr(p1) : payload.substr(p1, p2 - p1);
+        std::string b64pass = (p2 == std::string::npos)
+            ? std::string() : payload.substr(p2 + 1);
+        fire_password_submitted(e->jvm, e->password_callback,
+                                frameUrl.c_str(), b64user.c_str(),
+                                b64pass.c_str());
+    }
+}
+
+static std::once_flag g_webview_pw_delegate_once;
+static Class g_webview_pw_delegate_cls = nil;
+
+// Dedicated WKScriptMessageHandler for the "__webview_pw__" channel.  Reads
+// the committed frame URL natively (frameInfo.request.URL, falling back to
+// webView.URL) and hands it to Java as the trusted origin.
+static Class get_webview_pw_delegate_cls() {
+    std::call_once(g_webview_pw_delegate_once, [] {
+        Class c = objc_allocateClassPair((Class)objc_cls("NSObject"),
+                                         "WebviewPwDelegate", 0);
+        class_addProtocol(c, objc_getProtocol("WKScriptMessageHandler"));
+        class_addMethod(
+            c,
+            sel("userContentController:didReceiveScriptMessage:"),
+            (IMP)(+[](id self, SEL, id, id m) {
+                Engine *eng = (Engine *)objc_getAssociatedObject(self, "eng");
+                if (!eng) return;
+                id body = msg(m, sel("body"));
+                if (!body) return;
+                const char *s = msg<const char *>(body, sel("UTF8String"));
+                if (!s) return;
+                std::string payload(s);
+                std::string frameUrl = frame_url_utf8(
+                    msg(m, sel("frameInfo")), msg(m, sel("webView")));
+                handle_password_message(eng, payload, frameUrl);
+            }),
+            "v@:@@");
+        objc_registerClassPair(c);
+        g_webview_pw_delegate_cls = c;
+    });
+    return g_webview_pw_delegate_cls;
+}
+
+// Register (or clear, when cb is null) the Java WebViewPasswordCallback for
+// this engine.  Mirrors cocoa_set_dialog_callback.
+static void cocoa_set_password_callback(Engine *e, JNIEnv *env, jobject cb) {
+    if (!e) return;
+    if (e->password_callback) {
+        env->DeleteGlobalRef(e->password_callback);
+        e->password_callback = nullptr;
+    }
+    if (cb) {
+        e->password_callback = env->NewGlobalRef(cb);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Mouse-down hook on WKWebView.
 //
 // We swizzle -[WKWebView mouseDown:], -[WKWebView rightMouseDown:], and
@@ -6395,6 +6567,19 @@ static Engine *cocoa_create_engine(JNIEnv *env, jobject parentComponent,
                           sel("addScriptMessageHandler:name:"), delegate,
                           ns_str("external"));
 
+        // Password-manager bridge: a dedicated script-message handler for
+        // the "__webview_pw__" channel that the injected
+        // PasswordDispatcher.SHIM_JS posts login-submission / fill-request
+        // messages to.  Reads the committed frame URL natively (the trusted
+        // origin).  Removed in cocoa_destroy_engine alongside "external".
+        Class pw_delegate_cls = get_webview_pw_delegate_cls();
+        id pw_delegate = msg((id)pw_delegate_cls, sel("new"));
+        objc_setAssociatedObject(pw_delegate, "eng", (id)e,
+                                 OBJC_ASSOCIATION_ASSIGN);
+        msg<void, id, id>(e->manager,
+                          sel("addScriptMessageHandler:name:"), pw_delegate,
+                          ns_str("__webview_pw__"));
+
         // Browser-dialog bridge: install a WKUIDelegate so JS-initiated
         // alert / confirm / prompt and <input type=file> requests flow
         // through Java (DialogDispatcher → WebViewDialogHandler) instead
@@ -6819,6 +7004,17 @@ static void cocoa_destroy_engine(Engine *e) {
         e->dialog_callback = nullptr;
         if (detach) e->jvm->DetachCurrentThread();
     }
+    if (e->password_callback) {
+        JNIEnv *env = nullptr;
+        bool detach = false;
+        if (e->jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+            e->jvm->AttachCurrentThread((void **)&env, nullptr);
+            detach = true;
+        }
+        if (env) env->DeleteGlobalRef(e->password_callback);
+        e->password_callback = nullptr;
+        if (detach) e->jvm->DetachCurrentThread();
+    }
     cocoa_run_on_main_async([e] {
         // Mark destroyed FIRST.  Any LATER-firing lambdas that read this
         // flag short-circuit; FIFO ordering on the main queue makes
@@ -6843,6 +7039,8 @@ static void cocoa_destroy_engine(Engine *e) {
         if (e->manager) {
             msg<void, id>(e->manager, sel("removeScriptMessageHandlerForName:"),
                           ns_str("external"));
+            msg<void, id>(e->manager, sel("removeScriptMessageHandlerForName:"),
+                          ns_str("__webview_pw__"));
         }
         // Abandon every download still in flight for this engine and
         // remove its NSProgress KVO observer.  An NSProgress released
@@ -7603,6 +7801,197 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
     // OffscreenWebView.setDialogCallback never gets here because
     // OffscreenWebView.create returns null on those platforms.
     (void)env; (void)cb;
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Password-manager callback registration + credential store (Canvas 23
+// macOS; Canvas 24 Linux).  Must live inside this extern "C" block so the
+// JVM can resolve them (UnsatisfiedLinkError otherwise).
+// ---------------------------------------------------------------------------
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1password_1callback
+  (JNIEnv *env, jclass, jlong wv, jobject cb) {
+    if (wv == 0) return;
+#if defined(WEBVIEW_COCOA)
+    embed::cocoa_set_password_callback((embed::Engine *)wv, env, cb);
+#else
+    // Linux GTK password channel wired in Canvas 24.
+    (void)env; (void)cb;
+#endif
+}
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1set_1password_1callback
+  (JNIEnv *env, jclass, jlong peer, jobject cb) {
+    // Linux lightweight wired in Canvas 24; macOS/Windows offscreen is a stub.
+    (void)peer; (void)env; (void)cb;
+}
+
+#if defined(WEBVIEW_COCOA)
+// Build a CFString from a UTF-8 C string (caller CFRelease's).
+static CFStringRef pw_cf(const char *s) {
+    return CFStringCreateWithCString(kCFAllocatorDefault, s ? s : "",
+                                     kCFStringEncodingUTF8);
+}
+#endif
+
+JNIEXPORT jboolean JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1store_1save
+  (JNIEnv *env, jclass, jstring jservice, jstring jorigin, jstring juser,
+   jstring jpass, jlong millis) {
+#if defined(WEBVIEW_COCOA)
+    const char *service = env->GetStringUTFChars(jservice, nullptr);
+    const char *origin = env->GetStringUTFChars(jorigin, nullptr);
+    const char *user = env->GetStringUTFChars(juser, nullptr);
+    const char *pass = env->GetStringUTFChars(jpass, nullptr);
+    std::string svc = std::string(service ? service : "") + ":"
+        + (origin ? origin : "");
+    std::string value = std::to_string((long long)millis) + "\n"
+        + (pass ? pass : "");
+    CFStringRef cfSvc = pw_cf(svc.c_str());
+    CFStringRef cfAcct = pw_cf(user ? user : "");
+    CFDataRef cfVal = CFDataCreate(kCFAllocatorDefault,
+        (const UInt8 *)value.data(), (CFIndex)value.size());
+    const void *qk[] = { kSecClass, kSecAttrService, kSecAttrAccount };
+    const void *qv[] = { kSecClassGenericPassword, cfSvc, cfAcct };
+    CFDictionaryRef query = CFDictionaryCreate(kCFAllocatorDefault, qk, qv, 3,
+        &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    jboolean ok = JNI_FALSE;
+    if (SecItemCopyMatching(query, nullptr) == errSecSuccess) {
+        const void *uk[] = { kSecValueData };
+        const void *uv[] = { cfVal };
+        CFDictionaryRef upd = CFDictionaryCreate(kCFAllocatorDefault, uk, uv, 1,
+            &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+        ok = (SecItemUpdate(query, upd) == errSecSuccess) ? JNI_TRUE : JNI_FALSE;
+        CFRelease(upd);
+    } else {
+        const void *ak[] = { kSecClass, kSecAttrService, kSecAttrAccount,
+                             kSecValueData, kSecAttrSynchronizable };
+        const void *av[] = { kSecClassGenericPassword, cfSvc, cfAcct,
+                             cfVal, kCFBooleanFalse };
+        CFDictionaryRef add = CFDictionaryCreate(kCFAllocatorDefault, ak, av, 5,
+            &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+        ok = (SecItemAdd(add, nullptr) == errSecSuccess) ? JNI_TRUE : JNI_FALSE;
+        CFRelease(add);
+    }
+    CFRelease(query); CFRelease(cfSvc); CFRelease(cfAcct); CFRelease(cfVal);
+    if (service) env->ReleaseStringUTFChars(jservice, service);
+    if (origin) env->ReleaseStringUTFChars(jorigin, origin);
+    if (user) env->ReleaseStringUTFChars(juser, user);
+    if (pass) env->ReleaseStringUTFChars(jpass, pass);
+    return ok;
+#else
+    (void)env; (void)jservice; (void)jorigin; (void)juser; (void)jpass;
+    (void)millis;
+    return JNI_FALSE;
+#endif
+}
+
+JNIEXPORT jobjectArray JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1store_1find
+  (JNIEnv *env, jclass, jstring jservice, jstring jorigin) {
+    jclass strCls = env->FindClass("java/lang/String");
+#if defined(WEBVIEW_COCOA)
+    const char *service = env->GetStringUTFChars(jservice, nullptr);
+    const char *origin = env->GetStringUTFChars(jorigin, nullptr);
+    std::string svc = std::string(service ? service : "") + ":"
+        + (origin ? origin : "");
+    CFStringRef cfSvc = pw_cf(svc.c_str());
+    const void *qk[] = { kSecClass, kSecAttrService, kSecMatchLimit,
+                         kSecReturnAttributes, kSecReturnData };
+    const void *qv[] = { kSecClassGenericPassword, cfSvc, kSecMatchLimitAll,
+                         kCFBooleanTrue, kCFBooleanTrue };
+    CFDictionaryRef query = CFDictionaryCreate(kCFAllocatorDefault, qk, qv, 5,
+        &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFTypeRef result = nullptr;
+    OSStatus st = SecItemCopyMatching(query, &result);
+    std::vector<std::string> triples;
+    if (st == errSecSuccess && result) {
+        CFArrayRef arr = (CFArrayRef)result;
+        CFIndex n = CFArrayGetCount(arr);
+        for (CFIndex i = 0; i < n; i++) {
+            CFDictionaryRef item =
+                (CFDictionaryRef)CFArrayGetValueAtIndex(arr, i);
+            CFStringRef acct =
+                (CFStringRef)CFDictionaryGetValue(item, kSecAttrAccount);
+            CFDataRef data =
+                (CFDataRef)CFDictionaryGetValue(item, kSecValueData);
+            std::string username, millisStr = "0", password;
+            if (acct) {
+                CFIndex maxlen = CFStringGetMaximumSizeForEncoding(
+                    CFStringGetLength(acct), kCFStringEncodingUTF8) + 1;
+                std::vector<char> buf((size_t)maxlen);
+                if (CFStringGetCString(acct, buf.data(), maxlen,
+                                       kCFStringEncodingUTF8)) {
+                    username = buf.data();
+                }
+            }
+            if (data) {
+                const UInt8 *bytes = CFDataGetBytePtr(data);
+                CFIndex len = CFDataGetLength(data);
+                std::string blob((const char *)bytes, (size_t)len);
+                size_t nl = blob.find('\n');
+                if (nl != std::string::npos) {
+                    millisStr = blob.substr(0, nl);
+                    password = blob.substr(nl + 1);
+                } else {
+                    password = blob;
+                }
+            }
+            triples.push_back(username);
+            triples.push_back(millisStr);
+            triples.push_back(password);
+        }
+    }
+    if (result) CFRelease(result);
+    CFRelease(query); CFRelease(cfSvc);
+    if (service) env->ReleaseStringUTFChars(jservice, service);
+    if (origin) env->ReleaseStringUTFChars(jorigin, origin);
+    jobjectArray out =
+        env->NewObjectArray((jsize)triples.size(), strCls, nullptr);
+    for (size_t i = 0; i < triples.size(); i++) {
+        jstring js = env->NewStringUTF(triples[i].c_str());
+        env->SetObjectArrayElement(out, (jsize)i, js);
+        env->DeleteLocalRef(js);
+    }
+    return out;
+#else
+    (void)jservice; (void)jorigin;
+    return env->NewObjectArray(0, strCls, nullptr);
+#endif
+}
+
+JNIEXPORT jboolean JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1store_1delete
+  (JNIEnv *env, jclass, jstring jservice, jstring jorigin, jstring juser) {
+#if defined(WEBVIEW_COCOA)
+    const char *service = env->GetStringUTFChars(jservice, nullptr);
+    const char *origin = env->GetStringUTFChars(jorigin, nullptr);
+    const char *user = env->GetStringUTFChars(juser, nullptr);
+    std::string svc = std::string(service ? service : "") + ":"
+        + (origin ? origin : "");
+    CFStringRef cfSvc = pw_cf(svc.c_str());
+    CFStringRef cfAcct = pw_cf(user ? user : "");
+    const void *qk[] = { kSecClass, kSecAttrService, kSecAttrAccount };
+    const void *qv[] = { kSecClassGenericPassword, cfSvc, cfAcct };
+    CFDictionaryRef query = CFDictionaryCreate(kCFAllocatorDefault, qk, qv, 3,
+        &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    OSStatus st = SecItemDelete(query);
+    CFRelease(query); CFRelease(cfSvc); CFRelease(cfAcct);
+    if (service) env->ReleaseStringUTFChars(jservice, service);
+    if (origin) env->ReleaseStringUTFChars(jorigin, origin);
+    if (user) env->ReleaseStringUTFChars(juser, user);
+    return (st == errSecSuccess) ? JNI_TRUE : JNI_FALSE;
+#else
+    (void)env; (void)jservice; (void)jorigin; (void)juser;
+    return JNI_FALSE;
+#endif
+}
+
+JNIEXPORT jboolean JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1store_1available
+  (JNIEnv *env, jclass) {
+    (void)env;
+#if defined(WEBVIEW_COCOA)
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
 #endif
 }
 

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -7975,6 +7975,110 @@ JNIEXPORT jobjectArray JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cr
 #endif
 }
 
+JNIEXPORT jobjectArray JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1store_1find_1all
+  (JNIEnv *env, jclass, jstring jservice) {
+    jclass strCls = env->FindClass("java/lang/String");
+#if defined(WEBVIEW_COCOA)
+    const char *service = env->GetStringUTFChars(jservice, nullptr);
+    std::string prefix = std::string(service ? service : "") + ":";
+    // Each item's kSecAttrService is "<namespace>:<origin>" (origin embedded
+    // in the service, plain username as the account), so there is no single
+    // service value covering all origins and the keychain has no prefix
+    // query.  Enumerate every generic-password item and keep those whose
+    // service starts with "<service>:".  Two phases as in find: the
+    // kSecMatchLimitAll + kSecReturnData combination returns errSecParam.
+    std::vector<std::string> quads;
+    const void *q1k[] = { kSecClass, kSecMatchLimit, kSecReturnAttributes };
+    const void *q1v[] = { kSecClassGenericPassword, kSecMatchLimitAll,
+                          kCFBooleanTrue };
+    CFDictionaryRef q1 = CFDictionaryCreate(kCFAllocatorDefault, q1k, q1v, 3,
+        &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFTypeRef listResult = nullptr;
+    OSStatus st = SecItemCopyMatching(q1, &listResult);
+    if (st == errSecSuccess && listResult) {
+        CFArrayRef arr = (CFArrayRef)listResult;
+        CFIndex n = CFArrayGetCount(arr);
+        for (CFIndex i = 0; i < n; i++) {
+            CFDictionaryRef item =
+                (CFDictionaryRef)CFArrayGetValueAtIndex(arr, i);
+            CFStringRef svcAttr =
+                (CFStringRef)CFDictionaryGetValue(item, kSecAttrService);
+            CFStringRef acct =
+                (CFStringRef)CFDictionaryGetValue(item, kSecAttrAccount);
+            if (!svcAttr || !acct) continue;
+            // Read the full service string.
+            CFIndex svcMax = CFStringGetMaximumSizeForEncoding(
+                CFStringGetLength(svcAttr), kCFStringEncodingUTF8) + 1;
+            std::vector<char> svcBuf((size_t)svcMax);
+            if (!CFStringGetCString(svcAttr, svcBuf.data(), svcMax,
+                                    kCFStringEncodingUTF8)) {
+                continue;
+            }
+            std::string fullSvc = svcBuf.data();
+            // Keep only our namespace; derive origin from the suffix.
+            if (fullSvc.size() < prefix.size()
+                    || fullSvc.compare(0, prefix.size(), prefix) != 0) {
+                continue;
+            }
+            std::string origin = fullSvc.substr(prefix.size());
+            // Read the account (username).
+            CFIndex acctMax = CFStringGetMaximumSizeForEncoding(
+                CFStringGetLength(acct), kCFStringEncodingUTF8) + 1;
+            std::vector<char> acctBuf((size_t)acctMax);
+            if (!CFStringGetCString(acct, acctBuf.data(), acctMax,
+                                    kCFStringEncodingUTF8)) {
+                continue;
+            }
+            std::string username = acctBuf.data();
+            std::string millisStr = "0", password;
+            // Phase 2: fetch this item's secret by exact service+account.
+            const void *q2k[] = { kSecClass, kSecAttrService, kSecAttrAccount,
+                                  kSecMatchLimit, kSecReturnData };
+            const void *q2v[] = { kSecClassGenericPassword, svcAttr, acct,
+                                  kSecMatchLimitOne, kCFBooleanTrue };
+            CFDictionaryRef q2 = CFDictionaryCreate(kCFAllocatorDefault,
+                q2k, q2v, 5, &kCFTypeDictionaryKeyCallBacks,
+                &kCFTypeDictionaryValueCallBacks);
+            CFTypeRef dataResult = nullptr;
+            if (SecItemCopyMatching(q2, &dataResult) == errSecSuccess
+                    && dataResult) {
+                CFDataRef data = (CFDataRef)dataResult;
+                const UInt8 *bytes = CFDataGetBytePtr(data);
+                CFIndex len = CFDataGetLength(data);
+                std::string blob((const char *)bytes, (size_t)len);
+                size_t nl = blob.find('\n');
+                if (nl != std::string::npos) {
+                    millisStr = blob.substr(0, nl);
+                    password = blob.substr(nl + 1);
+                } else {
+                    password = blob;
+                }
+            }
+            if (dataResult) CFRelease(dataResult);
+            CFRelease(q2);
+            quads.push_back(origin);
+            quads.push_back(username);
+            quads.push_back(millisStr);
+            quads.push_back(password);
+        }
+    }
+    if (listResult) CFRelease(listResult);
+    CFRelease(q1);
+    if (service) env->ReleaseStringUTFChars(jservice, service);
+    jobjectArray out =
+        env->NewObjectArray((jsize)quads.size(), strCls, nullptr);
+    for (size_t i = 0; i < quads.size(); i++) {
+        jstring js = env->NewStringUTF(quads[i].c_str());
+        env->SetObjectArrayElement(out, (jsize)i, js);
+        env->DeleteLocalRef(js);
+    }
+    return out;
+#else
+    (void)jservice;
+    return env->NewObjectArray(0, strCls, nullptr);
+#endif
+}
+
 JNIEXPORT jboolean JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1store_1delete
   (JNIEnv *env, jclass, jstring jservice, jstring jorigin, jstring juser) {
 #if defined(WEBVIEW_COCOA)

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -441,8 +441,8 @@ struct Engine {
     // nullptr.  Set by cocoa_set_password_callback / gtk_set_password_callback
     // and cleared on engine destroy.  Invoked by the __webview_pw__
     // script-message handler (login submission / autofill request) that
-    // the injected PasswordDispatcher.SHIM_JS posts to (Canvas 23 macOS;
-    // Canvas 24 Linux).
+    // the injected PasswordDispatcher.SHIM_JS posts to (Canvas 26 macOS;
+    // Canvas 27 Linux).
     jobject password_callback = nullptr;
 
     Engine() {}
@@ -5760,7 +5760,7 @@ static void cocoa_set_dialog_callback(Engine *e, JNIEnv *env, jobject cb) {
 }
 
 // ---------------------------------------------------------------------------
-// Password-manager bridge (Canvas 23).
+// Password-manager bridge (Canvas 26).
 //
 // The injected PasswordDispatcher.SHIM_JS posts to the reserved
 // "__webview_pw__" script-message channel:
@@ -7805,8 +7805,8 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
 }
 
 // ---------------------------------------------------------------------------
-// Password-manager callback registration + credential store (Canvas 23
-// macOS; Canvas 24 Linux).  Must live inside this extern "C" block so the
+// Password-manager callback registration + credential store (Canvas 26
+// macOS; Canvas 27 Linux).  Must live inside this extern "C" block so the
 // JVM can resolve them (UnsatisfiedLinkError otherwise).
 // ---------------------------------------------------------------------------
 
@@ -7816,14 +7816,14 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set
 #if defined(WEBVIEW_COCOA)
     embed::cocoa_set_password_callback((embed::Engine *)wv, env, cb);
 #else
-    // Linux GTK password channel wired in Canvas 24.
+    // Linux GTK password channel wired in Canvas 27.
     (void)env; (void)cb;
 #endif
 }
 
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1set_1password_1callback
   (JNIEnv *env, jclass, jlong peer, jobject cb) {
-    // Linux lightweight wired in Canvas 24; macOS/Windows offscreen is a stub.
+    // Linux lightweight wired in Canvas 27; macOS/Windows offscreen is a stub.
     (void)peer; (void)env; (void)cb;
 }
 

--- a/test/ca/weblite/webview/InMemoryCredentialStoreTest.java
+++ b/test/ca/weblite/webview/InMemoryCredentialStoreTest.java
@@ -1,0 +1,71 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Unit tests for {@link InMemoryCredentialStore} (also exercises the
+ *  origin-keying + recency contract shared with the native store). */
+public class InMemoryCredentialStoreTest {
+
+    private InMemoryCredentialStore store;
+
+    @Before public void setUp() { store = new InMemoryCredentialStore(); }
+
+    @Test public void saveThenFind() {
+        store.save(new WebViewCredential("https://svc.example.com", "bob", "pw123"));
+        Optional<WebViewCredential> c = store.find("https://svc.example.com");
+        assertTrue(c.isPresent());
+        assertEquals("bob", c.get().username());
+        assertEquals("pw123", c.get().password());
+    }
+
+    @Test public void overwriteKeepsSingleRecord() {
+        store.save(new WebViewCredential("https://svc.example.com", "bob", "oldpw"));
+        store.save(new WebViewCredential("https://svc.example.com", "bob", "newpw"));
+        List<WebViewCredential> all = store.findAll("https://svc.example.com");
+        assertEquals(1, all.size());
+        assertEquals("newpw", all.get(0).password());
+    }
+
+    @Test public void multipleUsernamesRetainedFindMostRecent() {
+        store.save(new WebViewCredential("https://svc.example.com", "bob", "pw1"));
+        store.save(new WebViewCredential("https://svc.example.com", "carol", "pw2"));
+        List<WebViewCredential> all = store.findAll("https://svc.example.com");
+        assertEquals(2, all.size());
+        // find() returns the most-recently-saved (carol).
+        assertEquals("carol", store.find("https://svc.example.com").get().username());
+    }
+
+    @Test public void deleteRemoves() {
+        store.save(new WebViewCredential("https://svc.example.com", "bob", "pw"));
+        assertTrue(store.delete("https://svc.example.com", "bob"));
+        assertFalse(store.find("https://svc.example.com").isPresent());
+        assertFalse(store.delete("https://svc.example.com", "bob"));
+    }
+
+    @Test public void originCanonicalisedOnSaveAndQuery() {
+        // Stored with an explicit default port + path; queried bare.
+        store.save(new WebViewCredential("https://example.com:443/login", "a", "p"));
+        assertTrue(store.find("https://example.com").isPresent());
+        // A different scheme/port is a different origin.
+        assertFalse(store.find("http://example.com").isPresent());
+        assertFalse(store.find("https://example.com:8443").isPresent());
+    }
+
+    @Test public void unparseableOriginIsNoOp() {
+        store.save(new WebViewCredential("about:blank", "a", "p"));
+        assertTrue(store.findAll("about:blank").isEmpty());
+    }
+}

--- a/test/ca/weblite/webview/InMemoryCredentialStoreTest.java
+++ b/test/ca/weblite/webview/InMemoryCredentialStoreTest.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /** Unit tests for {@link InMemoryCredentialStore} (also exercises the
@@ -67,5 +68,42 @@ public class InMemoryCredentialStoreTest {
     @Test public void unparseableOriginIsNoOp() {
         store.save(new WebViewCredential("about:blank", "a", "p"));
         assertTrue(store.findAll("about:blank").isEmpty());
+    }
+
+    // ---- STORY-006-005: enumerate-all --------------------------------
+
+    @Test public void findAllAcrossOriginsMostRecentFirst() {
+        store.save(new WebViewCredential("https://a.example", "alice", "pw1"));
+        store.save(new WebViewCredential("https://b.example", "bob", "pw2"));
+        store.save(new WebViewCredential("https://c.example", "carol", "pw3"));
+        List<WebViewCredential> all = store.findAll();
+        assertEquals(3, all.size());
+        assertEquals("carol", all.get(0).username());
+        assertEquals("bob", all.get(1).username());
+        assertEquals("alice", all.get(2).username());
+    }
+
+    @Test public void findAllIncludesMultipleUsernamesPerOrigin() {
+        store.save(new WebViewCredential("https://svc.example", "bob", "pw1"));
+        store.save(new WebViewCredential("https://svc.example", "carol", "pw2"));
+        store.save(new WebViewCredential("https://other.example", "dan", "pw3"));
+        List<WebViewCredential> all = store.findAll();
+        assertEquals(3, all.size());
+    }
+
+    @Test public void findAllEmptyStoreIsEmptyList() {
+        List<WebViewCredential> all = store.findAll();
+        assertNotNull(all);
+        assertTrue(all.isEmpty());
+    }
+
+    @Test public void findAllReflectsDeletion() {
+        store.save(new WebViewCredential("https://a.example", "alice", "pw1"));
+        store.save(new WebViewCredential("https://b.example", "bob", "pw2"));
+        assertTrue(store.delete("https://a.example", "alice"));
+        List<WebViewCredential> all = store.findAll();
+        assertEquals(1, all.size());
+        assertEquals("https://b.example", all.get(0).origin());
+        assertEquals("bob", all.get(0).username());
     }
 }

--- a/test/ca/weblite/webview/OriginsTest.java
+++ b/test/ca/weblite/webview/OriginsTest.java
@@ -1,0 +1,54 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/** Unit tests for {@link Origins#canonical}. */
+public class OriginsTest {
+
+    @Test public void httpsDefaultPortDropped() {
+        assertEquals("https://example.com", Origins.canonical("https://example.com"));
+        assertEquals("https://example.com", Origins.canonical("https://example.com:443"));
+        assertEquals("https://example.com",
+            Origins.canonical("https://EXAMPLE.com/login?x=1#frag"));
+    }
+
+    @Test public void httpDefaultPortDropped() {
+        assertEquals("http://example.com", Origins.canonical("http://example.com:80/"));
+    }
+
+    @Test public void nonDefaultPortKept() {
+        assertEquals("https://example.com:8443",
+            Origins.canonical("https://example.com:8443/login"));
+    }
+
+    @Test public void schemeIsPartOfOrigin() {
+        assertEquals("http://example.com", Origins.canonical("http://example.com"));
+        assertEquals("https://example.com", Origins.canonical("https://example.com"));
+        // http and https canonicalise to distinct origins.
+        org.junit.Assert.assertNotEquals(
+            Origins.canonical("http://example.com"),
+            Origins.canonical("https://example.com"));
+    }
+
+    @Test public void hostLowercased() {
+        assertEquals("https://svc.example.com",
+            Origins.canonical("https://SVC.Example.COM"));
+    }
+
+    @Test public void opaqueOrHostlessReturnsNull() {
+        assertNull(Origins.canonical("about:blank"));
+        assertNull(Origins.canonical("data:text/html,<b>hi</b>"));
+        assertNull(Origins.canonical(""));
+        assertNull(Origins.canonical("   "));
+        assertNull(Origins.canonical(null));
+        assertNull(Origins.canonical("not a url"));
+    }
+}

--- a/test/ca/weblite/webview/PasswordDispatcherTest.java
+++ b/test/ca/weblite/webview/PasswordDispatcherTest.java
@@ -1,0 +1,245 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import ca.weblite.webview.swing.WebViewComponent;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.swing.SwingUtilities;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link PasswordDispatcher} — exercise the Java contract
+ * (capture → save-policy → store, autofill push, enable/disable gating,
+ * store/handler seams, EDT marshaling, exception isolation, redaction)
+ * without a live native engine or the OS Keychain.  A
+ * {@link StubComponent} captures the {@code eval} the fill path emits.
+ */
+public class PasswordDispatcherTest {
+
+    /** Minimal {@link WebViewComponent} that records eval() calls. */
+    private static final class StubComponent extends WebViewComponent {
+        final BlockingQueue<String> evalCalls = new LinkedBlockingQueue<String>();
+        @Override public WebViewComponent setUrl(String url) { return this; }
+        @Override public String getUrl() { return ""; }
+        @Override public WebViewComponent setDebug(boolean debug) { return this; }
+        @Override public WebViewComponent addOnBeforeLoad(String js) { return this; }
+        @Override public WebViewComponent eval(String js) {
+            evalCalls.add(js);
+            return this;
+        }
+        @Override public CompletableFuture<String> evalAsync(String js) {
+            CompletableFuture<String> f = new CompletableFuture<String>();
+            f.completeExceptionally(new IllegalStateException("stub"));
+            return f;
+        }
+        @Override public WebViewComponent addJavascriptCallback(
+                String name, WebView.JavascriptCallback cb) { return this; }
+        @Override public WebViewComponent addJavascriptFunction(
+                String name, JavascriptFunction fn) { return this; }
+        @Override public WebViewComponent addJavascriptFunction(
+                String name, AsyncJavascriptFunction fn) { return this; }
+        @Override public WebViewComponent dispatch(Runnable r) { return this; }
+        @Override public void dispose() { }
+    }
+
+    private StubComponent source;
+    private PasswordDispatcher dispatcher;
+    private InMemoryCredentialStore store;
+    private Thread.UncaughtExceptionHandler priorHandler;
+    private AtomicReference<Throwable> uncaught;
+
+    private static String b64(String s) {
+        return Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Before public void setUp() {
+        source = new StubComponent();
+        dispatcher = new PasswordDispatcher(source);
+        store = new InMemoryCredentialStore();
+        dispatcher.setStore(store);
+        uncaught = new AtomicReference<Throwable>();
+        priorHandler = Thread.getDefaultUncaughtExceptionHandler();
+        Thread.setDefaultUncaughtExceptionHandler(
+            new Thread.UncaughtExceptionHandler() {
+                @Override public void uncaughtException(Thread t, Throwable e) {
+                    uncaught.set(e);
+                }
+            });
+    }
+
+    @After public void tearDown() {
+        Thread.setDefaultUncaughtExceptionHandler(priorHandler);
+        dispatcher.disposeAll();
+    }
+
+    /** Flush the EDT so any invokeLater task has run. */
+    private static void flushEdt() throws Exception {
+        SwingUtilities.invokeAndWait(new Runnable() { public void run() { } });
+    }
+
+    private static boolean awaitTrue(java.util.concurrent.Callable<Boolean> c)
+            throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(3);
+        while (System.nanoTime() < deadline) {
+            if (Boolean.TRUE.equals(c.call())) return true;
+            Thread.sleep(10);
+        }
+        return Boolean.TRUE.equals(c.call());
+    }
+
+    @Test public void saveDispositionStoresDecodedCredential() throws Exception {
+        dispatcher.setHandler(new WebViewSavePasswordHandler() {
+            @Override public SavePasswordDisposition onLoginSubmitted(
+                    WebViewSavePasswordEvent e) {
+                return SavePasswordDisposition.SAVE;
+            }
+        });
+        dispatcher.dispatchLoginSubmitted("https://example.com/login",
+            b64("alice"), b64("s3cret"));
+        assertTrue(awaitTrue(new java.util.concurrent.Callable<Boolean>() {
+            public Boolean call() {
+                return store.find("https://example.com").isPresent();
+            }
+        }));
+        WebViewCredential c = store.find("https://example.com").get();
+        assertEquals("alice", c.username());
+        assertEquals("s3cret", c.password());
+    }
+
+    @Test public void dontSaveStoresNothing() throws Exception {
+        dispatcher.setHandler(new WebViewSavePasswordHandler() {
+            @Override public SavePasswordDisposition onLoginSubmitted(
+                    WebViewSavePasswordEvent e) {
+                return SavePasswordDisposition.DONT_SAVE;
+            }
+        });
+        dispatcher.dispatchLoginSubmitted("https://example.com/login",
+            b64("alice"), b64("s3cret"));
+        flushEdt();
+        Thread.sleep(50);
+        assertFalse(store.find("https://example.com").isPresent());
+    }
+
+    @Test public void handlerRunsOnEdt() throws Exception {
+        final AtomicBoolean onEdt = new AtomicBoolean(false);
+        final Object done = new Object();
+        final AtomicBoolean fired = new AtomicBoolean(false);
+        dispatcher.setHandler(new WebViewSavePasswordHandler() {
+            @Override public SavePasswordDisposition onLoginSubmitted(
+                    WebViewSavePasswordEvent e) {
+                onEdt.set(SwingUtilities.isEventDispatchThread());
+                synchronized (done) { fired.set(true); done.notifyAll(); }
+                return SavePasswordDisposition.DONT_SAVE;
+            }
+        });
+        dispatcher.dispatchLoginSubmitted("https://example.com", b64("u"), b64("p"));
+        synchronized (done) {
+            if (!fired.get()) done.wait(3000);
+        }
+        assertTrue("handler must run on the EDT", onEdt.get());
+    }
+
+    @Test public void disabledSuppressesAutomaticButKeepsProgrammaticApi()
+            throws Exception {
+        dispatcher.setEnabled(false);
+        dispatcher.setHandler(new WebViewSavePasswordHandler() {
+            @Override public SavePasswordDisposition onLoginSubmitted(
+                    WebViewSavePasswordEvent e) {
+                return SavePasswordDisposition.SAVE;
+            }
+        });
+        dispatcher.dispatchLoginSubmitted("https://example.com", b64("a"), b64("p"));
+        dispatcher.dispatchFillRequested("https://example.com");
+        flushEdt();
+        Thread.sleep(50);
+        assertFalse(store.find("https://example.com").isPresent());
+        assertTrue(source.evalCalls.isEmpty());
+        // Programmatic API still works.
+        dispatcher.saveCredential(
+            new WebViewCredential("https://example.com", "bob", "pw"));
+        assertEquals("bob", dispatcher.getCredential("https://example.com").get().username());
+    }
+
+    @Test public void handlerExceptionIsolatedAndStoresNothing() throws Exception {
+        dispatcher.setHandler(new WebViewSavePasswordHandler() {
+            @Override public SavePasswordDisposition onLoginSubmitted(
+                    WebViewSavePasswordEvent e) {
+                throw new RuntimeException("boom");
+            }
+        });
+        // Must not throw out of dispatch.
+        dispatcher.dispatchLoginSubmitted("https://example.com", b64("a"), b64("p"));
+        flushEdt();
+        Thread.sleep(50);
+        assertFalse(store.find("https://example.com").isPresent());
+        assertNotNull("exception should reach the uncaught handler", uncaught.get());
+    }
+
+    @Test public void nullStoreAndHandlerRestoreDefaults() {
+        dispatcher.setStore(null);
+        assertNotNull(dispatcher.getStore());
+        assertTrue(dispatcher.getStore() instanceof NativeCredentialStore);
+        dispatcher.setHandler(null);
+        assertSame(WebViewSavePasswordHandler.DEFAULT, dispatcher.getHandler());
+    }
+
+    @Test public void fillPushesEncodedCredentialViaEval() throws Exception {
+        store.save(new WebViewCredential("https://example.com", "alice", "s3cret"));
+        dispatcher.dispatchFillRequested("https://example.com/login");
+        String js = source.evalCalls.poll(3, TimeUnit.SECONDS);
+        assertNotNull("fill should eval a __webview_pw_fill__ call", js);
+        assertTrue(js.contains("__webview_pw_fill__"));
+        // The password must be base64url-encoded in the eval, never the literal.
+        assertFalse(js.contains("s3cret"));
+        assertTrue(js.contains(b64("s3cret")));
+    }
+
+    @Test public void fillWithNoCredentialDoesNotEval() throws Exception {
+        dispatcher.dispatchFillRequested("https://example.com/login");
+        String js = source.evalCalls.poll(300, TimeUnit.MILLISECONDS);
+        assertNull("no stored credential must not trigger eval", js);
+    }
+
+    @Test public void fillOnDifferentOriginIsExact() throws Exception {
+        store.save(new WebViewCredential("https://example.com", "alice", "s3cret"));
+        dispatcher.dispatchFillRequested("https://evil.com/login");
+        String js = source.evalCalls.poll(300, TimeUnit.MILLISECONDS);
+        assertNull("autofill must be origin-exact", js);
+    }
+
+    @Test public void unparseableFrameUrlDropped() throws Exception {
+        store.save(new WebViewCredential("https://example.com", "alice", "s3cret"));
+        dispatcher.dispatchFillRequested("about:blank");
+        String js = source.evalCalls.poll(300, TimeUnit.MILLISECONDS);
+        assertNull(js);
+    }
+
+    @Test public void eventToStringRedactsPassword() {
+        WebViewSavePasswordEvent e = new WebViewSavePasswordEvent(
+            source, "https://example.com", "alice", "s3cret");
+        assertFalse(e.toString().contains("s3cret"));
+        assertTrue(e.toString().contains("***"));
+    }
+}

--- a/test/ca/weblite/webview/PasswordDispatcherTest.java
+++ b/test/ca/weblite/webview/PasswordDispatcherTest.java
@@ -242,4 +242,126 @@ public class PasswordDispatcherTest {
         assertFalse(e.toString().contains("s3cret"));
         assertTrue(e.toString().contains("***"));
     }
+
+    // ---- STORY-006-004: autofill-consent handler ---------------------
+
+    @Test public void defaultFillHandlerFillsWithoutPrompt() throws Exception {
+        // No fill handler installed => DEFAULT => FILL (no regression).
+        store.save(new WebViewCredential("https://example.com", "alice", "s3cret"));
+        dispatcher.dispatchFillRequested("https://example.com/login");
+        String js = source.evalCalls.poll(3, TimeUnit.SECONDS);
+        assertNotNull("default fill handler must autofill", js);
+        assertTrue(js.contains("__webview_pw_fill__"));
+    }
+
+    @Test public void dontFillHandlerSuppressesAutofill() throws Exception {
+        store.save(new WebViewCredential("https://example.com", "alice", "s3cret"));
+        dispatcher.setFillHandler(new WebViewFillPasswordHandler() {
+            @Override public FillPasswordDisposition onAutofillRequested(
+                    WebViewFillPasswordEvent e) {
+                return FillPasswordDisposition.DONT_FILL;
+            }
+        });
+        dispatcher.dispatchFillRequested("https://example.com/login");
+        String js = source.evalCalls.poll(500, TimeUnit.MILLISECONDS);
+        assertNull("DONT_FILL must suppress autofill", js);
+    }
+
+    @Test public void fillEventCarriesIdentityNotPasswordAndRunsOnEdt()
+            throws Exception {
+        store.save(new WebViewCredential("https://example.com", "alice", "s3cret"));
+        final AtomicReference<WebViewFillPasswordEvent> seen =
+            new AtomicReference<WebViewFillPasswordEvent>();
+        final AtomicBoolean onEdt = new AtomicBoolean(false);
+        dispatcher.setFillHandler(new WebViewFillPasswordHandler() {
+            @Override public FillPasswordDisposition onAutofillRequested(
+                    WebViewFillPasswordEvent e) {
+                onEdt.set(SwingUtilities.isEventDispatchThread());
+                seen.set(e);
+                return FillPasswordDisposition.FILL;
+            }
+        });
+        dispatcher.dispatchFillRequested("https://example.com/login");
+        assertNotNull(source.evalCalls.poll(3, TimeUnit.SECONDS));
+        WebViewFillPasswordEvent e = seen.get();
+        assertNotNull(e);
+        assertEquals("https://example.com", e.origin());
+        assertEquals("alice", e.username());
+        // The event exposes no password: its toString cannot leak one.
+        assertFalse(e.toString().contains("s3cret"));
+        assertTrue("fill handler must run on the EDT", onEdt.get());
+    }
+
+    @Test public void fillHandlerExceptionIsolated() throws Exception {
+        store.save(new WebViewCredential("https://example.com", "alice", "s3cret"));
+        dispatcher.setFillHandler(new WebViewFillPasswordHandler() {
+            @Override public FillPasswordDisposition onAutofillRequested(
+                    WebViewFillPasswordEvent e) {
+                throw new RuntimeException("boom");
+            }
+        });
+        dispatcher.dispatchFillRequested("https://example.com/login");
+        String js = source.evalCalls.poll(500, TimeUnit.MILLISECONDS);
+        assertNull("a throwing fill handler must fill nothing", js);
+        assertTrue(awaitTrue(new java.util.concurrent.Callable<Boolean>() {
+            public Boolean call() { return uncaught.get() != null; }
+        }));
+    }
+
+    @Test public void nullFillHandlerRestoresDefault() {
+        assertNotNull(dispatcher.getFillHandler());
+        dispatcher.setFillHandler(new WebViewFillPasswordHandler() {
+            @Override public FillPasswordDisposition onAutofillRequested(
+                    WebViewFillPasswordEvent e) {
+                return FillPasswordDisposition.DONT_FILL;
+            }
+        });
+        dispatcher.setFillHandler(null);
+        assertSame(WebViewFillPasswordHandler.DEFAULT, dispatcher.getFillHandler());
+    }
+
+    @Test public void dontFillDoesNotGateProgrammaticRead() {
+        store.save(new WebViewCredential("https://example.com", "alice", "s3cret"));
+        dispatcher.setFillHandler(new WebViewFillPasswordHandler() {
+            @Override public FillPasswordDisposition onAutofillRequested(
+                    WebViewFillPasswordEvent e) {
+                return FillPasswordDisposition.DONT_FILL;
+            }
+        });
+        assertEquals("alice",
+            dispatcher.getCredential("https://example.com").get().username());
+    }
+
+    @Test public void disabledSuppressesFillBeforeHandler() throws Exception {
+        store.save(new WebViewCredential("https://example.com", "alice", "s3cret"));
+        final AtomicBoolean handlerCalled = new AtomicBoolean(false);
+        dispatcher.setFillHandler(new WebViewFillPasswordHandler() {
+            @Override public FillPasswordDisposition onAutofillRequested(
+                    WebViewFillPasswordEvent e) {
+                handlerCalled.set(true);
+                return FillPasswordDisposition.FILL;
+            }
+        });
+        dispatcher.setEnabled(false);
+        dispatcher.dispatchFillRequested("https://example.com/login");
+        flushEdt();
+        Thread.sleep(50);
+        assertTrue(source.evalCalls.isEmpty());
+        assertFalse("disabled manager must not consult the fill handler",
+            handlerCalled.get());
+    }
+
+    // ---- STORY-006-005: enumerate-all via the dispatcher --------------
+
+    @Test public void getAllCredentialsEnumeratesAcrossOrigins() {
+        store.save(new WebViewCredential("https://a.example", "alice", "pw1"));
+        store.save(new WebViewCredential("https://b.example", "bob", "pw2"));
+        store.save(new WebViewCredential("https://c.example", "carol", "pw3"));
+        java.util.List<WebViewCredential> all = dispatcher.getAllCredentials();
+        assertEquals(3, all.size());
+        // Most-recently-saved first.
+        assertEquals("carol", all.get(0).username());
+        assertEquals("bob", all.get(1).username());
+        assertEquals("alice", all.get(2).username());
+    }
 }

--- a/test/ca/weblite/webview/PasswordDispatcherTest.java
+++ b/test/ca/weblite/webview/PasswordDispatcherTest.java
@@ -243,6 +243,81 @@ public class PasswordDispatcherTest {
         assertTrue(e.toString().contains("***"));
     }
 
+    // ---- STORY-006-001 AC21/AC22: no re-prompt for unchanged creds ----
+
+    /** Let the io worker run, then the EDT, then the io worker again
+     *  (the save path hops io -> EDT -> io). */
+    private void settle() throws Exception {
+        Thread.sleep(80);
+        flushEdt();
+        Thread.sleep(80);
+        flushEdt();
+    }
+
+    @Test public void unchangedCredentialDoesNotReprompt() throws Exception {
+        store.save(new WebViewCredential("https://example.com", "alice", "s3cret"));
+        final java.util.concurrent.atomic.AtomicInteger calls =
+            new java.util.concurrent.atomic.AtomicInteger(0);
+        dispatcher.setHandler(new WebViewSavePasswordHandler() {
+            @Override public SavePasswordDisposition onLoginSubmitted(
+                    WebViewSavePasswordEvent e) {
+                calls.incrementAndGet();
+                return SavePasswordDisposition.SAVE;
+            }
+        });
+        // Same {origin, username, password} already stored (e.g. autofilled).
+        dispatcher.dispatchLoginSubmitted("https://example.com/login",
+            b64("alice"), b64("s3cret"));
+        settle();
+        assertEquals("unchanged credential must not invoke the save handler",
+            0, calls.get());
+        assertEquals("no duplicate stored", 1,
+            store.findAll("https://example.com").size());
+    }
+
+    @Test public void changedPasswordStillPrompts() throws Exception {
+        store.save(new WebViewCredential("https://example.com", "alice", "s3cret"));
+        dispatcher.setHandler(new WebViewSavePasswordHandler() {
+            @Override public SavePasswordDisposition onLoginSubmitted(
+                    WebViewSavePasswordEvent e) {
+                return SavePasswordDisposition.SAVE;
+            }
+        });
+        // Same username, DIFFERENT password -> should prompt and overwrite.
+        dispatcher.dispatchLoginSubmitted("https://example.com/login",
+            b64("alice"), b64("n3wpw"));
+        assertTrue(awaitTrue(new java.util.concurrent.Callable<Boolean>() {
+            public Boolean call() {
+                return "n3wpw".equals(
+                    store.find("https://example.com").get().password());
+            }
+        }));
+        assertEquals("still one credential for the username", 1,
+            store.findAll("https://example.com").size());
+    }
+
+    @Test public void newUsernameStillPrompts() throws Exception {
+        store.save(new WebViewCredential("https://example.com", "alice", "s3cret"));
+        dispatcher.setHandler(new WebViewSavePasswordHandler() {
+            @Override public SavePasswordDisposition onLoginSubmitted(
+                    WebViewSavePasswordEvent e) {
+                return SavePasswordDisposition.SAVE;
+            }
+        });
+        // A different username at the same origin -> should prompt and add.
+        dispatcher.dispatchLoginSubmitted("https://example.com/login",
+            b64("bob"), b64("bobpw"));
+        assertTrue(awaitTrue(new java.util.concurrent.Callable<Boolean>() {
+            public Boolean call() {
+                for (WebViewCredential c
+                        : store.findAll("https://example.com")) {
+                    if (c.username().equals("bob")) return true;
+                }
+                return false;
+            }
+        }));
+    }
+
     // ---- STORY-006-004: autofill-consent handler ---------------------
 
     @Test public void defaultFillHandlerFillsWithoutPrompt() throws Exception {

--- a/test/ca/weblite/webview/WebViewCredentialTest.java
+++ b/test/ca/weblite/webview/WebViewCredentialTest.java
@@ -1,0 +1,53 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/** Unit tests for {@link WebViewCredential}. */
+public class WebViewCredentialTest {
+
+    @Test public void accessors() {
+        WebViewCredential c =
+            new WebViewCredential("https://example.com", "alice", "s3cret");
+        assertEquals("https://example.com", c.origin());
+        assertEquals("alice", c.username());
+        assertEquals("s3cret", c.password());
+    }
+
+    @Test public void nullArgsRejected() {
+        try { new WebViewCredential(null, "u", "p"); fail(); }
+        catch (NullPointerException e) { assertEquals("origin", e.getMessage()); }
+        try { new WebViewCredential("o", null, "p"); fail(); }
+        catch (NullPointerException e) { assertEquals("username", e.getMessage()); }
+        try { new WebViewCredential("o", "u", null); fail(); }
+        catch (NullPointerException e) { assertEquals("password", e.getMessage()); }
+    }
+
+    @Test public void equalityIgnoresPassword() {
+        WebViewCredential a = new WebViewCredential("https://x.com", "alice", "p1");
+        WebViewCredential b = new WebViewCredential("https://x.com", "alice", "p2");
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        WebViewCredential c = new WebViewCredential("https://x.com", "bob", "p1");
+        assertNotEquals(a, c);
+    }
+
+    @Test public void toStringRedactsPassword() {
+        WebViewCredential c =
+            new WebViewCredential("https://example.com", "alice", "s3cret");
+        String s = c.toString();
+        assertFalse("password must not appear in toString", s.contains("s3cret"));
+        assertTrue(s.contains("alice"));
+        assertTrue(s.contains("***"));
+    }
+}

--- a/windows/script/build.bat
+++ b/windows/script/build.bat
@@ -38,6 +38,7 @@ cl /D "WEBVIEW_API=__declspec(dllexport)" ^
 	/I "%src_dir%\script\Microsoft.Web.WebView2.0.8.355\build\native\include" ^
 	"%src_dir%\script\Microsoft.Web.WebView2.0.8.355\build\native\x86\WebView2Loader.dll.lib" ^
 	"%JAVA_HOME%\lib\jawt.lib" ^
+	Advapi32.lib ^
 	/std:c++17 /EHsc "/Fo%build_dir%"\ ^
 	"%src_dir%\webview.cc" "%src_dir%\webview_embed.cc" ^
 	/link /DLL "/OUT:%build_dir%\webview.dll"
@@ -53,6 +54,7 @@ cl /D "WEBVIEW_API=__declspec(dllexport)" ^
 	/I "%src_dir%\script\Microsoft.Web.WebView2.0.8.355\build\native\include" ^
 	"%src_dir%\script\Microsoft.Web.WebView2.0.8.355\build\native\x64\WebView2Loader.dll.lib" ^
 	"%JAVA_HOME%\lib\jawt.lib" ^
+	Advapi32.lib ^
 	/std:c++17 /EHsc "/Fo%build_dir%"\ ^
 	"%src_dir%\webview.cc" "%src_dir%\webview_embed.cc" ^
 	/link /DLL "/OUT:%build_dir%\webview.dll"

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -3456,6 +3456,63 @@ JNIEXPORT jobjectArray JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cr
     return out;
 }
 
+JNIEXPORT jobjectArray JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1store_1find_1all
+  (JNIEnv *env, jclass, jstring jservice) {
+    jclass strCls = env->FindClass("java/lang/String");
+    const char *service = env->GetStringUTFChars(jservice, nullptr);
+    std::string svc = service ? service : "";
+    std::string prefix = svc + ":";
+    std::wstring filterW = embed_win::utf8_to_wide((svc + ":*").c_str());
+
+    // Enumerate-all: same CredEnumerateW over the namespace prefix as find,
+    // but with no origin filter — every entry is kept and its origin emitted.
+    std::vector<std::string> quads;
+    DWORD count = 0;
+    PCREDENTIALW *creds = nullptr;
+    if (CredEnumerateW(filterW.c_str(), 0, &count, &creds) && creds) {
+        for (DWORD i = 0; i < count; i++) {
+            PCREDENTIALW c = creds[i];
+            if (!c || !c->TargetName) continue;
+            std::string name = embed_win::wide_to_utf8(c->TargetName);
+            if (name.rfind(prefix, 0) != 0) continue;
+            std::string rest = name.substr(prefix.size());
+            size_t bar = rest.find('|');
+            if (bar == std::string::npos) continue;
+            std::string origin_dec, user_dec;
+            if (!embed_win::pw_b64url_decode(rest.substr(0, bar), origin_dec)) continue;
+            if (!embed_win::pw_b64url_decode(rest.substr(bar + 1), user_dec)) continue;
+            std::string blob;
+            if (c->CredentialBlob && c->CredentialBlobSize > 0) {
+                blob.assign((const char *)c->CredentialBlob,
+                            (size_t)c->CredentialBlobSize);
+            }
+            std::string millisStr = "0", password;
+            size_t nl = blob.find('\n');
+            if (nl != std::string::npos) {
+                millisStr = blob.substr(0, nl);
+                password = blob.substr(nl + 1);
+            } else {
+                password = blob;
+            }
+            quads.push_back(origin_dec);
+            quads.push_back(user_dec);
+            quads.push_back(millisStr);
+            quads.push_back(password);
+        }
+        CredFree(creds);
+    }
+    if (service) env->ReleaseStringUTFChars(jservice, service);
+
+    jobjectArray out =
+        env->NewObjectArray((jsize)quads.size(), strCls, nullptr);
+    for (size_t i = 0; i < quads.size(); i++) {
+        jstring js = env->NewStringUTF(quads[i].c_str());
+        env->SetObjectArrayElement(out, (jsize)i, js);
+        env->DeleteLocalRef(js);
+    }
+    return out;
+}
+
 JNIEXPORT jboolean JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1store_1delete
   (JNIEnv *env, jclass, jstring jservice, jstring jorigin, jstring juser) {
     const char *service = env->GetStringUTFChars(jservice, nullptr);

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -168,6 +168,11 @@ struct Engine {
     std::mutex downloads_mutex;
     std::map<ICoreWebView2DownloadOperation *, struct WinDownloadCtx *> downloads;
 
+    // JNI global ref to the registered WebViewPasswordCallback, or nullptr.
+    // Stored here on Windows (Canvas 23); Canvas 25 wires the __webview_pw__
+    // branch of the WebMessageReceived handler off this field.
+    jobject password_callback = nullptr;
+
     // JNI global ref to the registered WebViewPopupCallback, or nullptr —
     // Canvas 15.  Stored here on Windows; the follow-up Windows coverage
     // canvas wires ICoreWebView2::add_NewWindowRequested off this field
@@ -3109,6 +3114,53 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
     // Windows has no offscreen engine; OffscreenWebView.create returns
     // null on Windows so this JNI bridge should never be reached.
     // Stub it for link-symmetry across all three native binaries.
+}
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1password_1callback
+  (JNIEnv *env, jclass, jlong wv, jobject cb) {
+    // Canvas 23 ships the callback storage on Windows; Canvas 25 wires the
+    // __webview_pw__ branch of the WebMessageReceived handler off this
+    // field plus the Credential Manager store.  Until then storing the ref
+    // is a harmless no-op.
+    auto *e = (Engine *)wv;
+    if (!e) return;
+    if (e->password_callback) {
+        env->DeleteGlobalRef(e->password_callback);
+        e->password_callback = nullptr;
+    }
+    if (cb) {
+        e->password_callback = env->NewGlobalRef(cb);
+    }
+}
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1set_1password_1callback
+  (JNIEnv *, jclass, jlong, jobject) {
+    // Windows has no offscreen engine; stub for link-symmetry.
+}
+
+// Credential store primitives — Canvas 25 implements these against the
+// Windows Credential Manager (CredWrite/CredRead/CredEnumerate/CredDelete).
+// Until then they are graceful stubs; NativeCredentialStore treats a false /
+// empty result as "unavailable" and degrades to a no-op.
+JNIEXPORT jboolean JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1store_1save
+  (JNIEnv *, jclass, jstring, jstring, jstring, jstring, jlong) {
+    return JNI_FALSE;
+}
+
+JNIEXPORT jobjectArray JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1store_1find
+  (JNIEnv *env, jclass, jstring, jstring) {
+    jclass strCls = env->FindClass("java/lang/String");
+    return env->NewObjectArray(0, strCls, nullptr);
+}
+
+JNIEXPORT jboolean JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1store_1delete
+  (JNIEnv *, jclass, jstring, jstring, jstring) {
+    return JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1store_1available
+  (JNIEnv *, jclass) {
+    return JNI_FALSE;
 }
 
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1popup_1callback

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -2918,6 +2918,63 @@ static Engine *adopt_retained_popup(JNIEnv *env, HWND parent, RetainedPopup *rp,
     return e;
 }
 
+// Standard base64url (no padding) over raw bytes -- used to build a
+// delimiter-safe Credential Manager TargetName in the password store
+// (Canvas 28).
+static std::string pw_b64url_encode(const std::string &in) {
+    static const char *T =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    std::string out;
+    out.reserve(((in.size() + 2) / 3) * 4);
+    size_t i = 0;
+    for (; i + 2 < in.size(); i += 3) {
+        unsigned n = ((unsigned char)in[i] << 16)
+                   | ((unsigned char)in[i + 1] << 8)
+                   | ((unsigned char)in[i + 2]);
+        out.push_back(T[(n >> 18) & 63]);
+        out.push_back(T[(n >> 12) & 63]);
+        out.push_back(T[(n >> 6) & 63]);
+        out.push_back(T[n & 63]);
+    }
+    size_t rem = in.size() - i;
+    if (rem == 1) {
+        unsigned n = ((unsigned char)in[i] << 16);
+        out.push_back(T[(n >> 18) & 63]);
+        out.push_back(T[(n >> 12) & 63]);
+    } else if (rem == 2) {
+        unsigned n = ((unsigned char)in[i] << 16)
+                   | ((unsigned char)in[i + 1] << 8);
+        out.push_back(T[(n >> 18) & 63]);
+        out.push_back(T[(n >> 12) & 63]);
+        out.push_back(T[(n >> 6) & 63]);
+    }
+    return out;
+}
+
+static bool pw_b64url_decode(const std::string &in, std::string &out) {
+    auto val = [](char c) -> int {
+        if (c >= 'A' && c <= 'Z') return c - 'A';
+        if (c >= 'a' && c <= 'z') return c - 'a' + 26;
+        if (c >= '0' && c <= '9') return c - '0' + 52;
+        if (c == '-') return 62;
+        if (c == '_') return 63;
+        return -1;
+    };
+    out.clear();
+    int buf = 0, bits = 0;
+    for (char c : in) {
+        int v = val(c);
+        if (v < 0) return false;
+        buf = (buf << 6) | v;
+        bits += 6;
+        if (bits >= 8) {
+            bits -= 8;
+            out.push_back((char)((buf >> bits) & 0xFF));
+        }
+    }
+    return true;
+}
+
 } // namespace embed_win
 
 // ---------------------------------------------------------------------------
@@ -3305,62 +3362,8 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
 // (origin and username are base64url-encoded so the '|' delimiter and any
 // URL characters are unambiguous), and whose CredentialBlob is UTF-8
 // "<savedAtMillis>\n<password>".  b64url keeps TargetName a valid,
-// delimiter-safe wide string.
-
-// Standard base64url (no padding) over raw bytes.
-static std::string pw_b64url_encode(const std::string &in) {
-    static const char *T =
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
-    std::string out;
-    out.reserve(((in.size() + 2) / 3) * 4);
-    size_t i = 0;
-    for (; i + 2 < in.size(); i += 3) {
-        unsigned n = ((unsigned char)in[i] << 16)
-                   | ((unsigned char)in[i + 1] << 8)
-                   | ((unsigned char)in[i + 2]);
-        out.push_back(T[(n >> 18) & 63]);
-        out.push_back(T[(n >> 12) & 63]);
-        out.push_back(T[(n >> 6) & 63]);
-        out.push_back(T[n & 63]);
-    }
-    size_t rem = in.size() - i;
-    if (rem == 1) {
-        unsigned n = ((unsigned char)in[i] << 16);
-        out.push_back(T[(n >> 18) & 63]);
-        out.push_back(T[(n >> 12) & 63]);
-    } else if (rem == 2) {
-        unsigned n = ((unsigned char)in[i] << 16)
-                   | ((unsigned char)in[i + 1] << 8);
-        out.push_back(T[(n >> 18) & 63]);
-        out.push_back(T[(n >> 12) & 63]);
-        out.push_back(T[(n >> 6) & 63]);
-    }
-    return out;
-}
-
-static bool pw_b64url_decode(const std::string &in, std::string &out) {
-    auto val = [](char c) -> int {
-        if (c >= 'A' && c <= 'Z') return c - 'A';
-        if (c >= 'a' && c <= 'z') return c - 'a' + 26;
-        if (c >= '0' && c <= '9') return c - '0' + 52;
-        if (c == '-') return 62;
-        if (c == '_') return 63;
-        return -1;
-    };
-    out.clear();
-    int buf = 0, bits = 0;
-    for (char c : in) {
-        int v = val(c);
-        if (v < 0) return false;
-        buf = (buf << 6) | v;
-        bits += 6;
-        if (bits >= 8) {
-            bits -= 8;
-            out.push_back((char)((buf >> bits) & 0xFF));
-        }
-    }
-    return true;
-}
+// delimiter-safe wide string.  The base64url helpers live in namespace
+// embed_win (above); reference them qualified from this extern "C" block.
 
 JNIEXPORT jboolean JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1store_1save
   (JNIEnv *env, jclass, jstring jservice, jstring jorigin, jstring juser,
@@ -3370,12 +3373,12 @@ JNIEXPORT jboolean JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1
     const char *user = env->GetStringUTFChars(juser, nullptr);
     const char *pass = env->GetStringUTFChars(jpass, nullptr);
     std::string target = std::string(service ? service : "") + ":"
-        + pw_b64url_encode(origin ? origin : "") + "|"
-        + pw_b64url_encode(user ? user : "");
+        + embed_win::pw_b64url_encode(origin ? origin : "") + "|"
+        + embed_win::pw_b64url_encode(user ? user : "");
     std::string blob = std::to_string((long long)millis) + "\n"
         + (pass ? pass : "");
-    std::wstring targetW = utf8_to_wide(target.c_str());
-    std::wstring userW = utf8_to_wide(user ? user : "");
+    std::wstring targetW = embed_win::utf8_to_wide(target.c_str());
+    std::wstring userW = embed_win::utf8_to_wide(user ? user : "");
 
     CREDENTIALW cred = {};
     cred.Type = CRED_TYPE_GENERIC;
@@ -3403,7 +3406,7 @@ JNIEXPORT jobjectArray JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cr
     std::string svc = service ? service : "";
     std::string targetOrigin = origin ? origin : "";
     std::string prefix = svc + ":";
-    std::wstring filterW = utf8_to_wide((svc + ":*").c_str());
+    std::wstring filterW = embed_win::utf8_to_wide((svc + ":*").c_str());
 
     std::vector<std::string> triples;
     DWORD count = 0;
@@ -3412,14 +3415,14 @@ JNIEXPORT jobjectArray JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cr
         for (DWORD i = 0; i < count; i++) {
             PCREDENTIALW c = creds[i];
             if (!c || !c->TargetName) continue;
-            std::string name = wide_to_utf8(c->TargetName);
+            std::string name = embed_win::wide_to_utf8(c->TargetName);
             if (name.rfind(prefix, 0) != 0) continue;
             std::string rest = name.substr(prefix.size());
             size_t bar = rest.find('|');
             if (bar == std::string::npos) continue;
             std::string origin_dec, user_dec;
-            if (!pw_b64url_decode(rest.substr(0, bar), origin_dec)) continue;
-            if (!pw_b64url_decode(rest.substr(bar + 1), user_dec)) continue;
+            if (!embed_win::pw_b64url_decode(rest.substr(0, bar), origin_dec)) continue;
+            if (!embed_win::pw_b64url_decode(rest.substr(bar + 1), user_dec)) continue;
             if (origin_dec != targetOrigin) continue;
             std::string blob;
             if (c->CredentialBlob && c->CredentialBlobSize > 0) {
@@ -3459,9 +3462,9 @@ JNIEXPORT jboolean JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1
     const char *origin = env->GetStringUTFChars(jorigin, nullptr);
     const char *user = env->GetStringUTFChars(juser, nullptr);
     std::string target = std::string(service ? service : "") + ":"
-        + pw_b64url_encode(origin ? origin : "") + "|"
-        + pw_b64url_encode(user ? user : "");
-    std::wstring targetW = utf8_to_wide(target.c_str());
+        + embed_win::pw_b64url_encode(origin ? origin : "") + "|"
+        + embed_win::pw_b64url_encode(user ? user : "");
+    std::wstring targetW = embed_win::utf8_to_wide(target.c_str());
     BOOL ok = CredDeleteW(targetW.c_str(), CRED_TYPE_GENERIC, 0);
     if (service) env->ReleaseStringUTFChars(jservice, service);
     if (origin) env->ReleaseStringUTFChars(jorigin, origin);

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -18,6 +18,9 @@
 // WIN32_LEAN_AND_MEAN excludes objbase.h, which defines `interface` (=struct)
 // used pervasively by WebView2.h's COM declarations.  Pull it in explicitly.
 #include <objbase.h>
+// Windows Credential Manager (CredWriteW / CredReadW / CredEnumerateW /
+// CredDeleteW / CredFree) for the password-manager secret store (Canvas 28).
+#include <wincred.h>
 
 #include <atomic>
 #include <cstdio>
@@ -447,6 +450,89 @@ static char *fire_dialog_prompt(JavaVM *jvm, jobject callback,
     return result;  // caller owns; free with free()
 }
 
+// Password-manager fire helpers (Canvas 28) -- mirror the fire_dialog_*
+// shape.  Both target methods are void and non-blocking on the Java side
+// (PasswordDispatcher marshals the save prompt to the EDT via invokeLater
+// and runs store I/O on a worker), so unlike the dialog confirm/prompt
+// path these may be called directly from the WebMessageReceived worker
+// without a deferral.  The username / password arrive already base64url
+// encoded and are passed through verbatim; Java decodes them.  No-op when
+// the callback global ref is null.
+static void fire_password_submitted(JavaVM *jvm, jobject callback,
+                                    const char *frameUrl,
+                                    const char *b64user,
+                                    const char *b64pass) {
+    if (!jvm || !callback) return;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK
+                || !env) {
+            return;
+        }
+        detach = true;
+    }
+    if (!env) {
+        if (detach) jvm->DetachCurrentThread();
+        return;
+    }
+    jstring jframe = env->NewStringUTF(frameUrl ? frameUrl : "");
+    jstring juser = env->NewStringUTF(b64user ? b64user : "");
+    jstring jpass = env->NewStringUTF(b64pass ? b64pass : "");
+    jclass cls = env->GetObjectClass(callback);
+    if (cls) {
+        jmethodID m = env->GetMethodID(
+            cls, "onLoginSubmitted",
+            "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+        if (m) {
+            env->CallVoidMethod(callback, m, jframe, juser, jpass);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (jframe) env->DeleteLocalRef(jframe);
+    if (juser) env->DeleteLocalRef(juser);
+    if (jpass) env->DeleteLocalRef(jpass);
+    if (detach) jvm->DetachCurrentThread();
+}
+
+static void fire_password_fill_requested(JavaVM *jvm, jobject callback,
+                                         const char *frameUrl) {
+    if (!jvm || !callback) return;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK
+                || !env) {
+            return;
+        }
+        detach = true;
+    }
+    if (!env) {
+        if (detach) jvm->DetachCurrentThread();
+        return;
+    }
+    jstring jframe = env->NewStringUTF(frameUrl ? frameUrl : "");
+    jclass cls = env->GetObjectClass(callback);
+    if (cls) {
+        jmethodID m = env->GetMethodID(cls, "onFillRequested",
+                                       "(Ljava/lang/String;)V");
+        if (m) {
+            env->CallVoidMethod(callback, m, jframe);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            }
+        }
+        env->DeleteLocalRef(cls);
+    }
+    if (jframe) env->DeleteLocalRef(jframe);
+    if (detach) jvm->DetachCurrentThread();
+}
+
 // IUnknown helper -- gives each WebView2 callback proper refcounting and
 // QueryInterface support.  The interfaces we implement are all single-
 // inheritance (Iface : IUnknown), so a templated base keeps boilerplate low.
@@ -549,6 +635,53 @@ public:
             args->get_WebMessageAsJson(&msg);
         }
         if (msg) {
+            // Password-manager channel (Canvas 28): the shared SHIM_JS posts
+            // `__webview_pw__:<payload>` on the single WebView2 message
+            // channel.  Demux by content -- a `__webview_pw__:` prefix is a
+            // login-submission ("S|b64user|b64pass") or fill-request ("F")
+            // and is routed to the password callback; everything else falls
+            // through to the normal bind dispatch.
+            std::string full = wide_to_utf8(msg);
+            static const std::string PW_PREFIX = "__webview_pw__:";
+            if (full.rfind(PW_PREFIX, 0) == 0) {
+                std::string payload = full.substr(PW_PREFIX.size());
+                // Committed source URL, read natively (the trusted origin).
+                std::string src;
+                LPWSTR src_w = nullptr;
+                if (SUCCEEDED(args->get_Source(&src_w)) && src_w) {
+                    src = wide_to_utf8(src_w);
+                    CoTaskMemFree(src_w);
+                } else if (m_engine && m_engine->webview) {
+                    LPWSTR page_w = nullptr;
+                    if (SUCCEEDED(m_engine->webview->get_Source(&page_w))
+                            && page_w) {
+                        src = wide_to_utf8(page_w);
+                        CoTaskMemFree(page_w);
+                    }
+                }
+                JavaVM *jvm = m_engine ? m_engine->jvm : nullptr;
+                jobject cb = m_engine ? m_engine->password_callback : nullptr;
+                if (cb && !payload.empty()) {
+                    if (payload[0] == 'S') {
+                        // S|b64user|b64pass -- the base64url fields never
+                        // contain '|', so a plain split is unambiguous.
+                        std::string rest = payload.substr(1);
+                        if (!rest.empty() && rest[0] == '|') rest = rest.substr(1);
+                        size_t bar = rest.find('|');
+                        std::string b64user = (bar == std::string::npos)
+                            ? rest : rest.substr(0, bar);
+                        std::string b64pass = (bar == std::string::npos)
+                            ? std::string() : rest.substr(bar + 1);
+                        fire_password_submitted(jvm, cb, src.c_str(),
+                                                b64user.c_str(),
+                                                b64pass.c_str());
+                    } else if (payload[0] == 'F') {
+                        fire_password_fill_requested(jvm, cb, src.c_str());
+                    }
+                }
+                CoTaskMemFree(msg);
+                return S_OK;
+            }
             engine_on_message(m_engine, msg);
             CoTaskMemFree(msg);
         }
@@ -2282,6 +2415,18 @@ static void engine_thread(Engine *e, HWND /*parent*/, int width, int height,
                         // the ScriptDialogHandler registered below.
                         // STORY-004-003.
                         settings->put_AreDefaultScriptDialogsEnabled(FALSE);
+                        // Disable Edge's built-in "save password?" autosave so
+                        // it does not compete with this library's own manager
+                        // (Canvas 28).  Guarded: a Runtime without
+                        // ICoreWebView2Settings4 is a silent no-op.
+                        ICoreWebView2Settings4 *settings4 = nullptr;
+                        if (SUCCEEDED(settings->QueryInterface(
+                                __uuidof(ICoreWebView2Settings4),
+                                reinterpret_cast<void **>(&settings4)))
+                                && settings4) {
+                            settings4->put_IsPasswordAutosaveEnabled(FALSE);
+                            settings4->Release();
+                        }
                         settings->Release();
                     }
 
@@ -2544,6 +2689,20 @@ static void destroy_engine(Engine *e) {
         }
         if (env) env->DeleteGlobalRef(e->dialog_callback);
         e->dialog_callback = nullptr;
+        if (detach) e->jvm->DetachCurrentThread();
+    }
+    // Symmetric cleanup for the password callback global ref (Canvas 28).
+    // The WebMessageReceived handler fires off this field, so clear it
+    // before the worker thread tears down.
+    if (e->password_callback) {
+        JNIEnv *env = nullptr;
+        bool detach = false;
+        if (e->jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+            e->jvm->AttachCurrentThread((void **)&env, nullptr);
+            detach = true;
+        }
+        if (env) env->DeleteGlobalRef(e->password_callback);
+        e->password_callback = nullptr;
         if (detach) e->jvm->DetachCurrentThread();
     }
     // Symmetric cleanup for the download callback global ref (Canvas 25),
@@ -3118,10 +3277,10 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
 
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1password_1callback
   (JNIEnv *env, jclass, jlong wv, jobject cb) {
-    // Canvas 26 ships the callback storage on Windows; Canvas 28 wires the
-    // __webview_pw__ branch of the WebMessageReceived handler off this
-    // field plus the Credential Manager store.  Until then storing the ref
-    // is a harmless no-op.
+    // Stores the WebViewPasswordCallback global ref that the
+    // __webview_pw__ branch of the WebMessageReceived handler fires off
+    // (Canvas 28).  Cleared here on replacement and in the engine destroy
+    // path.
     auto *e = (Engine *)wv;
     if (!e) return;
     if (e->password_callback) {
@@ -3138,29 +3297,181 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
     // Windows has no offscreen engine; stub for link-symmetry.
 }
 
-// Credential store primitives — Canvas 28 implements these against the
-// Windows Credential Manager (CredWrite/CredRead/CredEnumerate/CredDelete).
-// Until then they are graceful stubs; NativeCredentialStore treats a false /
-// empty result as "unavailable" and degrades to a no-op.
+// Credential store primitives — Canvas 28, backed by the Windows
+// Credential Manager (CredWriteW / CredEnumerateW / CredDeleteW).
+//
+// Each record is a CRED_TYPE_GENERIC credential whose TargetName is
+//   "<service>:" + b64url(origin) + "|" + b64url(username)
+// (origin and username are base64url-encoded so the '|' delimiter and any
+// URL characters are unambiguous), and whose CredentialBlob is UTF-8
+// "<savedAtMillis>\n<password>".  b64url keeps TargetName a valid,
+// delimiter-safe wide string.
+
+// Standard base64url (no padding) over raw bytes.
+static std::string pw_b64url_encode(const std::string &in) {
+    static const char *T =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    std::string out;
+    out.reserve(((in.size() + 2) / 3) * 4);
+    size_t i = 0;
+    for (; i + 2 < in.size(); i += 3) {
+        unsigned n = ((unsigned char)in[i] << 16)
+                   | ((unsigned char)in[i + 1] << 8)
+                   | ((unsigned char)in[i + 2]);
+        out.push_back(T[(n >> 18) & 63]);
+        out.push_back(T[(n >> 12) & 63]);
+        out.push_back(T[(n >> 6) & 63]);
+        out.push_back(T[n & 63]);
+    }
+    size_t rem = in.size() - i;
+    if (rem == 1) {
+        unsigned n = ((unsigned char)in[i] << 16);
+        out.push_back(T[(n >> 18) & 63]);
+        out.push_back(T[(n >> 12) & 63]);
+    } else if (rem == 2) {
+        unsigned n = ((unsigned char)in[i] << 16)
+                   | ((unsigned char)in[i + 1] << 8);
+        out.push_back(T[(n >> 18) & 63]);
+        out.push_back(T[(n >> 12) & 63]);
+        out.push_back(T[(n >> 6) & 63]);
+    }
+    return out;
+}
+
+static bool pw_b64url_decode(const std::string &in, std::string &out) {
+    auto val = [](char c) -> int {
+        if (c >= 'A' && c <= 'Z') return c - 'A';
+        if (c >= 'a' && c <= 'z') return c - 'a' + 26;
+        if (c >= '0' && c <= '9') return c - '0' + 52;
+        if (c == '-') return 62;
+        if (c == '_') return 63;
+        return -1;
+    };
+    out.clear();
+    int buf = 0, bits = 0;
+    for (char c : in) {
+        int v = val(c);
+        if (v < 0) return false;
+        buf = (buf << 6) | v;
+        bits += 6;
+        if (bits >= 8) {
+            bits -= 8;
+            out.push_back((char)((buf >> bits) & 0xFF));
+        }
+    }
+    return true;
+}
+
 JNIEXPORT jboolean JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1store_1save
-  (JNIEnv *, jclass, jstring, jstring, jstring, jstring, jlong) {
-    return JNI_FALSE;
+  (JNIEnv *env, jclass, jstring jservice, jstring jorigin, jstring juser,
+   jstring jpass, jlong millis) {
+    const char *service = env->GetStringUTFChars(jservice, nullptr);
+    const char *origin = env->GetStringUTFChars(jorigin, nullptr);
+    const char *user = env->GetStringUTFChars(juser, nullptr);
+    const char *pass = env->GetStringUTFChars(jpass, nullptr);
+    std::string target = std::string(service ? service : "") + ":"
+        + pw_b64url_encode(origin ? origin : "") + "|"
+        + pw_b64url_encode(user ? user : "");
+    std::string blob = std::to_string((long long)millis) + "\n"
+        + (pass ? pass : "");
+    std::wstring targetW = utf8_to_wide(target.c_str());
+    std::wstring userW = utf8_to_wide(user ? user : "");
+
+    CREDENTIALW cred = {};
+    cred.Type = CRED_TYPE_GENERIC;
+    cred.TargetName = const_cast<LPWSTR>(targetW.c_str());
+    cred.CredentialBlobSize = (DWORD)blob.size();
+    cred.CredentialBlob = (LPBYTE)blob.data();
+    cred.Persist = CRED_PERSIST_LOCAL_MACHINE;
+    cred.UserName = const_cast<LPWSTR>(userW.c_str());
+    BOOL ok = CredWriteW(&cred, 0);
+    // Do not leave the plaintext password lingering in this buffer.
+    if (!blob.empty()) SecureZeroMemory(&blob[0], blob.size());
+
+    if (service) env->ReleaseStringUTFChars(jservice, service);
+    if (origin) env->ReleaseStringUTFChars(jorigin, origin);
+    if (user) env->ReleaseStringUTFChars(juser, user);
+    if (pass) env->ReleaseStringUTFChars(jpass, pass);
+    return ok ? JNI_TRUE : JNI_FALSE;
 }
 
 JNIEXPORT jobjectArray JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1store_1find
-  (JNIEnv *env, jclass, jstring, jstring) {
+  (JNIEnv *env, jclass, jstring jservice, jstring jorigin) {
     jclass strCls = env->FindClass("java/lang/String");
-    return env->NewObjectArray(0, strCls, nullptr);
+    const char *service = env->GetStringUTFChars(jservice, nullptr);
+    const char *origin = env->GetStringUTFChars(jorigin, nullptr);
+    std::string svc = service ? service : "";
+    std::string targetOrigin = origin ? origin : "";
+    std::string prefix = svc + ":";
+    std::wstring filterW = utf8_to_wide((svc + ":*").c_str());
+
+    std::vector<std::string> triples;
+    DWORD count = 0;
+    PCREDENTIALW *creds = nullptr;
+    if (CredEnumerateW(filterW.c_str(), 0, &count, &creds) && creds) {
+        for (DWORD i = 0; i < count; i++) {
+            PCREDENTIALW c = creds[i];
+            if (!c || !c->TargetName) continue;
+            std::string name = wide_to_utf8(c->TargetName);
+            if (name.rfind(prefix, 0) != 0) continue;
+            std::string rest = name.substr(prefix.size());
+            size_t bar = rest.find('|');
+            if (bar == std::string::npos) continue;
+            std::string origin_dec, user_dec;
+            if (!pw_b64url_decode(rest.substr(0, bar), origin_dec)) continue;
+            if (!pw_b64url_decode(rest.substr(bar + 1), user_dec)) continue;
+            if (origin_dec != targetOrigin) continue;
+            std::string blob;
+            if (c->CredentialBlob && c->CredentialBlobSize > 0) {
+                blob.assign((const char *)c->CredentialBlob,
+                            (size_t)c->CredentialBlobSize);
+            }
+            std::string millisStr = "0", password;
+            size_t nl = blob.find('\n');
+            if (nl != std::string::npos) {
+                millisStr = blob.substr(0, nl);
+                password = blob.substr(nl + 1);
+            } else {
+                password = blob;
+            }
+            triples.push_back(user_dec);
+            triples.push_back(millisStr);
+            triples.push_back(password);
+        }
+        CredFree(creds);
+    }
+    if (service) env->ReleaseStringUTFChars(jservice, service);
+    if (origin) env->ReleaseStringUTFChars(jorigin, origin);
+
+    jobjectArray out =
+        env->NewObjectArray((jsize)triples.size(), strCls, nullptr);
+    for (size_t i = 0; i < triples.size(); i++) {
+        jstring js = env->NewStringUTF(triples[i].c_str());
+        env->SetObjectArrayElement(out, (jsize)i, js);
+        env->DeleteLocalRef(js);
+    }
+    return out;
 }
 
 JNIEXPORT jboolean JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1store_1delete
-  (JNIEnv *, jclass, jstring, jstring, jstring) {
-    return JNI_FALSE;
+  (JNIEnv *env, jclass, jstring jservice, jstring jorigin, jstring juser) {
+    const char *service = env->GetStringUTFChars(jservice, nullptr);
+    const char *origin = env->GetStringUTFChars(jorigin, nullptr);
+    const char *user = env->GetStringUTFChars(juser, nullptr);
+    std::string target = std::string(service ? service : "") + ":"
+        + pw_b64url_encode(origin ? origin : "") + "|"
+        + pw_b64url_encode(user ? user : "");
+    std::wstring targetW = utf8_to_wide(target.c_str());
+    BOOL ok = CredDeleteW(targetW.c_str(), CRED_TYPE_GENERIC, 0);
+    if (service) env->ReleaseStringUTFChars(jservice, service);
+    if (origin) env->ReleaseStringUTFChars(jorigin, origin);
+    if (user) env->ReleaseStringUTFChars(juser, user);
+    return ok ? JNI_TRUE : JNI_FALSE;
 }
 
 JNIEXPORT jboolean JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1store_1available
   (JNIEnv *, jclass) {
-    return JNI_FALSE;
+    return JNI_TRUE;
 }
 
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1popup_1callback

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -169,7 +169,7 @@ struct Engine {
     std::map<ICoreWebView2DownloadOperation *, struct WinDownloadCtx *> downloads;
 
     // JNI global ref to the registered WebViewPasswordCallback, or nullptr.
-    // Stored here on Windows (Canvas 23); Canvas 25 wires the __webview_pw__
+    // Stored here on Windows (Canvas 26); Canvas 28 wires the __webview_pw__
     // branch of the WebMessageReceived handler off this field.
     jobject password_callback = nullptr;
 
@@ -3118,7 +3118,7 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
 
 JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1password_1callback
   (JNIEnv *env, jclass, jlong wv, jobject cb) {
-    // Canvas 23 ships the callback storage on Windows; Canvas 25 wires the
+    // Canvas 26 ships the callback storage on Windows; Canvas 28 wires the
     // __webview_pw__ branch of the WebMessageReceived handler off this
     // field plus the Credential Manager store.  Until then storing the ref
     // is a harmless no-op.
@@ -3138,7 +3138,7 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
     // Windows has no offscreen engine; stub for link-symmetry.
 }
 
-// Credential store primitives — Canvas 25 implements these against the
+// Credential store primitives — Canvas 28 implements these against the
 // Windows Credential Manager (CredWrite/CredRead/CredEnumerate/CredDelete).
 // Until then they are graceful stubs; NativeCredentialStore treats a false /
 // empty result as "unavailable" and degrades to a no-op.


### PR DESCRIPTION
## What & why

The embedded engines (`WKWebView`, `WebKitGTK`, `WebView2`) deliberately withhold the browser "offer to save this password / autofill it next time" experience from third-party host apps. Concretely, logging into an Okta page inside `WebViewComponent` on macOS forces the user to retype the full password every time, even though Safari and Chrome autofill it.

This PR builds the library's **own** browser-grade password manager:

- **Save** — injected JS watches login-form submissions, and the library pops a Swing "Save password?" prompt (browser-style). On approval the credential is written to the **OS-native secret store**.
- **Autofill on load** — on page load, if a credential exists for the page origin, the username + password are injected into the detected login fields automatically.
- **OS-native storage** — macOS Keychain (this release); Linux libsecret / Secret Service and Windows Credential Manager land in the follow-up canvases. The library never rolls its own crypto and never writes a plaintext credential file or logs a password.
- **Deterministic Java API** on `WebViewComponent` — enable/disable, get/save/delete, plus overridable credential-store and save-policy seams so hosts and headless tests can drive it without UI or the real keychain.

Credentials are keyed by page **origin** (scheme + host + port); autofill is exact-origin only. The **origin is stamped natively** from the committed frame URL — never trusted from JS — so a page cannot save-into or read another origin's credential.

## Approach

Developed via this repo's SPDD workflow, following the multi-platform Canvas split established by the Browser-Initiated UI Dialogs feature:

- **Canvas 23** (STORY-006-001) — public Java contract + shared detection/fill JavaScript + macOS Keychain backend.
- **Canvas 24** (STORY-006-002) — Linux WebKitGTK channel + libsecret store.
- **Canvas 25** (STORY-006-003) — Windows WebView2 channel + Credential Manager store.

Design highlights: **non-blocking** dispatch (`invokeLater`; store I/O on a worker) — unlike the blocking dialog dispatcher — because a login submission has no synchronous JS contract; autofill is a native fill-request → store lookup → `eval` of a **write-only** `window.__webview_pw_fill__` entrypoint that never returns a credential.

## Status

- [x] `/spdd-story` — `requirements/[User-story-6]webview-native-password-manager.md` (3 INVEST stories, 46 ACs)
- [x] `/spdd-analysis` — `spdd/analysis/…-webview-native-password-manager.md`
- [x] `/spdd-reasons-canvas` — Canvases **23** (base + macOS), **24** (Linux), **25** (Windows)
- [x] `/spdd-generate` — Java layer + shared JS + **27 unit tests passing** + macOS Keychain native + Windows link-symmetry stubs + demo + README
- [x] **Native compile validation on CI** — all 7 build jobs green (osx_64/arm64, linux_64/arm64, windows_64/arm64, and the all-platforms `WebView.jar`)
- [ ] Linux libsecret + Windows Credential Manager native bodies (Canvases 24 / 25 — follow-up)

**Coverage this release: macOS** (Keychain). On Linux/Windows the Java API + programmatic store are present and degrade gracefully; automatic capture/fill activate when the per-platform native channel + store land.

### Verification done here
- Java layer compiles (Java 8 target) and **all 27 new unit tests pass** (`OriginsTest`, `WebViewCredentialTest`, `InMemoryCredentialStoreTest`, `PasswordDispatcherTest`), covering origin canonicalisation, upsert + recency, enable/disable gating, store/handler null-restores-default, EDT marshaling, save-handler exception isolation, origin-exact autofill, and password redaction.
- The macOS Keychain + `__webview_pw__` message-handler native code compiles on the CI runners, and all native build jobs across macOS/Linux/Windows are green.

## Follow-on enhancements (browser-parity gaps)

Two additional stories added to the same epic — both driven through the full SPDD flow (story → analysis → canvas → generate), both reversing a Scope-Out item STORY-006-001 originally deferred. Canvases 26 (base + macOS), 27 (Linux) and 28 (Windows) carry these.

- **STORY-006-004 — autofill-consent handler** (Java-only, cross-platform). The autofill path was ungated; now a symmetric `WebViewFillPasswordHandler` (with `WebViewFillPasswordEvent` → `FillPasswordDisposition {FILL, DONT_FILL}`) is consulted on the EDT before injecting, so a host can show a browser-style "use saved password?" confirmation and/or require an OS biometric / re-auth check. `DEFAULT` fills silently (no regression); `CONFIRM` prompts. The consent event **carries no password**, and only the automatic page-load autofill is gated — the programmatic read API is not. New `setFillPasswordHandler` / `getFillPasswordHandler` on `WebViewComponent`.
- **STORY-006-005 — enumerate-all credentials** for a "manage saved passwords" UI. New `WebViewCredentialStore.findAll()` (no-arg) + `WebViewComponent.getAllCredentials()`, backed by a new `webview_cred_store_find_all` JNI primitive (flat quads `[origin, username, millis, password]`): macOS Keychain body (enumerate + `<service>:` prefix filter, two-phase read), Windows `CredEnumerateW` body, in-memory enumeration; Linux stays a graceful stub until the libsecret channel lands. Enumeration returns credentials to host Java only — never to page JavaScript.

Verification: **all 175 Java unit tests pass** (12 new for the two seams), and **all 7 CI jobs are green** on this head — the native matrix (osx/linux/windows × 64/arm64) validated the new `find_all` C++ on every platform. The demo gains a "Get All" action and a "Confirm before autofill" toggle; the README documents both seams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012i5Jya9oqHBtDYECXihMex