### PR TITLE
Per-destination User-Agent resolver (Canvas 21, 1.5.0) + build-script JAWT fix (Canvas 8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,56 @@ wv.setUrl("https://example.com/");   // first request carries the custom UA
   pattern-faithful but must be validated on-device (confirm the header via an
   echo endpoint).
 
+## Per-host user agent
+
+One static UA cannot satisfy two sites that want opposite things. Slack
+rejects the engine's own UA as an unsupported browser and wants a mainstream
+desktop Chrome string; Google's sign-in, presented that same Chrome UA by a
+WebKit engine, scores it as a spoof — the claimed Chrome build has no
+`navigator.userAgentData`, sends no `Sec-CH-UA` client hints, and carries a
+WebKit TLS fingerprint — and answers with a CAPTCHA that cannot be passed at
+any score.
+
+`setUserAgentResolver` picks the UA per destination instead:
+
+```java
+WebViewComponent wv = WebViewComponent.create();
+wv.setUserAgent(SAFARI_UA);                  // the default for everything
+wv.setUserAgentResolver(url ->
+    url.contains("://app.slack.com/") ? CHROME_UA : null);   // null = fall through
+wv.setUrl("https://app.slack.com/client");   // first request carries CHROME_UA
+```
+
+* **Precedence.** The resolver's answer wins when it is non-null and
+  non-blank; otherwise the static `setUserAgent` value applies; otherwise the
+  engine default. A `null` or blank return means *fall through*, **not** "use
+  the engine default" — a resolver can never force the engine default over a
+  static override.
+* **When it is consulted.** At three points, each a navigation that is about
+  to start and that the library controls: before a view's initial navigation,
+  before any `setUrl` on a live view, and before a browser-initiated pop-up
+  child's first navigation — keyed on the **pop-up's own target URL**. That
+  last one is the point of the feature: an OAuth sign-in popped out of a site
+  that needs a spoofed UA lands on an identity provider that penalises exactly
+  that spoof. When a resolver is installed it supersedes the opener-copy
+  described under *Popups inherit it* above; with no resolver, opener-copy is
+  unchanged.
+* **Limitation.** This is not per-request switching. A server-side redirect
+  that crosses hosts *during* a navigation keeps the UA that navigation
+  started with. Intercepting every navigation was considered and rejected:
+  WebKit does not reliably expose `NSURLRequest.HTTPBody` to
+  `decidePolicyForNavigationAction` for form POSTs, so the
+  cancel-set-UA-reissue pattern would silently drop OAuth form-post bodies.
+* **Threading.** The resolver runs on the engine UI thread immediately before
+  the navigation it governs, so keep it fast and non-blocking — a host-suffix
+  check, not a network call. A resolver that throws is treated as a `null`
+  return and can never break a navigation.
+* **Platform coverage.** The pop-up path upcalls the resolver natively on
+  macOS, Linux and Windows; the other two points resolve in Java. As with the
+  UA setters, the native upcall ships pattern-faithful but must be validated
+  on-device (`WebViewAdoptPopupDemo`'s **Resolver** toggle plus the
+  `https://httpbin.org/user-agent` echo).
+
 ## Clear cache
 
 When a site renders blank because a stale (or poisoned) cached resource is

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -6,15 +6,18 @@ if pkg-config --exists webkit2gtk-4.1; then
 else
     WEBKIT_PKG=webkit2gtk-4.0
 fi
-# Link against JAWT for the Swing embedding bridge. Use an array so the
-# -L path stays a single argument even if JAVA_HOME contains spaces.
-JAWT_LIB=(-L"${JAVA_HOME}/lib" -ljawt)
+# JAWT is deliberately NOT linked (Canvas 8, Op 8). The JAWT_* symbols resolve
+# at load time from the already-loaded JVM, against the libjawt WebViewNative
+# pre-loads before this library. Linking -ljawt would make the build depend on a
+# standalone libjawt that some JDKs do not ship -- the very case the loader is
+# written to survive. This mirrors the Linux `native` job in
+# .github/workflows/build.yml, which produces the artifact that ships.
 g++ -I"${JAVA_HOME}/include" -I"${JAVA_HOME}/include/linux" -fPIC -std=c++11 -Wall -Wextra -pedantic -I./src_c -DWEBVIEW_GTK=1 \
     `pkg-config --cflags gtk+-3.0 $WEBKIT_PKG` \
     src_c/webview.c src_c/webview_embed.cpp src_c/webkit_loader.cpp \
     $LDFLAGS \
     `pkg-config --libs gtk+-3.0` \
-    "${JAWT_LIB[@]}" -lX11 -ldl \
+    -lX11 -ldl \
     -shared -o libwebview.so
 # NOTE: WebKitGTK/JavaScriptCore are intentionally NOT linked (only --cflags
 # for the headers). They are dlopen'd at runtime (4.1 preferred, 4.0 fallback)

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -1,11 +1,25 @@
 #!/bin/bash
 set -e
-# Note: on macOS, JAWT lives next to libjli inside the JDK; -ljawt links it.
+# Build the macOS native library for the HOST architecture (Canvas 8, Op 8).
+#
+# Note: JAWT is deliberately NOT linked. The JAWT_* symbols are left undefined
+# at link time (-Wl,-undefined,dynamic_lookup) and resolve at load time against
+# the libjawt that WebViewNative pre-loads before this library (the two-phase
+# preload). Linking -ljawt would make the build depend on a standalone libjawt
+# that some JDKs do not ship -- exactly the case the loader is written to
+# survive -- and fails with "ld: library 'jawt' not found" on a stock JDK.
+# This mirrors the macOS `native` job in .github/workflows/build.yml, which
+# produces the artifact that actually ships.
+case "$(uname -m)" in
+    arm64|aarch64) NATIVE_DIR=osx_arm64 ;;
+    x86_64)        NATIVE_DIR=osx_64 ;;
+    *)             NATIVE_DIR=osx_64 ;;
+esac
+echo "Building for host arch $(uname -m) -> natives/$NATIVE_DIR"
+mkdir -p "natives/$NATIVE_DIR"
 c++ -I"${JAVA_HOME}/include" -I"${JAVA_HOME}/include/darwin" -dynamiclib \
-    src_c/webview.c src_c/webview_embed.cpp \
-    -o libwebview.dylib \
+    src_c/webview_embed.cpp \
+    -o "natives/$NATIVE_DIR/libwebview.dylib" \
     -DWEBVIEW_COCOA=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=1 -std=c++11 \
     -framework WebKit -framework Cocoa -framework QuartzCore \
-    -L"${JAVA_HOME}/lib" -ljawt
-mkdir -p natives/osx_64
-mv libwebview.dylib natives/osx_64/
+    -Wl,-undefined,dynamic_lookup

--- a/demos/WebViewAdoptPopupDemo/src/ca/weblite/webview/demos/WebViewAdoptPopupDemo.java
+++ b/demos/WebViewAdoptPopupDemo/src/ca/weblite/webview/demos/WebViewAdoptPopupDemo.java
@@ -147,6 +147,10 @@ public final class WebViewAdoptPopupDemo {
     }
 
     private static JPanel buildControls(WebViewComponent opener) {
+        // Canvas 21 Op 14.4: three rows, not one long FlowLayout line. A row
+        // wider than the frame silently wraps its trailing components out of
+        // view, and in a fixed-height row they become unreachable -- the
+        // control then looks absent rather than clipped.
         JPanel bar = new JPanel(new java.awt.FlowLayout(
             java.awt.FlowLayout.LEFT, 8, 6));
         bar.setBorder(BorderFactory.createEmptyBorder(2, 4, 2, 4));
@@ -163,22 +167,17 @@ public final class WebViewAdoptPopupDemo {
         });
         bar.add(modeBox);
 
-        bar.add(new JLabel("   User-Agent:"));
-        JTextField uaField = new JTextField(SAFARI_UA, 34);
-        bar.add(uaField);
+        JTextField uaField = new JTextField(SAFARI_UA, 20);
         JButton setUa = new JButton("Set UA");
         setUa.addActionListener(e -> {
             opener.setUserAgent(uaField.getText());
             opener.setUrl(openerPage());  // reload so the UA applies
         });
-        bar.add(setUa);
         JButton resetUa = new JButton("Reset UA");
         resetUa.addActionListener(e -> {
             opener.setUserAgent(null);
             opener.setUrl(openerPage());
         });
-        bar.add(resetUa);
-
         // Canvas 21 (1.5.0): per-destination resolver.  Maps httpbin.org to a
         // distinctive UA while leaving every other host on the static field
         // value above, so the window.open -> https://httpbin.org/user-agent
@@ -207,14 +206,37 @@ public final class WebViewAdoptPopupDemo {
         });
         bar.add(clearCache);
 
-        // Canvas 21 Op 14.3: the address row below is what makes consultation
-        // point (b) -- a Java-initiated setUrl on an already-live view --
-        // testable on-device. Without it the opener only ever sat on a data:
-        // URL, which has no host, so the resolver never fired for it.
-        JPanel stack = new JPanel(new java.awt.GridLayout(2, 1));
+        // Row 2: the User-Agent field takes the slack, its buttons pin right,
+        // so the row's width never depends on the field's preferred size.
+        JPanel uaRow = fieldRow("User-Agent:", uaField, setUa, resetUa);
+
+        // Canvas 21 Op 14.3: the address row is what makes consultation point
+        // (b) -- a Java-initiated setUrl on an already-live view -- testable
+        // on-device. Without it the opener only ever sat on a data: URL, which
+        // has no host, so the resolver never fired for it.
+        JPanel stack = new JPanel(new java.awt.GridLayout(0, 1));
         stack.add(bar);
+        stack.add(uaRow);
         stack.add(buildAddressRow(opener));
         return stack;
+    }
+
+    /**
+     * One control row: a label, a text field that absorbs all slack, and
+     * buttons pinned to the trailing edge (Canvas 21 Op 14.4). Because the
+     * field is the only stretchy part, the row fits any window width and no
+     * button can wrap out of view.
+     */
+    private static JPanel fieldRow(String label, JTextField field, JButton... buttons) {
+        JPanel row = new JPanel(new java.awt.BorderLayout(8, 0));
+        row.setBorder(BorderFactory.createEmptyBorder(2, 8, 2, 8));
+        row.add(new JLabel(label), java.awt.BorderLayout.WEST);
+        row.add(field, java.awt.BorderLayout.CENTER);
+        JPanel right = new JPanel(new java.awt.FlowLayout(
+            java.awt.FlowLayout.LEFT, 6, 0));
+        for (JButton b : buttons) right.add(b);
+        row.add(right, java.awt.BorderLayout.EAST);
+        return row;
     }
 
     /**
@@ -228,20 +250,13 @@ public final class WebViewAdoptPopupDemo {
      * field's value.
      */
     private static JPanel buildAddressRow(WebViewComponent opener) {
-        JPanel row = new JPanel(new java.awt.FlowLayout(
-            java.awt.FlowLayout.LEFT, 8, 6));
-        row.setBorder(BorderFactory.createEmptyBorder(2, 4, 2, 4));
-
-        row.add(new JLabel("URL:"));
-        JTextField urlField = new JTextField(HTTPBIN_UA_URL, 38);
-        row.add(urlField);
+        JTextField urlField = new JTextField(HTTPBIN_UA_URL, 20);
 
         JButton go = new JButton("Go");
         go.addActionListener(e -> {
             String url = urlField.getText().trim();
             if (!url.isEmpty()) opener.setUrl(url);
         });
-        row.add(go);
         // Enter in the field navigates too.
         urlField.addActionListener(e -> {
             String url = urlField.getText().trim();
@@ -255,8 +270,6 @@ public final class WebViewAdoptPopupDemo {
             urlField.setText(HTTPBIN_UA_URL);
             opener.setUrl(HTTPBIN_UA_URL);
         });
-        row.add(httpbin);
-
         JButton httpbingo = new JButton("httpbingo (not overridden)");
         httpbingo.setToolTipText(
             "A different host the resolver declines, so it falls through to the "
@@ -265,17 +278,13 @@ public final class WebViewAdoptPopupDemo {
             urlField.setText(HTTPBINGO_UA_URL);
             opener.setUrl(HTTPBINGO_UA_URL);
         });
-        row.add(httpbingo);
-
         JButton home = new JButton("Home");
         home.setToolTipText("Back to the opener page, for the pop-up tests.");
         home.addActionListener(e -> {
             urlField.setText("");
             opener.setUrl(openerPage());
         });
-        row.add(home);
-
-        return row;
+        return fieldRow("URL:", urlField, go, httpbin, httpbingo, home);
     }
 
     private static void addTab(JTabbedPane tabs, String title,

--- a/demos/WebViewAdoptPopupDemo/src/ca/weblite/webview/demos/WebViewAdoptPopupDemo.java
+++ b/demos/WebViewAdoptPopupDemo/src/ca/weblite/webview/demos/WebViewAdoptPopupDemo.java
@@ -62,6 +62,17 @@ import javax.swing.ToolTipManager;
  *       proving a popup child's first request is keyed on the child's own
  *       target URL instead of copied from the opener.  Untick it and the
  *       opener-copy behaviour returns unchanged.</li>
+ *   <li><b>Address bar</b> (Canvas 21, 1.5.0) &mdash; a URL field + <b>Go</b>,
+ *       plus one-click <b>httpbin (overridden)</b> /
+ *       <b>httpbingo (not overridden)</b> / <b>Home</b> buttons.  This is what
+ *       makes consultation point <b>(b)</b> &mdash; a Java-initiated
+ *       {@code setUrl} on an already-live view &mdash; testable on-device;
+ *       previously the opener only ever sat on a {@code data:} URL, which has
+ *       no host, so the resolver never fired for it.  With the resolver toggle
+ *       <b>on</b>, httpbin echoes {@code SwingWebView-Resolver} while httpbingo
+ *       echoes the User-Agent field's value: per-host selection and
+ *       fall-through in two clicks, no pop-up involved.  With the toggle
+ *       <b>off</b>, both echo the field's value.</li>
  * </ul>
  *
  * <p>The POST/echo checks hit {@code https://httpbin.org/post}, so they need
@@ -70,6 +81,14 @@ import javax.swing.ToolTipManager;
 public final class WebViewAdoptPopupDemo {
 
     /** A current desktop Safari UA (prefilled into the UA field). */
+    /** The host the demo's resolver overrides; its /user-agent echoes back
+     *  whatever UA the request carried (Canvas 21, 1.5.0, Op 14.3). */
+    private static final String HTTPBIN_UA_URL = "https://httpbin.org/user-agent";
+    /** A DIFFERENT host the resolver does NOT override, serving the same
+     *  /user-agent JSON shape so the two echoes read side by side. Fallback if
+     *  it is unreachable: https://postman-echo.com/get (Canvas 21, Op 14.3). */
+    private static final String HTTPBINGO_UA_URL = "https://httpbingo.org/user-agent";
+
     /** A UA distinct from every preset, so the httpbin echo is unambiguous
      *  about which layer chose it (Canvas 21, 1.5.0). */
     private static final String RESOLVER_UA =
@@ -187,7 +206,76 @@ public final class WebViewAdoptPopupDemo {
             opener.eval("location.reload()");
         });
         bar.add(clearCache);
-        return bar;
+
+        // Canvas 21 Op 14.3: the address row below is what makes consultation
+        // point (b) -- a Java-initiated setUrl on an already-live view --
+        // testable on-device. Without it the opener only ever sat on a data:
+        // URL, which has no host, so the resolver never fired for it.
+        JPanel stack = new JPanel(new java.awt.GridLayout(2, 1));
+        stack.add(bar);
+        stack.add(buildAddressRow(opener));
+        return stack;
+    }
+
+    /**
+     * The address row: a URL field + Go, plus one-click destinations that make
+     * the per-host contrast a two-click test (Canvas 21 Op 14.3).
+     *
+     * <p>With the <b>Per-host resolver</b> toggle on, <b>httpbin (overridden)</b>
+     * must echo {@link #RESOLVER_UA} and <b>httpbingo (not overridden)</b> must
+     * echo the User-Agent field's value — per-host selection and fall-through,
+     * on one engine, with no pop-up involved. With the toggle off, both echo the
+     * field's value.
+     */
+    private static JPanel buildAddressRow(WebViewComponent opener) {
+        JPanel row = new JPanel(new java.awt.FlowLayout(
+            java.awt.FlowLayout.LEFT, 8, 6));
+        row.setBorder(BorderFactory.createEmptyBorder(2, 4, 2, 4));
+
+        row.add(new JLabel("URL:"));
+        JTextField urlField = new JTextField(HTTPBIN_UA_URL, 38);
+        row.add(urlField);
+
+        JButton go = new JButton("Go");
+        go.addActionListener(e -> {
+            String url = urlField.getText().trim();
+            if (!url.isEmpty()) opener.setUrl(url);
+        });
+        row.add(go);
+        // Enter in the field navigates too.
+        urlField.addActionListener(e -> {
+            String url = urlField.getText().trim();
+            if (!url.isEmpty()) opener.setUrl(url);
+        });
+
+        JButton httpbin = new JButton("httpbin (overridden)");
+        httpbin.setToolTipText(
+            "Resolver maps this host to " + RESOLVER_UA + " when the toggle is on.");
+        httpbin.addActionListener(e -> {
+            urlField.setText(HTTPBIN_UA_URL);
+            opener.setUrl(HTTPBIN_UA_URL);
+        });
+        row.add(httpbin);
+
+        JButton httpbingo = new JButton("httpbingo (not overridden)");
+        httpbingo.setToolTipText(
+            "A different host the resolver declines, so it falls through to the "
+            + "User-Agent field. Same /user-agent JSON shape as httpbin.");
+        httpbingo.addActionListener(e -> {
+            urlField.setText(HTTPBINGO_UA_URL);
+            opener.setUrl(HTTPBINGO_UA_URL);
+        });
+        row.add(httpbingo);
+
+        JButton home = new JButton("Home");
+        home.setToolTipText("Back to the opener page, for the pop-up tests.");
+        home.addActionListener(e -> {
+            urlField.setText("");
+            opener.setUrl(openerPage());
+        });
+        row.add(home);
+
+        return row;
     }
 
     private static void addTab(JTabbedPane tabs, String title,

--- a/demos/WebViewAdoptPopupDemo/src/ca/weblite/webview/demos/WebViewAdoptPopupDemo.java
+++ b/demos/WebViewAdoptPopupDemo/src/ca/weblite/webview/demos/WebViewAdoptPopupDemo.java
@@ -189,10 +189,10 @@ public final class WebViewAdoptPopupDemo {
                 "Resolve httpbin.org to " + RESOLVER_UA + "; other hosts fall "
                 + "through to the User-Agent field.");
         resolverBox.addActionListener(e -> {
-            opener.setUserAgentResolver(resolverBox.isSelected()
-                    ? url -> url != null && url.contains("httpbin.org")
-                            ? RESOLVER_UA : null
-                    : null);
+            opener.setUserAgentResolver(
+                resolverBox.isSelected() ? WebViewAdoptPopupDemo::resolveUa : null);
+            System.out.println("[demo] resolver "
+                + (resolverBox.isSelected() ? "INSTALLED" : "cleared"));
             opener.setUrl(openerPage());
         });
         bar.add(resolverBox);
@@ -249,6 +249,23 @@ public final class WebViewAdoptPopupDemo {
      * on one engine, with no pop-up involved. With the toggle off, both echo the
      * field's value.
      */
+    /**
+     * The demo's per-destination resolver: {@code httpbin.org} gets
+     * {@link #RESOLVER_UA}, every other host is declined so the static
+     * {@code setUserAgent} value applies.
+     *
+     * <p>Prints every decision (Canvas 21 Op 14.3). Paired with the Windows
+     * setter's {@code WV_LOG} line, one run says unambiguously whether a wrong
+     * User-Agent came from this resolution chain or from an engine that ignored
+     * what it resolved.
+     */
+    private static String resolveUa(String url) {
+        boolean match = url != null && url.contains("httpbin.org");
+        System.out.println("[demo] resolver(" + url + ") -> "
+            + (match ? "RESOLVER_UA" : "(decline -> static UA)"));
+        return match ? RESOLVER_UA : null;
+    }
+
     private static JPanel buildAddressRow(WebViewComponent opener) {
         JTextField urlField = new JTextField(HTTPBIN_UA_URL, 20);
 

--- a/demos/WebViewAdoptPopupDemo/src/ca/weblite/webview/demos/WebViewAdoptPopupDemo.java
+++ b/demos/WebViewAdoptPopupDemo/src/ca/weblite/webview/demos/WebViewAdoptPopupDemo.java
@@ -14,6 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
@@ -51,6 +52,16 @@ import javax.swing.ToolTipManager;
  *       Native-window modes; with Reset UA it echoes the engine default.  This
  *       verifies the opener's override is applied to the popup child before its
  *       in-flight initial navigation.</li>
+ *   <li><b>Per-host resolver</b> (Canvas 21, 1.5.0) — tick
+ *       <b>Per-host resolver (httpbin)</b> to install a
+ *       {@link WebViewComponent#setUserAgentResolver(java.util.function.Function)}
+ *       that maps {@code httpbin.org} to a distinctive
+ *       {@code SwingWebView-Resolver} UA and declines (returns {@code null})
+ *       for every other host.  Now open {@code window.open &rarr; popup}: the
+ *       popup echoes the <em>resolver's</em> UA rather than the opener's,
+ *       proving a popup child's first request is keyed on the child's own
+ *       target URL instead of copied from the opener.  Untick it and the
+ *       opener-copy behaviour returns unchanged.</li>
  * </ul>
  *
  * <p>The POST/echo checks hit {@code https://httpbin.org/post}, so they need
@@ -59,6 +70,12 @@ import javax.swing.ToolTipManager;
 public final class WebViewAdoptPopupDemo {
 
     /** A current desktop Safari UA (prefilled into the UA field). */
+    /** A UA distinct from every preset, so the httpbin echo is unambiguous
+     *  about which layer chose it (Canvas 21, 1.5.0). */
+    private static final String RESOLVER_UA =
+            "Mozilla/5.0 (SwingWebView-Resolver) AppleWebKit/537.36 "
+                    + "(KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36";
+
     private static final String SAFARI_UA =
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
       + "AppleWebKit/605.1.15 (KHTML, like Gecko) "
@@ -142,6 +159,26 @@ public final class WebViewAdoptPopupDemo {
             opener.setUrl(openerPage());
         });
         bar.add(resetUa);
+
+        // Canvas 21 (1.5.0): per-destination resolver.  Maps httpbin.org to a
+        // distinctive UA while leaving every other host on the static field
+        // value above, so the window.open -> https://httpbin.org/user-agent
+        // popup echoes the RESOLVER's UA rather than the opener's -- the
+        // on-device proof that a popup child's first request is keyed on the
+        // child's own target URL, not copied from its opener.
+        JCheckBox resolverBox = new JCheckBox("Per-host resolver (httpbin)");
+        resolverBox.setToolTipText(
+                "Resolve httpbin.org to " + RESOLVER_UA + "; other hosts fall "
+                + "through to the User-Agent field.");
+        resolverBox.addActionListener(e -> {
+            opener.setUserAgentResolver(resolverBox.isSelected()
+                    ? url -> url != null && url.contains("httpbin.org")
+                            ? RESOLVER_UA : null
+                    : null);
+            opener.setUrl(openerPage());
+        });
+        bar.add(resolverBox);
+
         JButton clearCache = new JButton("Clear cache");
         clearCache.addActionListener(e -> {
             // Canvas 22: purge the HTTP resource cache, then reload so the

--- a/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
+++ b/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
@@ -44,8 +44,9 @@ generated_at: 2026-08-06T14:00:00-07:00
   to the newly created popup child **before its initial (in-flight)
   navigation**, so the popup's **first** request carries the opener's
   UA — not the engine default. When the opener has no override, the
-  child keeps the engine default. This holds on macOS, Linux, and
-  Windows. **Why.** `customUserAgent` (and its per-engine analogues)
+  child keeps the engine default. This holds on macOS and Linux.
+  **It does NOT hold on Windows** — see the known limitation below.
+  **Why.** `customUserAgent` (and its per-engine analogues)
   is a per-view **instance** property, not part of the
   `WKWebViewConfiguration` / related-view linkage the child inherits
   from the opener, so without explicit propagation the popup's first
@@ -56,6 +57,32 @@ generated_at: 2026-08-06T14:00:00-07:00
   canvases that own the child-creation sites: Canvas 15 (`window.open`
   / macOS), Canvas 16/17 (native-window Linux/Windows), and Canvas
   18/19/20 (popup adoption macOS/Linux/Windows).
+
+- **KNOWN LIMITATION — a pop-up child's User-Agent cannot be set on
+  WebView2.** Verified on-device: the propagation site runs, chooses a
+  UA (from the resolver or the opener's tracked override), and
+  `put_UserAgent` on the **child** returns `S_OK` — and the child's
+  first request still goes out with the engine default. By the time
+  `NewWindowRequested` hands us the child, WebView2 has already
+  committed that navigation, and a settings write cannot overtake it.
+  This is the same defect shape as the empty-string reset (Approach 2):
+  WebView2 accepts a settings write and does not necessarily act on it.
+  It applies equally to the 1.5.0 resolver and to the 1.3.1 opener-copy,
+  so **pop-up UA propagation has never worked on Windows**, and the
+  claim above that it did was never validated on-device.
+  The fallback behaviour is safe rather than wrong: a Windows pop-up
+  presents the engine's own (Chromium/Edge) UA, which is a truthful,
+  mainstream string that UA-gating sites accept — the failure mode the
+  propagation exists to prevent is a macOS/WebKit one. Callers who need
+  a specific UA in a Windows pop-up must currently open the destination
+  in a normal tab instead.
+  The candidate fix is `ICoreWebView2_2::add_WebResourceRequested` with
+  a filter on the child, rewriting the `User-Agent` **request header**
+  rather than the setting — per-request, so it cannot lose a race with a
+  navigation. Deliberately not attempted blind: it is non-trivial COM on
+  a path that currently preserves `window.opener` and the in-flight POST
+  body (Canvas 18 D7), and breaking either of those to fix a UA would be
+  a bad trade.
 
 - **Per-host User-Agent resolver (1.5.0).** Let a caller supply a
   *resolver* — a function from the URL a navigation is about to load
@@ -146,10 +173,13 @@ generated_at: 2026-08-06T14:00:00-07:00
     return, and that a throwing resolver falls through instead of
     propagating.
   - A popup opened toward a host the resolver maps to a distinct UA
-    sends **that** UA on its first request — not the opener's — on all
-    three engines, for both ADOPT and NATIVE_WINDOW. Verifiable in
+    sends **that** UA on its first request — not the opener's — on
+    **macOS and Linux**, for both ADOPT and NATIVE_WINDOW. Verifiable in
     `WebViewAdoptPopupDemo` via its resolver toggle plus the
-    `https://httpbin.org/user-agent` echo.
+    `https://httpbin.org/user-agent` echo. **Windows is excluded** by the
+    known limitation above: its pop-up children keep the engine default,
+    and the diagnostic log is the evidence that the failure is the
+    engine's rather than this library's.
   - **Point (b) is verifiable on-device, no pop-up involved.** With the
     resolver toggle **on**, navigating the opener (address bar or the
     one-click buttons) to the **overridden** host echoes the resolver's

--- a/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
+++ b/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
@@ -58,32 +58,27 @@ generated_at: 2026-08-06T14:00:00-07:00
   / macOS), Canvas 16/17 (native-window Linux/Windows), and Canvas
   18/19/20 (popup adoption macOS/Linux/Windows).
 
-- **KNOWN LIMITATION — a pop-up child's User-Agent cannot be set on
-  WebView2.** Verified on-device: the propagation site runs, chooses a
-  UA (from the resolver or the opener's tracked override), and
-  `put_UserAgent` on the **child** returns `S_OK` — and the child's
-  first request still goes out with the engine default. By the time
-  `NewWindowRequested` hands us the child, WebView2 has already
-  committed that navigation, and a settings write cannot overtake it.
-  This is the same defect shape as the empty-string reset (Approach 2):
-  WebView2 accepts a settings write and does not necessarily act on it.
-  It applies equally to the 1.5.0 resolver and to the 1.3.1 opener-copy,
-  so **pop-up UA propagation has never worked on Windows**, and the
-  claim above that it did was never validated on-device.
-  The fallback behaviour is safe rather than wrong: a Windows pop-up
-  presents the engine's own (Chromium/Edge) UA, which is a truthful,
-  mainstream string that UA-gating sites accept — the failure mode the
-  propagation exists to prevent is a macOS/WebKit one. Callers who need
-  a specific UA in a Windows pop-up must currently open the destination
-  in a normal tab instead.
-  The candidate fix is `ICoreWebView2_2::add_WebResourceRequested` with
-  a filter on the child, rewriting the `User-Agent` **request header**
-  rather than the setting — per-request, so it cannot lose a race with a
-  navigation. Deliberately not attempted blind: it is non-trivial COM on
-  a path that currently preserves `window.opener` and the in-flight POST
-  body (Canvas 18 D7), and breaking either of those to fix a UA would be
-  a bad trade.
-
+- **A pop-up child's User-Agent is set on the REQUEST, not the setting
+  (Windows).** Verified on-device: `put_UserAgent` on a WebView2 pop-up
+  child returns `S_OK` and the child's first request still carries the
+  engine default. By the time `NewWindowRequested` hands us the child,
+  WebView2 has committed that navigation and a settings write cannot
+  overtake it — the same defect shape as the empty-string reset
+  (Approach 2): this engine accepts a settings write and does not
+  necessarily act on it. It applies equally to the 1.5.0 resolver and the
+  1.3.1 opener-copy, which write through the same call, so pop-up UA
+  propagation had never worked on Windows and the earlier claim that it
+  held on all three engines was never validated.
+  The request header can still be rewritten, and a request cannot lose a
+  race with itself: the child gets a `WebResourceRequested` hook,
+  registered inside the deferral **before** `Complete()`, which sets the
+  `User-Agent` header on its first document request (Op 7.5). The
+  `put_UserAgent` call stays and covers every request after that one — by
+  then the settings write has landed — so the two together give the child
+  a consistent UA. Nothing is cancelled or re-issued, only a header set,
+  so `window.opener` and the in-flight POST body (Canvas 18 D7) are
+  untouched. macOS and Linux are unaffected: `customUserAgent` and
+  `WebKitSettings` both apply to the child's first request already.
 - **Per-host User-Agent resolver (1.5.0).** Let a caller supply a
   *resolver* — a function from the URL a navigation is about to load
   to the User-Agent to present for it — so one embedded browser can
@@ -176,10 +171,10 @@ generated_at: 2026-08-06T14:00:00-07:00
     sends **that** UA on its first request — not the opener's — on
     **macOS and Linux**, for both ADOPT and NATIVE_WINDOW. Verifiable in
     `WebViewAdoptPopupDemo` via its resolver toggle plus the
-    `https://httpbin.org/user-agent` echo. **Windows is excluded** by the
-    known limitation above: its pop-up children keep the engine default,
-    and the diagnostic log is the evidence that the failure is the
-    engine's rather than this library's.
+    `https://httpbin.org/user-agent` echo. On **Windows** the same holds
+    via the first-request header rewrite (Op 7.5) rather than the setting;
+    the diagnostic log distinguishes a hook that never fired from one that
+    fired and was ignored, so a regression there stays legible.
   - **Point (b) is verifiable on-device, no pop-up involved.** With the
     resolver toggle **on**, navigating the opener (address bar or the
     one-click buttons) to the **overridden** host echoes the resolver's
@@ -527,7 +522,21 @@ File: `windows/webview_embed.cc`
    what the opener's tracked override held, which of the two was chosen,
    and the `HRESULT`. The call sites log entry, so "never reached" is
    distinguishable from "reached and declined".
-5. **The setter reports its outcome via `WV_LOG`** — the UA it was asked
+5. **Pop-up children get their UA on the first request, not the setting.**
+   In `propagate_popup_user_agent`, after the existing `put_UserAgent`,
+   register a `WebResourceRequested` handler on the **child**, filtered to
+   `COREWEBVIEW2_WEB_RESOURCE_CONTEXT_DOCUMENT` with a `"*"` URI filter, and
+   have it `SetHeader(L"User-Agent", ua)` on the request. It acts **once**
+   (a latch, so it is inert for every later request) and both registrations
+   happen inside the `NewWindowRequested` deferral, **before**
+   `Complete()` — that is the only window in which the child's first
+   request has not yet gone out. Keep `put_UserAgent`: it is what gives the
+   child a consistent UA for everything after the first request. The
+   handler follows the file's `CallbackBase` pattern and is `Release`d
+   after `add_WebResourceRequested`, so WebView2 holds the only reference.
+   Log the filter/add `HRESULT`s and the header rewrite, so a hook that
+   never fires is distinguishable from one that fired and was ignored.
+6. **The setter reports its outcome via `WV_LOG`** — the UA it was asked
    to apply, whether the `ICoreWebView2Settings2` query-interface
    succeeded, and the `HRESULT` from `put_UserAgent`. Silence is not
    acceptable here: WebView2's only failure mode for an unavailable `_2`

--- a/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
+++ b/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
@@ -487,7 +487,17 @@ File: `windows/webview_embed.cc`
    string back rather than `L""`. When the capture failed the setter has
    nothing to restore, so it logs that the reset cannot be honoured
    rather than silently doing nothing.
-4. **The setter reports its outcome via `WV_LOG`** — the UA it was asked
+4. **The pop-up propagation reports its outcome too.** Same reasoning as
+   the setter, and more acutely: `propagate_popup_user_agent` has three
+   silent exits (no opener/child, no UA to apply after the resolver and
+   the tracked override both decline, `ICoreWebView2Settings2`
+   unavailable) plus an unchecked `put_UserAgent`. A child that ends up on
+   the engine default is consistent with every one of them, so the site
+   must log which it took: the target URI, what the resolver answered,
+   what the opener's tracked override held, which of the two was chosen,
+   and the `HRESULT`. The call sites log entry, so "never reached" is
+   distinguishable from "reached and declined".
+5. **The setter reports its outcome via `WV_LOG`** — the UA it was asked
    to apply, whether the `ICoreWebView2Settings2` query-interface
    succeeded, and the `HRESULT` from `put_UserAgent`. Silence is not
    acceptable here: WebView2's only failure mode for an unavailable `_2`

--- a/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
+++ b/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
@@ -468,6 +468,16 @@ File: `windows/webview_embed.cc`
    `put_UserAgent(widen(ua ? ua : ""))`; no-op if the `_2` interface
    is unavailable.
 2. JNI bridge `Java_..._webview_1embed_1set_1user_1agent`.
+3. **The setter reports its outcome via `WV_LOG`** — the UA it was asked
+   to apply, whether the `ICoreWebView2Settings2` query-interface
+   succeeded, and the `HRESULT` from `put_UserAgent`. Silence is not
+   acceptable here: WebView2's only failure mode for an unavailable `_2`
+   interface is a no-op, so without a log a UA that never changes is
+   indistinguishable from one the engine ignored, and the canvas already
+   requires this setter to be validated on-device (Safeguards). The log
+   is the instrument that makes that validation possible, and it is what
+   separates "Java resolved the wrong UA" from "the engine declined the
+   one Java resolved".
 
 ### 8. Test + README
 1. `test/ca/weblite/webview/WebViewComponentUserAgentTest.java`
@@ -640,6 +650,11 @@ Files: `src_c/webview_embed.cpp` (macOS + Linux),
      `https://postman-echo.com/get` is the documented fallback if
      httpbingo is unreachable;
    - **Home** → back to the opener page, for the pop-up tests.
+   The demo's resolver also **prints each decision** to stdout — the URL it
+   was asked about and whether it answered or declined. Paired with the
+   Windows setter's log (Op 7.3), one run then says unambiguously whether a
+   wrong UA came from the Java resolution chain or from an engine that
+   ignored what Java resolved.
 4. **Every control stays reachable at the default window size.** The demo's
    controls must not be laid out as one long `FlowLayout` row per line: a row
    wider than the frame silently wraps its trailing components out of view, and

--- a/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
+++ b/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
@@ -282,11 +282,21 @@ OffscreenWebView ..> WebViewNative : JNI
    and live on subsequent `setUserAgent` calls when the peer exists.
    No override → native setter never called → engine default.
 
-2. **Empty means default.** `setUserAgent(null|"")` stores `null`;
-   the native setter, when invoked with `null`, clears the engine
-   override (macOS `customUserAgent = nil`; GTK
-   `webkit_settings_set_user_agent(settings, NULL)` restores default;
-   WebView2 `put_UserAgent(L"")` — empty restores default).
+2. **Empty means default — but only two engines can say so directly.**
+   `setUserAgent(null|"")` stores `null`; the native setter, when
+   invoked with `null`, clears the engine override. macOS
+   (`customUserAgent = nil`) and GTK
+   (`webkit_settings_set_user_agent(settings, NULL)`) both restore the
+   default from a null.
+   **WebView2 does not.** `put_UserAgent(L"")` returns `S_OK` and
+   leaves the previous override in force — an earlier revision of this
+   canvas claimed the empty string restores the default, and that claim
+   was wrong; the setter implemented it faithfully and Windows was left
+   unable to reset a User-Agent at all. There is no "clear" verb on
+   `ICoreWebView2Settings2`, so the default has to be **captured and
+   restored literally**: read `get_UserAgent` once, before the first
+   override is applied, and write that captured string back whenever a
+   reset is asked for (Op 7.4).
 
 3. **Per-engine native facility.**
    - macOS WKWebView: `-[WKWebView setCustomUserAgent:]` with an
@@ -468,7 +478,16 @@ File: `windows/webview_embed.cc`
    `put_UserAgent(widen(ua ? ua : ""))`; no-op if the `_2` interface
    is unavailable.
 2. JNI bridge `Java_..._webview_1embed_1set_1user_1agent`.
-3. **The setter reports its outcome via `WV_LOG`** — the UA it was asked
+3. **Reset is capture-and-restore, not an empty string.** `Engine` gains
+   a `default_user_agent`, captured lazily from
+   `ICoreWebView2Settings2::get_UserAgent` on the **first** setter call —
+   which is necessarily before any override has been applied, because the
+   setter is the only thing that overrides — and therefore holds the
+   pristine engine UA. A set with an empty/null UA writes that captured
+   string back rather than `L""`. When the capture failed the setter has
+   nothing to restore, so it logs that the reset cannot be honoured
+   rather than silently doing nothing.
+4. **The setter reports its outcome via `WV_LOG`** — the UA it was asked
    to apply, whether the `ICoreWebView2Settings2` query-interface
    succeeded, and the `HRESULT` from `put_UserAgent`. Silence is not
    acceptable here: WebView2's only failure mode for an unavailable `_2`
@@ -706,8 +725,12 @@ Files: `src_c/webview_embed.cpp` (macOS + Linux),
 - **Backward compatibility (never-relax):** unset UA → native setter
   not invoked → engine default unchanged.
 - **Reset semantics:** `setUserAgent(null)` and `setUserAgent("")`
-  both clear the override on every engine (macOS `nil`, GTK `NULL`,
-  WebView2 empty string).
+  both clear the override on every engine — macOS `nil`, GTK `NULL`, and
+  on WebView2 by writing back the **captured default** (Op 7.3), never
+  `L""`, which that engine accepts and ignores. A reset that leaves the
+  previous UA in force is a bug on any engine, and is the specific defect
+  that made Windows unable to fall through from a per-host override back
+  to the static value.
 - **Timing:** applied before the first `navigate` at attach so the
   initial request carries it; live changes affect the next
   navigation only (documented; engines do not rewrite in-flight

--- a/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
+++ b/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
@@ -640,7 +640,17 @@ Files: `src_c/webview_embed.cpp` (macOS + Linux),
      `https://postman-echo.com/get` is the documented fallback if
      httpbingo is unreachable;
    - **Home** → back to the opener page, for the pop-up tests.
-4. README "Per-host user agent" subsection: the resolver API, the
+4. **Every control stays reachable at the default window size.** The demo's
+   controls must not be laid out as one long `FlowLayout` row per line: a row
+   wider than the frame silently wraps its trailing components out of view, and
+   in a fixed-height row they are then unreachable — the control looks absent
+   rather than clipped, which reads as "the feature was never built". The
+   controls are therefore split across rows, and any row carrying a text field
+   gives that field the slack (field in the centre, buttons pinned to the
+   trailing edge) so the row's width never depends on the field's preferred
+   size. The **resolver toggle** in particular sits on the first row, since it
+   is the control the point-(b) and point-(c) tests both switch on.
+5. README "Per-host user agent" subsection: the resolver API, the
    precedence chain, the three consultation points, the
    fall-through-on-null rule, and the cross-host-redirect limitation.
 

--- a/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
+++ b/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
@@ -150,6 +150,15 @@ generated_at: 2026-08-06T14:00:00-07:00
     three engines, for both ADOPT and NATIVE_WINDOW. Verifiable in
     `WebViewAdoptPopupDemo` via its resolver toggle plus the
     `https://httpbin.org/user-agent` echo.
+  - **Point (b) is verifiable on-device, no pop-up involved.** With the
+    resolver toggle **on**, navigating the opener (address bar or the
+    one-click buttons) to the **overridden** host echoes the resolver's
+    UA, while navigating to the **not-overridden** host echoes the
+    User-Agent field's value — per-host selection and fall-through
+    demonstrated on one engine in two clicks. With the toggle **off**,
+    both hosts echo the field's value. This closes the gap where point
+    (b) was covered only by the headless test and could not be shown on
+    any engine.
   - README gains a "Per-host user agent" subsection covering the
     resolver, its precedence, the three consultation points, and the
     cross-host-redirect limitation.
@@ -613,7 +622,25 @@ Files: `src_c/webview_embed.cpp` (macOS + Linux),
    `window.open → https://httpbin.org/user-agent` popup echoes the
    resolver's UA rather than the opener's — the on-device proof for
    point (c).
-3. README "Per-host user agent" subsection: the resolver API, the
+3. The demo also gains an **address bar** — a URL field plus a **Go**
+   button calling `setUrl` on the opener — which is the seam that
+   exercises consultation point **(b)**, a Java-initiated navigation on
+   an already-live view. Until now the demo could not reach point (b)
+   at all: its opener page is a `data:` URL, which has no host, so the
+   resolver never fires for it, and nothing could navigate the opener
+   anywhere else. Point (b) was therefore covered only by the headless
+   test, on no engine.
+   Beside the field sit three one-click destinations, so the per-host
+   contrast needs no typing:
+   - **httpbin (overridden)** → `https://httpbin.org/user-agent`, the
+     host the demo's resolver maps to its distinctive UA;
+   - **httpbingo (not overridden)** → `https://httpbingo.org/user-agent`,
+     a *different* host serving the same `/user-agent` JSON shape so the
+     two responses are read side by side without interpretation.
+     `https://postman-echo.com/get` is the documented fallback if
+     httpbingo is unreachable;
+   - **Home** → back to the opener page, for the pop-up tests.
+4. README "Per-host user agent" subsection: the resolver API, the
    precedence chain, the three consultation points, the
    fall-through-on-null rule, and the cross-host-redirect limitation.
 

--- a/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
+++ b/spdd/prompt/21-20260806-1400-[Feat]-Custom-User-Agent.md
@@ -57,6 +57,68 @@ generated_at: 2026-08-06T14:00:00-07:00
   / macOS), Canvas 16/17 (native-window Linux/Windows), and Canvas
   18/19/20 (popup adoption macOS/Linux/Windows).
 
+- **Per-host User-Agent resolver (1.5.0).** Let a caller supply a
+  *resolver* — a function from the URL a navigation is about to load
+  to the User-Agent to present for it — so one embedded browser can
+  show a different UA per destination host. Expose
+  `WebViewComponent.setUserAgentResolver(Function<String,String>)` and
+  `getUserAgentResolver()`, plumbed through the same
+  pending-value-then-apply-at-attach path `setUserAgent` already uses.
+
+- **Why a resolver, not just a string.** A single static UA cannot
+  satisfy two sites with opposite demands. Slack rejects the engine's
+  own UA as an unsupported browser and needs a mainstream desktop
+  Chrome string; Google's sign-in, by contrast, scores a Chrome UA
+  presented by a WebKit engine as a spoof — the claimed Chrome build
+  has no `navigator.userAgentData`, sends no `Sec-CH-UA` client
+  hints, and carries a WebKit TLS fingerprint — and answers with a
+  CAPTCHA that cannot be passed at any score. Choosing the UA per
+  destination host is the only way to serve both from one browser.
+
+- **Resolver precedence.** Resolver result when non-null and
+  non-blank → the static `setUserAgent` value → the engine default
+  (`null`). A `null` or blank resolver return means **fall through**,
+  *not* "engine default": only the absence of both a resolver result
+  and a static override yields the engine default. When no resolver is
+  set, behaviour is byte-for-byte that of 1.4.0.
+
+- **Consulted at exactly three points**, each a navigation that is
+  about to start and that this library controls: (a) before a view's
+  **initial** navigation (peer attach / first `setUrl`); (b) before any
+  **Java-initiated `setUrl`** on an already-live view; (c) before a
+  browser-initiated **popup child's first** navigation, keyed on the
+  **popup's own target URL**.
+
+- **Supersedes popup inheritance when a resolver is set.** Point (c)
+  replaces the blanket copy of the opener's override described in the
+  Popup inheritance requirement above: the child's UA is chosen from
+  the child's target URL rather than inherited from the opener. The
+  popup is the case that needs this most — an OAuth sign-in opened
+  from a site that requires a spoofed UA lands on an identity provider
+  that penalises exactly that spoof. When **no** resolver is set, the
+  opener-copy behaviour is retained unchanged.
+
+- **Resolver threading and failure.** The resolver is invoked on the
+  engine UI thread immediately before the navigation it governs, so it
+  must be fast and must not block. A resolver that throws is swallowed
+  and treated as a `null` return (fall through to the static UA): a
+  resolver must never be able to break a navigation.
+
+- **Rejected alternative — true per-navigation interception.** The
+  resolver deliberately does **not** provide per-request or mid-page UA
+  switching: a server-side redirect that crosses hosts *during* a
+  navigation keeps the UA that navigation started with. Intercepting
+  every navigation via the macOS `WKNavigationDelegate`
+  `webView:decidePolicyForNavigationAction:decisionHandler:` — cancel
+  the action, set `customUserAgent`, re-issue the request — was
+  considered and **rejected**: WebKit does not reliably expose
+  `NSURLRequest.HTTPBody` to that delegate for form POSTs, so
+  re-issuing would silently drop OAuth form-post bodies. That is the
+  same class of breakage Canvas 18 D7 already avoids by never
+  re-`setUrl`-ing an adopted popup. Presenting a slightly stale UA
+  after a cross-host redirect is a far smaller defect than losing a
+  sign-in POST.
+
 - Definition of Done:
   - `wv.setUserAgent("…Safari…")` before display makes the first and
     subsequent navigations send that `User-Agent` header on all three
@@ -77,8 +139,23 @@ generated_at: 2026-08-06T14:00:00-07:00
     engine default yields a popup at the engine default. Verifiable in
     `WebViewAdoptPopupDemo`: the `window.open → popup` button opens
     `https://httpbin.org/user-agent`, which echoes the popup's UA.
+  - `setUserAgentResolver` chooses the UA per destination host at all
+    three consultation points; a headless
+    `WebViewComponentUserAgentResolverTest` verifies precedence
+    (resolver → static → default), fall-through on a `null`/blank
+    return, and that a throwing resolver falls through instead of
+    propagating.
+  - A popup opened toward a host the resolver maps to a distinct UA
+    sends **that** UA on its first request — not the opener's — on all
+    three engines, for both ADOPT and NATIVE_WINDOW. Verifiable in
+    `WebViewAdoptPopupDemo` via its resolver toggle plus the
+    `https://httpbin.org/user-agent` echo.
+  - README gains a "Per-host user agent" subsection covering the
+    resolver, its precedence, the three consultation points, and the
+    cross-host-redirect limitation.
 
-- Out of scope: per-request UA switching; UA-Client-Hints
+- Out of scope: per-request / mid-navigation UA switching (see the
+  rejected alternative above); UA-Client-Hints
   (`Sec-CH-UA`) customisation; spoofing `navigator.userAgent` from
   Java (that is a caller-side `addOnBeforeLoad` concern); the
   standalone in-process `WebView` class (embedded surface only, same
@@ -135,6 +212,37 @@ generated_at: 2026-08-06T14:00:00-07:00
   WebView2 worker thread and cannot distinguish an override from the
   default via `get_UserAgent` — can propagate the opener's override to
   the child.
+- **WebViewComponent** (modified, resolver). Also gains:
+  - `protected java.util.function.Function<String,String>
+    pendingUserAgentResolver = null;` (adjacent to `pendingUserAgent`).
+  - `public WebViewComponent setUserAgentResolver(
+    Function<String,String> resolver)` — store, push down to the peer
+    when attached. `null` clears it.
+  - `public Function<String,String> getUserAgentResolver()`.
+  - `protected String resolveUserAgentFor(String url)` — the shared
+    Java-side precedence helper (resolver → `pendingUserAgent` →
+    `null`), guarded so a throwing resolver falls through.
+  - `protected void applyUserAgentResolverToPeer(
+    Function<String,String> r) { }` (no-op default), overridden by the
+    two subclasses so the **native popup path** can reach the resolver.
+- **EmbeddedWebView / OffscreenWebView** (modified, resolver).
+  `setUserAgentResolver(Function<String,String>)` →
+  `WebViewNative.webview_embed_set_user_agent_resolver(peer, r)` /
+  `webview_offscreen_set_user_agent_resolver(peer, r)`.
+- **WebViewNative** (modified, resolver). `native static void
+  webview_embed_set_user_agent_resolver(long w, Object resolver);` and
+  the offscreen counterpart. The parameter is typed `Object` at the
+  JNI boundary and invoked reflectively as
+  `java.util.function.Function#apply`, so no new callback interface is
+  introduced.
+- **Native `Engine`** (modified, resolver — all three engines). Gains a
+  JNI **global reference** to the resolver object (cleared and
+  re-created on each set, deleted on engine destroy) plus a cached
+  `Function.apply` method id, and a `resolve_ua_for(Engine*, const
+  char* url)` helper that attaches the current thread to the JVM,
+  invokes the resolver, clears any pending exception, and returns a
+  freshly allocated UTF-8 string or `nullptr`.
+- **WebViewComponentUserAgentResolverTest** (new).
 - **WebViewComponentUserAgentTest** (new), **README.md** (modified).
 
 ```mermaid
@@ -215,6 +323,40 @@ OffscreenWebView ..> WebViewNative : JNI
      Nested popups reuse the opener engine, so they inherit the same
      override.
 
+6. **Resolve in Java where Java drives the navigation; upcall only
+   where the engine does.** Of the three consultation points, (a) the
+   initial navigation and (b) a Java-initiated `setUrl` are both
+   driven from Java, which already knows the target URL — so those
+   resolve **entirely in Java**: `resolveUserAgentFor(url)` runs the
+   precedence chain and the result is pushed through the existing
+   `setUserAgent` path *before* `navigate` is called. Only (c), the
+   popup child, is engine-driven: WebKit/WebView2 creates the child and
+   starts its request without asking Java, so that site alone needs a
+   native **upcall** into the resolver. This keeps the new native
+   surface to a single helper per engine and leaves the well-tested
+   Java UA path in charge of everything else.
+
+7. **Popup resolution replaces opener-copy only when it answers.** At
+   each popup-child creation site the child's target URL is already in
+   hand (macOS: the navigation action's `request.URL`; Linux: the
+   `WebKitNavigationAction`'s request URI; Windows: the
+   `NewWindowRequested` args' `Uri`). The site asks the opener
+   engine's resolver for that URL first; a non-empty answer is applied
+   to the child and the opener-copy is skipped, while a `null`/empty
+   answer — or no resolver at all — falls through to the existing
+   opener-copy behaviour unchanged. So 1.4.0 semantics survive exactly
+   for callers that never set a resolver.
+
+8. **Resolver lifetime across JNI.** The resolver is held as a JNI
+   global reference on the engine so it outlives the Java call that
+   set it; setting a new resolver deletes the previous global ref, and
+   engine destruction deletes it too. The upcall attaches the calling
+   engine thread to the JVM (the popup sites run on the engine UI
+   thread, which on Windows is the WebView2 worker thread and is not
+   otherwise attached), and always clears any pending exception before
+   returning, so a throwing resolver can never propagate into engine
+   code.
+
 ## S · Structure
 
 ### Inheritance Relationships
@@ -227,15 +369,24 @@ OffscreenWebView ..> WebViewNative : JNI
    (`EmbeddedWebView`/`OffscreenWebView`).
 2. Engine wrappers → `WebViewNative` natives → per-engine setter.
 3. `createPeer()` / `addNotify()` → apply pending UA before navigate.
-4. Popup-child creation site → opener's effective override (read from
-   the opener view on macOS/Linux, from the opener `Engine`'s tracked
-   value on Windows) → child view's UA, before the child's in-flight
-   initial navigation.
+4. Popup-child creation site → opener engine's **resolver** keyed on
+   the child's target URL, falling back to the opener's effective
+   override (read from the opener view on macOS/Linux, from the opener
+   `Engine`'s tracked value on Windows) → child view's UA, before the
+   child's in-flight initial navigation.
+5. `WebViewComponent.setUrl` / attach path →
+   `resolveUserAgentFor(url)` → `setUserAgent` → engine wrapper, before
+   `navigate`.
+6. `WebViewComponent.setUserAgentResolver` → engine wrapper →
+   `WebViewNative` resolver natives → engine-held global ref, used
+   only by the popup-child sites.
 
 ### Layered Architecture
 1. Native engine layer (`src_c/webview_embed.cpp`,
-   `windows/webview_embed.cc`): setters + JNI bridges.
-2. JNI surface (`WebViewNative`): two decls.
+   `windows/webview_embed.cc`): setters, the resolver holder +
+   `resolve_ua_for` upcall helper, and JNI bridges.
+2. JNI surface (`WebViewNative`): four decls (UA setter + resolver
+   setter, embed and offscreen).
 3. Engine wrapper layer (`EmbeddedWebView`/`OffscreenWebView`).
 4. Component API layer (`WebViewComponent`).
 5. Wiring layer (`createPeer`/`addNotify`).
@@ -359,6 +510,113 @@ NATIVE_WINDOW dispositions, on all three engines.
       Nested popups reuse the opener engine, so they inherit the same
       override.
 
+### 10. Resolver API on WebViewComponent
+File: `src/ca/weblite/webview/swing/WebViewComponent.java`
+1. Add `protected Function<String,String> pendingUserAgentResolver =
+   null;` beside `pendingUserAgent`.
+2. `public WebViewComponent setUserAgentResolver(
+   Function<String,String> r)`: store; if the peer is attached, call
+   `applyUserAgentResolverToPeer(r)`. Return `this`. `null` clears.
+3. `public Function<String,String> getUserAgentResolver()`.
+4. `protected String resolveUserAgentFor(String url)`: when a resolver
+   is set and `url` is non-blank, call it inside a `try`/`catch
+   (Throwable)`; a non-null, non-blank return wins. Otherwise return
+   `pendingUserAgent`. Never throws.
+5. `protected void applyUserAgentResolverToPeer(Function<String,String>
+   r) { }` — no-op default, overridden by both subclasses.
+
+### 11. Consult the resolver on Java-driven navigations
+1. `WebViewComponent.setUrl(String url)`: before handing the URL to
+   the peer, compute `String ua = resolveUserAgentFor(url)` and, when
+   it differs from the UA currently applied to the peer, apply it via
+   the existing live-apply path. Track the last-applied value so an
+   unchanged UA does not re-enter the engine setter on every
+   navigation.
+2. `WebViewHeavyweightComponent.createPeer()` and
+   `WebViewLightweightComponent.addNotify()`: replace the bare
+   `if (pendingUserAgent != null) …setUserAgent(pendingUserAgent)` with
+   `String ua = resolveUserAgentFor(pendingUrl); if (ua != null)
+   …setUserAgent(ua);`, still **before** the initial `navigate`, and
+   then push the resolver down via `…setUserAgentResolver(
+   pendingUserAgentResolver)` when one is set. With no resolver,
+   `resolveUserAgentFor` returns `pendingUserAgent` and the behaviour
+   is identical to 1.4.0.
+3. Both subclasses override `applyUserAgentResolverToPeer` against
+   their engine wrapper (`embedded` / `engine`), mirroring
+   `applyUserAgentToPeer`.
+
+### 12. Resolver plumbing to native
+1. `EmbeddedWebView.setUserAgentResolver(Function<String,String> r)`:
+   `checkAlive()`; retain `r` in the existing `heap` set (as
+   `setDownloadCallback` does) so it is not collected;
+   `WebViewNative.webview_embed_set_user_agent_resolver(peer, r)`.
+2. `OffscreenWebView.setUserAgentResolver(...)`: same against
+   `webview_offscreen_set_user_agent_resolver`.
+3. `WebViewNative`: add `native static void
+   webview_embed_set_user_agent_resolver(long w, Object resolver);` and
+   `native static void webview_offscreen_set_user_agent_resolver(
+   long peer, Object resolver);`. Block comment: the object is invoked
+   as `java.util.function.Function#apply(Object)Object`; `null` clears;
+   the upcall runs on the engine UI thread and never throws across JNI.
+
+### 13. Native resolver holder + popup-child resolution
+Files: `src_c/webview_embed.cpp` (macOS + Linux),
+`windows/webview_embed.cc` (Windows)
+1. Each `Engine` gains a `jobject ua_resolver` global ref (initialised
+   `nullptr`) and a cached `jmethodID` for `Function.apply`. The
+   resolver setter deletes any previous global ref, creates a new one
+   when the incoming object is non-null, and resolves the method id
+   once from `java/util/function/Function`. Engine destruction deletes
+   the ref.
+2. Add `static char *resolve_ua_for(Engine *e, const char *url)`:
+   returns `nullptr` when the engine, resolver or url is null.
+   Otherwise attach the current thread to the JVM (`GetEnv`, falling
+   back to `AttachCurrentThread`, detaching again only if this call
+   attached it), build a `jstring` from `url`, invoke
+   `CallObjectMethod`, `ExceptionCheck` → `ExceptionClear` → return
+   `nullptr`, then copy the returned UTF-8 into a freshly allocated
+   buffer (returning `nullptr` for a null or empty result). Callers own
+   and free the buffer.
+3. macOS `impl_create_web_view`: read the child's target URL from the
+   navigation action's `request.URL.absoluteString`, call
+   `resolve_ua_for(e, url)`, and when it yields a value call
+   `setCustomUserAgent:` on the child with it and **skip** the
+   opener-copy. When it yields `nullptr`, run the existing opener-copy
+   unchanged. Still before the `if (!adopt)` window setup, so both
+   dispositions are covered.
+4. Linux `handle_create_web_view`: take the child's target URI from the
+   `WebKitNavigationAction`'s request, call `resolve_ua_for`, and on a
+   value set it on the child's `WebKitSettings`, skipping the
+   opener-copy; otherwise fall through to the existing copy.
+5. Windows `NewWindowRequestedHandler`: read the target from the args'
+   `get_Uri`, call `resolve_ua_for` (the handler already runs on the
+   WebView2 worker thread, which the helper attaches), and on a value
+   `put_UserAgent` it on the child via `ICoreWebView2Settings2`,
+   skipping the tracked-override copy; otherwise fall through. Applies
+   to both the ADOPT and NATIVE_WINDOW branches, before
+   `deferral->Complete()`.
+6. JNI bridges for the two resolver setters in the existing
+   `extern "C"` block, dispatching per `#ifdef`.
+
+### 14. Resolver test, demo, README
+1. `test/ca/weblite/webview/WebViewComponentUserAgentResolverTest.java`
+   (StubComponent, no native peer): a resolver returning a UA for one
+   host and `null` for another proves per-host selection and
+   fall-through to the static UA; a blank return falls through; a
+   resolver that throws falls through instead of propagating;
+   `getUserAgentResolver()` round-trips and `null` clears;
+   `resolveUserAgentFor` returns `pendingUserAgent` when no resolver is
+   set and `null` when neither is set.
+2. `WebViewAdoptPopupDemo` gains a **Resolver** toggle that installs a
+   resolver mapping `httpbin.org` to a distinctive UA while leaving
+   other hosts at the static field's value, so opening the
+   `window.open → https://httpbin.org/user-agent` popup echoes the
+   resolver's UA rather than the opener's — the on-device proof for
+   point (c).
+3. README "Per-host user agent" subsection: the resolver API, the
+   precedence chain, the three consultation points, the
+   fall-through-on-null rule, and the cross-host-redirect limitation.
+
 ## N · Norms
 
 - **Mirror `pendingUrl`** lifecycle: store on the component, apply at
@@ -370,7 +628,19 @@ NATIVE_WINDOW dispositions, on all three engines.
   conversion released on every path.
 - **Java 8 target**; get-style accessors (`setUserAgent`/
   `getUserAgent`) matching `setUrl`/`getUrl`.
-- **No new dependency; no JS shim; no reserved binding.**
+- **No new dependency; no JS shim; no reserved binding.** The
+  resolver is a `java.util.function.Function`, already in Java 8 — no
+  new callback interface is introduced.
+- **Resolver falls through, never overrides downward.** A `null` or
+  blank resolver return means "I have no opinion" and yields to the
+  static UA; only the absence of both yields the engine default. A
+  resolver can never be used to *force* the engine default.
+- **A resolver never breaks a navigation.** Every call site wraps the
+  invocation and treats any throw as a `null` return, in Java and
+  across JNI alike.
+- **Resolve in Java wherever Java drives the navigation.** The native
+  upcall exists solely for the engine-driven popup child; no other
+  site may add one.
 - **Popup inheritance runs at the child-creation site, before the
   child's in-flight navigation**, covers both dispositions on all three
   engines, and never propagates an empty override: an opener at the
@@ -406,6 +676,24 @@ NATIVE_WINDOW dispositions, on all three engines.
   the sandbox): confirm the popup's first request carries the opener's
   UA via an echo endpoint (`WebViewAdoptPopupDemo` `window.open` →
   `https://httpbin.org/user-agent`), for both ADOPT and NATIVE_WINDOW.
+- **Resolver backward compatibility (never-relax):** with no resolver
+  set, every path — attach, `setUrl`, and both popup dispositions on
+  all three engines — behaves byte-for-byte as in 1.4.0, including the
+  opener-copy popup inheritance.
+- **Resolver precedence is fall-through:** resolver result (non-null,
+  non-blank) → static `setUserAgent` → engine default. Verified
+  headlessly; a blank or throwing resolver must not clear a static UA.
+- **Resolver upcall safety:** the JNI helper attaches the calling
+  thread when needed and detaches only if it attached, always clears a
+  pending exception before returning, and never lets a Java throwable
+  reach engine code. The resolver is held as a global ref so it
+  survives the setting call; the ref is deleted on replacement and on
+  engine destroy (no leak, no use-after-free).
+- **Cross-host redirect limitation (accepted, documented):** a
+  server-side redirect crossing hosts mid-navigation keeps the UA the
+  navigation started with. This is deliberate — see the rejected
+  per-navigation interception in Requirements — and must be stated in
+  the README rather than worked around.
 - **Native coverage status (mirrors Canvas 15/18):** the Java
   contract (Ops 1–5, 8) plus the macOS + Linux native setters (Op 6)
   and the Windows setter (Op 7) are this canvas's deliverable. The
@@ -424,6 +712,7 @@ NATIVE_WINDOW dispositions, on all three engines.
 - `src_c/webview_embed.cpp` (macOS + Linux)
 - `windows/webview_embed.cc` (Windows)
 - `test/ca/weblite/webview/WebViewComponentUserAgentTest.java`
+- `test/ca/weblite/webview/WebViewComponentUserAgentResolverTest.java`
 - `demos/WebViewAdoptPopupDemo/…` (UA field; shared with Canvas 18)
 - `run-mac-adopt-popup-demo.sh`
 - `README.md`

--- a/spdd/prompt/8-20260516-0719-[Feat]-Native-Library-Loading-And-Packaging.md
+++ b/spdd/prompt/8-20260516-0719-[Feat]-Native-Library-Loading-And-Packaging.md
@@ -82,6 +82,21 @@ generated_at: 2026-05-16T07:19:13-07:00
   manually before the WebView dylib avoids a SIGSEGV at PC=0 on
   the first JAWT call. The comment at
   `WebViewNative.java:25` records the diagnosis.
+- **The native libraries therefore do not LINK JAWT.** This is the
+  direct consequence of the preload above, and it was never written
+  down. JAWT symbols are left **undefined at link time** and resolve
+  at load time against the `libjawt` the loader has already brought
+  in — on macOS via `-Wl,-undefined,dynamic_lookup`, on Linux by
+  simply not passing `-ljawt` (the symbols come from the already
+  loaded JVM). Linking `-ljawt` contradicts the design twice over:
+  the loader already tolerates JDKs that **do not ship `libjawt` as
+  a standalone loadable library** (Safeguards), so a link-time
+  dependency on it makes the build require a file the canvas
+  explicitly says may not exist — which is exactly how
+  `build-mac.sh` came to fail with `ld: library 'jawt' not found`
+  on a stock JDK. Both CI workflows already build this way, and CI
+  produces the shipped artifact, so the developer scripts were the
+  outlier rather than CI.
 - **Per-architecture directory inside the jar.** The Maven
   resource configuration explicitly packages native
   subdirectories (`linux_64/**`, `linux_arm64/**`, `osx_64/**`,
@@ -142,6 +157,10 @@ generated_at: 2026-05-16T07:19:13-07:00
   the host OS/arch and drop it under `natives/<arch>/`. A local
   `mvn package` after one of these produces a jar containing only
   that host's native lib (sufficient for local smoke testing).
+  They must match the CI recipe for their platform in **linkage**
+  and in **which translation units they compile** (Operation 8);
+  a script that diverges produces a library the shipped one is not,
+  which defeats the point of a local smoke test.
 - `.github/workflows/build.yml` and
   `.github/workflows/maven-release.yml` — the canonical six-way
   build pipeline. A `native` matrix job per platform produces and
@@ -399,6 +418,49 @@ Files: `src_c/webkit_loader.h`, `src_c/webkit_loader.cpp`,
    per-version build, alongside the existing Windows WebView2-Runtime
    note.
 
+### 8. Developer Build Scripts Match the CI Recipe
+Files: `build-mac.sh`, `build-linux.sh`
+
+1. Responsibility: produce, for the host platform only, a native
+   library whose **linkage and translation units are identical to
+   what the CI matrix produces for that same platform** — so a local
+   `mvn package` smoke test exercises the library that actually
+   ships, not a differently-linked lookalike.
+
+2. **No `-ljawt`, anywhere.** Remove the JAWT link flag from both
+   scripts. It contradicts the two-phase preload (Approach) and
+   depends on a file the Safeguards say may not exist.
+   - `build-mac.sh` links with `-Wl,-undefined,dynamic_lookup`,
+     leaving the `JAWT_*` symbols to resolve at load time.
+   - `build-linux.sh` passes no JAWT flag at all; the symbols come
+     from the already-loaded JVM. Its `-lX11 -ldl` and the
+     GTK-only `pkg-config --libs` from Operation 7.4 are unchanged.
+
+3. **Translation units per platform, matching CI.**
+   - macOS compiles **only** `src_c/webview_embed.cpp`. It does not
+     compile `src_c/webview.c` (which is C built as C++ and only
+     emits a deprecation warning there).
+   - Linux compiles `src_c/webview.c`, `src_c/webview_embed.cpp`
+     and `src_c/webkit_loader.cpp`, as Operation 7.4 already
+     requires.
+
+4. **Host architecture, not a hardcoded one.** The Entities section
+   already says these scripts drop the library under
+   `natives/<arch>/` for the **host** OS/arch, but `build-mac.sh`
+   hardcodes `natives/osx_64`. On an Apple Silicon Mac that writes an
+   arm64 dylib into the x86_64 directory, and the local jar then
+   cannot load it — the failure surfaces far from its cause, as a
+   missing native library at runtime. `build-mac.sh` must read
+   `uname -m` and select `osx_arm64` for `arm64`/`aarch64` and
+   `osx_64` for `x86_64`.
+
+5. **Known remaining gap, deliberately not closed here:**
+   `build-linux.sh` still hardcodes `natives/linux_64` and
+   `build-windows.sh` still hardcodes `natives/windows_64`, so both
+   mis-place the library on an arm64 host. Only the JAWT flag is
+   corrected in `build-linux.sh`; `build-windows.sh` is untouched
+   (it links no JAWT and delegates to `windows/script/build.bat`).
+
 ## N · Norms
 - The developer `build-*.sh` scripts must quote every shell
   expansion that carries a filesystem path — `"${JAVA_HOME}"`
@@ -453,6 +515,18 @@ Files: `src_c/webkit_loader.h`, `src_c/webkit_loader.cpp`,
   `WebViewNative.java:31`. Do not change this to rethrow:
   some JDKs do not ship `libjawt` as a standalone loadable
   library.
+- **Never link JAWT (never-relax).** Because the line above tolerates
+  a JDK with no standalone `libjawt`, no build entry point — CI job,
+  developer `build-*.sh`, or `run-*` demo script — may pass `-ljawt`
+  or otherwise create a link-time dependency on it. JAWT resolves at
+  load time only. A build that links it fails on exactly the JDKs the
+  loader was written to survive.
+- **CI is the source of truth for linkage (never-relax).** A
+  developer `build-*.sh` must produce a library whose linkage matches
+  what the CI matrix produces for the same platform. Where the two
+  diverge, the script is wrong, not CI — CI builds the artifact that
+  ships, so a local smoke test against a differently-linked library
+  proves nothing about the release.
 - The extractor cleans up leftover libraries older than 5
   minutes (`BaseJniExtractor.java:66`), bounded by the
   `org.scijava.nativelib.leftoverMinAgeMs` system property.

--- a/src/ca/weblite/webview/EmbeddedWebView.java
+++ b/src/ca/weblite/webview/EmbeddedWebView.java
@@ -641,6 +641,32 @@ public class EmbeddedWebView {
     }
 
     /**
+     * Install a per-destination User-Agent resolver: a function from the URL a
+     * navigation is about to load to the User-Agent to present for it.  A
+     * {@code null} or blank return falls through to the static
+     * {@link #setUserAgent(String)} value.
+     *
+     * <p>Only the engine-driven pop-up path upcalls this natively (a pop-up
+     * child's UA is keyed on the child's own target URL); navigations Java
+     * drives are resolved on the Java side before {@code navigate}.  The
+     * upcall runs on the engine UI thread, so the resolver must be fast and
+     * must not block; one that throws is treated as a {@code null} return.
+     *
+     * @param resolver the resolver, or {@code null} to clear it
+     * @return {@code this} for chaining
+     */
+    public EmbeddedWebView setUserAgentResolver(java.util.function.Function<String, String> resolver) {
+        checkAlive();
+        if (resolver != null) {
+            // Anchored so the JNI global ref never outlives a collectable
+            // Java object (mirrors setDownloadCallback).
+            heap.add(resolver);
+        }
+        WebViewNative.webview_embed_set_user_agent_resolver(peer, resolver);
+        return this;
+    }
+
+    /**
      * Purge the engine's HTTP resource cache (disk + memory), keeping cookies
      * and other site data so an active login survives.  The purge runs on the
      * engine UI thread; trigger a navigation afterwards to refetch from the

--- a/src/ca/weblite/webview/OffscreenWebView.java
+++ b/src/ca/weblite/webview/OffscreenWebView.java
@@ -510,6 +510,30 @@ public class OffscreenWebView {
     }
 
     /**
+     * Install a per-destination User-Agent resolver: a function from the URL a
+     * navigation is about to load to the User-Agent to present for it.  A
+     * {@code null} or blank return falls through to the static
+     * {@link #setUserAgent(String)} value.
+     *
+     * <p>Only the engine-driven pop-up path upcalls this natively (a pop-up
+     * child's UA is keyed on the child's own target URL); navigations Java
+     * drives are resolved on the Java side before {@code navigate}.  The
+     * upcall runs on the engine UI thread, so the resolver must be fast and
+     * must not block; one that throws is treated as a {@code null} return.
+     *
+     * @param resolver the resolver, or {@code null} to clear it
+     * @return {@code this} for chaining
+     */
+    public OffscreenWebView setUserAgentResolver(java.util.function.Function<String, String> resolver) {
+        checkAlive();
+        if (resolver != null) {
+            heap.add(resolver);
+        }
+        WebViewNative.webview_offscreen_set_user_agent_resolver(peer, resolver);
+        return this;
+    }
+
+    /**
      * Purge the offscreen engine's HTTP resource cache (disk + memory),
      * keeping cookies and other site data.  Runs on the engine UI thread;
      * trigger a navigation afterwards to refetch from the network.

--- a/src/ca/weblite/webview/WebViewNative.java
+++ b/src/ca/weblite/webview/WebViewNative.java
@@ -340,6 +340,18 @@ native static void webview_embed_set_download_callback(long w, WebViewDownloadCa
 // Passing 0 for w is a silent no-op.  Never throws via JNI.
 native static void webview_embed_set_user_agent(long w, String ua);
 
+// Install a per-destination User-Agent resolver on the embedded WebView.  The
+// resolver is invoked as java.util.function.Function#apply(Object)Object with
+// the URL a navigation is about to load, and returns the User-Agent to present
+// for it (null or empty => fall through to the static setUserAgent value).
+// Held as a JNI global reference until replaced or the engine is destroyed;
+// resolver == null clears it.  Only the engine-driven popup-child path upcalls
+// it -- navigations Java drives resolve on the Java side.  The upcall runs on
+// the engine UI thread, attaches that thread to the JVM when needed, and clears
+// any pending exception, so a throwing resolver falls through instead of
+// propagating.  Passing 0 for w is a silent no-op.  Never throws via JNI.
+native static void webview_embed_set_user_agent_resolver(long w, Object resolver);
+
 // Purge the embedded WebView's HTTP resource cache (disk + memory) so the
 // next navigation re-fetches from the network.  Clears the resource cache
 // ONLY: cookies, local storage, and service-worker registrations are left
@@ -495,6 +507,11 @@ native static void webview_offscreen_set_download_callback(long peer, WebViewDow
 // and this is a native-side no-op.  ua == null clears the override.  Never
 // throws via JNI.
 native static void webview_offscreen_set_user_agent(long peer, String ua);
+
+// Offscreen counterpart to webview_embed_set_user_agent_resolver.  Same
+// contract; Linux only, a native-side no-op where the offscreen engine is a
+// stub.
+native static void webview_offscreen_set_user_agent_resolver(long peer, Object resolver);
 
 // Offscreen counterpart to webview_embed_clear_cache.  Linux purges the
 // WebKitGTK context's HTTP resource cache; macOS / Windows offscreen engines

--- a/src/ca/weblite/webview/swing/WebViewComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewComponent.java
@@ -20,6 +20,7 @@ import ca.weblite.webview.WebViewMouseListener;
 
 import java.io.PrintStream;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import javax.swing.JComponent;
 
 /**
@@ -241,6 +242,7 @@ public abstract class WebViewComponent extends JComponent {
      */
     public WebViewComponent setUserAgent(String ua) {
         pendingUserAgent = (ua == null || ua.isEmpty()) ? null : ua;
+        lastAppliedUserAgentValid = false;
         applyUserAgentToPeer(pendingUserAgent);
         return this;
     }
@@ -255,6 +257,108 @@ public abstract class WebViewComponent extends JComponent {
      *  No-op on the base class and when no peer is attached; subclasses
      *  forward to their engine wrapper's {@code setUserAgent}. */
     protected void applyUserAgentToPeer(String ua) {
+    }
+
+    /** Per-destination User-Agent resolver, or {@code null} when none is
+     *  set.  Survives the peer's create/destroy cycle alongside
+     *  {@link #pendingUserAgent}. */
+    protected Function<String, String> pendingUserAgentResolver = null;
+
+    /** The User-Agent last pushed to the peer, so an unchanged value is not
+     *  re-entered into the engine setter on every navigation. */
+    private String lastAppliedUserAgent = null;
+    private boolean lastAppliedUserAgentValid = false;
+
+    /**
+     * Install a <b>per-destination</b> User-Agent resolver: a function from
+     * the URL a navigation is about to load to the User-Agent to present for
+     * it.  This lets one embedded browser show a different UA per destination
+     * host — useful when two sites want opposite things (one rejects the
+     * engine's own UA as an unsupported browser, another penalises the
+     * mainstream UA the first one demands).
+     *
+     * <p><b>Precedence.</b>  The resolver's answer wins when it is non-null
+     * and non-blank; otherwise the static {@link #setUserAgent(String)} value
+     * applies; otherwise the engine default.  A {@code null} or blank return
+     * therefore means <em>fall through</em>, not "use the engine default" — a
+     * resolver can never force the engine default over a static override.
+     *
+     * <p><b>When it is consulted.</b>  At exactly three points, each a
+     * navigation that is about to start and that this library controls:
+     * before a view's initial navigation, before any Java-initiated
+     * {@link #setUrl(String)} on a live view, and before a browser-initiated
+     * pop-up child's first navigation (keyed on the pop-up's own target URL,
+     * so an OAuth sign-in opened from a UA-spoofing site can present a
+     * different UA than its opener).
+     *
+     * <p><b>Limitation.</b>  This is not per-request switching: a server-side
+     * redirect that crosses hosts <em>during</em> a navigation keeps the UA
+     * that navigation started with.
+     *
+     * <p><b>Threading.</b>  The resolver is invoked on the engine UI thread
+     * immediately before the navigation it governs, so it must be fast and
+     * must not block.  A resolver that throws is swallowed and treated as a
+     * {@code null} return — it can never break a navigation.
+     *
+     * @param resolver the resolver, or {@code null} to clear it
+     * @return {@code this} for chaining
+     */
+    public WebViewComponent setUserAgentResolver(Function<String, String> resolver) {
+        pendingUserAgentResolver = resolver;
+        lastAppliedUserAgentValid = false;
+        applyUserAgentResolverToPeer(resolver);
+        return this;
+    }
+
+    /** @return the per-destination User-Agent resolver, or {@code null}. */
+    public Function<String, String> getUserAgentResolver() {
+        return pendingUserAgentResolver;
+    }
+
+    /**
+     * Run the User-Agent precedence chain for a navigation to {@code url}:
+     * the resolver's answer when non-null and non-blank, else the static
+     * {@link #pendingUserAgent}, else {@code null} (engine default).  Never
+     * throws — a resolver that fails falls through to the static value.
+     */
+    protected String resolveUserAgentFor(String url) {
+        Function<String, String> r = pendingUserAgentResolver;
+        if (r != null && url != null && url.trim().length() > 0) {
+            try {
+                String ua = r.apply(url);
+                if (ua != null && ua.trim().length() > 0) {
+                    return ua;
+                }
+            } catch (Throwable ignored) {
+                // A resolver must never be able to break a navigation.
+            }
+        }
+        return pendingUserAgent;
+    }
+
+    /**
+     * Resolve and apply the User-Agent for an imminent navigation to
+     * {@code url}.  Applied only when it differs from the value last pushed
+     * to the peer, so an unchanged UA does not re-enter the engine setter on
+     * every navigation.  Called from the attach path (before the first
+     * navigate) and from each subclass's {@link #setUrl(String)}.
+     */
+    protected void applyResolvedUserAgentFor(String url) {
+        String ua = resolveUserAgentFor(url);
+        if (lastAppliedUserAgentValid
+                && (ua == null ? lastAppliedUserAgent == null : ua.equals(lastAppliedUserAgent))) {
+            return;
+        }
+        applyUserAgentToPeer(ua);
+        lastAppliedUserAgent = ua;
+        lastAppliedUserAgentValid = true;
+    }
+
+    /** Push the (possibly {@code null}) resolver down to the live native peer
+     *  so the engine-driven pop-up path can consult it.  No-op on the base
+     *  class and when no peer is attached; subclasses forward to their engine
+     *  wrapper's {@code setUserAgentResolver}. */
+    protected void applyUserAgentResolverToPeer(Function<String, String> resolver) {
     }
 
     /**

--- a/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewHeavyweightComponent.java
@@ -122,6 +122,9 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
     public WebViewComponent setUrl(String url) {
         pendingUrl = url;
         if (embedded != null) {
+            // Resolve the User-Agent for this destination before navigating,
+            // so the request carries it (Canvas 21, consultation point (b)).
+            applyResolvedUserAgentFor(url);
             embedded.navigate(url);
         }
         return this;
@@ -464,6 +467,14 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
     }
 
     @Override
+    protected void applyUserAgentResolverToPeer(java.util.function.Function<String, String> resolver) {
+        EmbeddedWebView e = embedded;
+        if (e != null) {
+            e.setUserAgentResolver(resolver);
+        }
+    }
+
+    @Override
     protected void clearCacheOnPeer() {
         EmbeddedWebView e = embedded;
         if (e != null) {
@@ -542,9 +553,16 @@ public class WebViewHeavyweightComponent extends WebViewComponent {
             embedded.addJavascriptFunction(e.getKey(), e.getValue());
         }
         // Apply any custom User-Agent BEFORE the first navigate so the
-        // initial request carries it.
-        if (pendingUserAgent != null) {
-            embedded.setUserAgent(pendingUserAgent);
+        // initial request carries it.  With no resolver installed this
+        // resolves to pendingUserAgent, i.e. the pre-1.5.0 behaviour.
+        String initialUa = resolveUserAgentFor(pendingUrl);
+        if (initialUa != null) {
+            embedded.setUserAgent(initialUa);
+        }
+        // Push the resolver down so the engine-driven popup path can key a
+        // child's UA off the child's own target URL (consultation point (c)).
+        if (pendingUserAgentResolver != null) {
+            embedded.setUserAgentResolver(pendingUserAgentResolver);
         }
         // An adopted popup already carries the engine's own in-flight
         // navigation (the original request WebKit drove into the child, POST

--- a/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
+++ b/src/ca/weblite/webview/swing/WebViewLightweightComponent.java
@@ -206,6 +206,14 @@ public class WebViewLightweightComponent extends WebViewComponent {
     }
 
     @Override
+    protected void applyUserAgentResolverToPeer(java.util.function.Function<String, String> resolver) {
+        OffscreenWebView e = engine;
+        if (e != null) {
+            e.setUserAgentResolver(resolver);
+        }
+    }
+
+    @Override
     protected void clearCacheOnPeer() {
         OffscreenWebView e = engine;
         if (e != null) {
@@ -412,9 +420,16 @@ public class WebViewLightweightComponent extends WebViewComponent {
         }
         allocateBuffer(w, h);
         // Apply any custom User-Agent BEFORE the first navigate so the
-        // initial request carries it.
-        if (pendingUserAgent != null) {
-            engine.setUserAgent(pendingUserAgent);
+        // initial request carries it.  With no resolver installed this
+        // resolves to pendingUserAgent, i.e. the pre-1.5.0 behaviour.
+        String initialUa = resolveUserAgentFor(pendingUrl);
+        if (initialUa != null) {
+            engine.setUserAgent(initialUa);
+        }
+        // Push the resolver down so the engine-driven popup path can key a
+        // child's UA off the child's own target URL (consultation point (c)).
+        if (pendingUserAgentResolver != null) {
+            engine.setUserAgentResolver(pendingUserAgentResolver);
         }
         // An adopted popup already carries the engine's own in-flight
         // navigation (the original request WebKit drove into the child, POST
@@ -556,6 +571,9 @@ public class WebViewLightweightComponent extends WebViewComponent {
     public WebViewComponent setUrl(String url) {
         pendingUrl = url;
         if (engine != null) {
+            // Resolve the User-Agent for this destination before navigating,
+            // so the request carries it (Canvas 21, consultation point (b)).
+            applyResolvedUserAgentFor(url);
             engine.navigate(url);
         }
         return this;

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -428,6 +428,12 @@ struct Engine {
     // Canvas 16.  A child (popup) web view inherits this ref via its own
     // PopupEngine so nested popups work.
     jobject popup_callback = nullptr;
+    // Canvas 21 (1.5.0): per-destination User-Agent resolver
+    // (java.util.function.Function<String,String>) as a JNI global ref.
+    // Consulted at the popup-child creation site with the CHILD's target
+    // URL; a decline falls back to copying the opener's UA.  Deleted on
+    // replacement and on engine destroy.
+    jobject ua_resolver = nullptr;
 
     Engine() {}
     ~Engine() {}
@@ -918,6 +924,9 @@ struct PopupEngine {
     WebKitWebView *web = nullptr;       // the related child web view
     JavaVM *jvm = nullptr;
     jobject popup_callback = nullptr;   // inherited global ref
+    // Canvas 21 (1.5.0): inherited global ref, so a nested popup resolves
+    // its own child's UA the same way its opener did.
+    jobject ua_resolver = nullptr;
     jobject dialog_callback = nullptr;  // inherited global ref, may be null
     jobject download_callback = nullptr; // inherited global ref, may be null
     jlong popup_id = 0;
@@ -1024,6 +1033,51 @@ static int fire_popup_disposition(JavaVM *jvm, jobject cb,
     if (jp) env->DeleteLocalRef(jp);
     if (detach) jvm->DetachCurrentThread();
     return disposition;
+}
+
+// Canvas 21 (1.5.0): ask the per-destination User-Agent resolver which UA to
+// present for a navigation to `url`.  Returns a freshly allocated UTF-8 string
+// the CALLER must free(), or nullptr when there is no resolver, no url, or the
+// resolver declines (a null/empty return) or throws.  A resolver must never be
+// able to break a navigation, so a pending exception is cleared and treated as
+// a decline -- the caller then falls back to the opener-copy behaviour.
+// Invoked on the engine UI thread, which is not necessarily attached to the
+// JVM, so it attaches and detaches symmetrically.  The resolver object is
+// java.util.function.Function, invoked reflectively as apply(Object)Object.
+static char *resolve_ua_for(JavaVM *jvm, jobject resolver, const char *url) {
+    if (!jvm || !resolver || !url || !*url) return nullptr;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return nullptr;
+        detach = true;
+    }
+    char *out = nullptr;
+    jstring ju = env->NewStringUTF(url);
+    jclass cls = env->GetObjectClass(resolver);
+    if (cls && ju) {
+        jmethodID mid = env->GetMethodID(cls, "apply",
+            "(Ljava/lang/Object;)Ljava/lang/Object;");
+        if (mid) {
+            jobject r = env->CallObjectMethod(resolver, mid, ju);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+                r = nullptr;
+            }
+            if (r) {
+                const char *cs = env->GetStringUTFChars((jstring)r, nullptr);
+                if (cs && *cs) out = strdup(cs);
+                if (cs) env->ReleaseStringUTFChars((jstring)r, cs);
+                env->DeleteLocalRef(r);
+            }
+        }
+    }
+    if (cls) env->DeleteLocalRef(cls);
+    if (ju) env->DeleteLocalRef(ju);
+    if (detach) jvm->DetachCurrentThread();
+    return out;
 }
 
 // Fire onPopupOpened.  CallVoidMethod (fire-and-forget); the Java dispatcher
@@ -1159,6 +1213,7 @@ static void on_close_popup(WebKitWebView *web, gpointer user_data);
 // WebKitWebView for WebKit to adopt, or NULL to block the popup.
 static GtkWidget *handle_create_web_view(JavaVM *jvm, jobject popup_cb,
                                          jobject dialog_cb,
+                                         jobject ua_resolver,
                                          WebKitWebView *opener,
                                          WebKitNavigationAction *nav) {
     if (!popup_cb) return NULL;
@@ -1208,12 +1263,26 @@ static GtkWidget *handle_create_web_view(JavaVM *jvm, jobject popup_cb,
     // yields the engine default.  Composes for nested popups: a popup's child
     // reads the popup view's already-propagated UA.  Covers BOTH the ADOPT and
     // NATIVE_WINDOW dispositions.
-    if (opener) {
-        WebKitSettings *os = webkit_web_view_get_settings(opener);
+    //
+    // Canvas 21 (1.5.0): when a per-destination resolver is installed, the
+    // child's UA is chosen from the CHILD's own target URL rather than copied
+    // from the opener -- the case that matters is an OAuth sign-in popped out
+    // of a site that requires a spoofed UA, landing on an identity provider
+    // that penalises exactly that spoof.  A resolver that declines (or none at
+    // all) falls through to the opener-copy below, so pre-1.5.0 behaviour is
+    // preserved byte-for-byte for callers that never set one.
+    {
         WebKitSettings *cs = webkit_web_view_get_settings(child);
-        if (os && cs) {
-            const char *oua = webkit_settings_get_user_agent(os);
-            if (oua) webkit_settings_set_user_agent(cs, oua);
+        char *resolved = resolve_ua_for(jvm, ua_resolver, uri);
+        if (resolved) {
+            if (cs) webkit_settings_set_user_agent(cs, resolved);
+            free(resolved);
+        } else if (opener) {
+            WebKitSettings *os = webkit_web_view_get_settings(opener);
+            if (os && cs) {
+                const char *oua = webkit_settings_get_user_agent(os);
+                if (oua) webkit_settings_set_user_agent(cs, oua);
+            }
         }
     }
 
@@ -1256,6 +1325,9 @@ static GtkWidget *handle_create_web_view(JavaVM *jvm, jobject popup_cb,
     if (env) {
         pe->popup_callback = env->NewGlobalRef(popup_cb);
         if (dialog_cb) pe->dialog_callback = env->NewGlobalRef(dialog_cb);
+        // Canvas 21 (1.5.0): a nested popup resolves its own child's UA the
+        // same way its opener did, so the resolver is inherited transitively.
+        if (ua_resolver) pe->ua_resolver = env->NewGlobalRef(ua_resolver);
         // Downloads started in a popup belong to the OPENER's handler --
         // a transfer is the user's, not a property of which view began
         // it (Canvas 24).  The opener's DownloadSink is the source of
@@ -1391,10 +1463,12 @@ static void on_close_popup(WebKitWebView *web, gpointer user_data) {
         // (Canvas 24).
         if (pe->web) gtk_clear_download_sink(GTK_WIDGET(pe->web), env);
         if (pe->download_callback) env->DeleteGlobalRef(pe->download_callback);
+        if (pe->ua_resolver) env->DeleteGlobalRef(pe->ua_resolver);
         if (detach) pe->jvm->DetachCurrentThread();
     }
     pe->popup_callback = nullptr;
     pe->dialog_callback = nullptr;
+    pe->ua_resolver = nullptr;
     pe->download_callback = nullptr;
     delete pe;
 }
@@ -1405,7 +1479,8 @@ static GtkWidget *on_create_web_view_popup(WebKitWebView *web,
     PopupEngine *pe = static_cast<PopupEngine *>(user_data);
     if (!pe) return NULL;
     return handle_create_web_view(pe->jvm, pe->popup_callback,
-                                  pe->dialog_callback, web, nav);
+                                  pe->dialog_callback, pe->ua_resolver,
+                                  web, nav);
 }
 static gboolean on_script_dialog_popup(WebKitWebView *web,
         WebKitScriptDialog *dialog, gpointer user_data) {
@@ -1429,7 +1504,8 @@ static GtkWidget *on_create_web_view_engine(WebKitWebView *web,
     Engine *e = static_cast<Engine *>(user_data);
     if (!e) return NULL;
     return handle_create_web_view(e->jvm, e->popup_callback,
-                                  e->dialog_callback, web, nav);
+                                  e->dialog_callback, e->ua_resolver,
+                                  web, nav);
 }
 
 static void engine_on_message(Engine *e, const char *msg) {
@@ -1850,6 +1926,20 @@ static Engine *gtk_create_engine(JNIEnv *env, jobject component, jint debug,
 
 static void gtk_destroy_engine(Engine *e) {
     if (!e) return;
+    // Canvas 21 (1.5.0): drop the User-Agent resolver's global ref.  Only the
+    // popup-child creation path reads it, but a late popup during teardown
+    // would follow a freed ref, so it goes with the other callbacks.
+    if (e->ua_resolver) {
+        JNIEnv *env = nullptr;
+        bool detach = false;
+        if (e->jvm && e->jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+            e->jvm->AttachCurrentThread((void **)&env, nullptr);
+            detach = true;
+        }
+        if (env) env->DeleteGlobalRef(e->ua_resolver);
+        e->ua_resolver = nullptr;
+        if (detach) e->jvm->DetachCurrentThread();
+    }
     // Release the click callback's JNI global ref BEFORE we destroy the
     // GtkWidget tree so any pressed signal already dispatched but not yet
     // run sees a null field instead of invoking a freed ref.  Symmetric
@@ -2446,6 +2536,21 @@ static void gtk_set_user_agent(Engine *e, const char *ua) {
     if (s) webkit_settings_set_user_agent(s, ua);
 }
 
+// Canvas 21 (1.5.0): install/clear the per-destination User-Agent resolver.
+// Held as a JNI global ref so it survives the setting call; the previous ref is
+// released first.  Consulted only at the popup-child creation site (navigations
+// Java drives are resolved on the Java side before navigate).
+static void gtk_set_user_agent_resolver(Engine *e, JNIEnv *env, jobject r) {
+    if (!e || !env) return;
+    if (e->ua_resolver) {
+        env->DeleteGlobalRef(e->ua_resolver);
+        e->ua_resolver = nullptr;
+    }
+    if (r) {
+        e->ua_resolver = env->NewGlobalRef(r);
+    }
+}
+
 // Canvas 22: purge the WebKitGTK HTTP resource cache (memory + disk) for the
 // view's web context.  Clears the resource cache only -- the cookie manager
 // is untouched, so an active login survives.
@@ -2542,6 +2647,11 @@ static Engine *gtk_adopt_popup(JNIEnv *env, jobject parent, jlong popupId,
     // gtk_set_popup_callback / gtk_set_dialog_callback at attach).
     e->popup_callback = pe->popup_callback;
     pe->popup_callback = nullptr;
+    // Canvas 21 (1.5.0): the resolver rides along with the callbacks so an
+    // adopted popup keeps resolving its own children's UAs until the
+    // component's attach installs its own.
+    e->ua_resolver = pe->ua_resolver;
+    pe->ua_resolver = nullptr;
     e->dialog_callback = pe->dialog_callback;
     pe->dialog_callback = nullptr;
     // The adopted child keeps the DownloadSink it was created with, so an
@@ -2610,10 +2720,12 @@ static void gtk_discard_popup(jlong popupId) {
         // (Canvas 24).
         if (pe->web) gtk_clear_download_sink(GTK_WIDGET(pe->web), env);
         if (pe->download_callback) env->DeleteGlobalRef(pe->download_callback);
+        if (pe->ua_resolver) env->DeleteGlobalRef(pe->ua_resolver);
         if (detach) pe->jvm->DetachCurrentThread();
     }
     pe->popup_callback = nullptr;
     pe->dialog_callback = nullptr;
+    pe->ua_resolver = nullptr;
     pe->download_callback = nullptr;
     delete pe;
 }
@@ -2658,6 +2770,12 @@ struct OffEngine {
     // gtk_off_create_engine, which routes through the shared
     // handle_create_web_view inner function (Canvas 16).
     jobject popup_callback = nullptr;
+    // Canvas 21 (1.5.0): per-destination User-Agent resolver
+    // (java.util.function.Function<String,String>) as a JNI global ref.
+    // Consulted at the popup-child creation site with the CHILD's target
+    // URL; a decline falls back to copying the opener's UA.  Deleted on
+    // replacement and on engine destroy.
+    jobject ua_resolver = nullptr;
 };
 
 // Per-OffEngine wrapper for the `script-dialog` signal.  Reads page URL,
@@ -2691,7 +2809,8 @@ static GtkWidget *on_create_web_view_off_engine(WebKitWebView *web,
     OffEngine *e = static_cast<OffEngine *>(user_data);
     if (!e) return NULL;
     return handle_create_web_view(e->jvm, e->popup_callback,
-                                  e->dialog_callback, web, nav);
+                                  e->dialog_callback, e->ua_resolver,
+                                  web, nav);
 }
 
 // Parallel of engine_on_message for OffEngine: parse the {name, seq, args}
@@ -2894,6 +3013,20 @@ static OffEngine *gtk_off_create_engine(JNIEnv *env,
 
 static void gtk_off_destroy_engine(OffEngine *e) {
     if (!e) return;
+    // Canvas 21 (1.5.0): drop the User-Agent resolver's global ref.  Only the
+    // popup-child creation path reads it, but a late popup during teardown
+    // would follow a freed ref, so it goes with the other callbacks.
+    if (e->ua_resolver) {
+        JNIEnv *env = nullptr;
+        bool detach = false;
+        if (e->jvm && e->jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+            e->jvm->AttachCurrentThread((void **)&env, nullptr);
+            detach = true;
+        }
+        if (env) env->DeleteGlobalRef(e->ua_resolver);
+        e->ua_resolver = nullptr;
+        if (detach) e->jvm->DetachCurrentThread();
+    }
     // Drop the download-callback global ref and the view's DownloadSink
     // BEFORE the widget is destroyed (Canvas 24) -- same ordering rule
     // as the heavyweight engine.
@@ -3015,6 +3148,21 @@ static void gtk_off_set_user_agent(OffEngine *e, const char *ua) {
     if (s) webkit_settings_set_user_agent(s, ua);
 }
 
+// Canvas 21 (1.5.0): install/clear the per-destination User-Agent resolver.
+// Held as a JNI global ref so it survives the setting call; the previous ref is
+// released first.  Consulted only at the popup-child creation site (navigations
+// Java drives are resolved on the Java side before navigate).
+static void gtk_off_set_user_agent_resolver(OffEngine *e, JNIEnv *env, jobject r) {
+    if (!e || !env) return;
+    if (e->ua_resolver) {
+        env->DeleteGlobalRef(e->ua_resolver);
+        e->ua_resolver = nullptr;
+    }
+    if (r) {
+        e->ua_resolver = env->NewGlobalRef(r);
+    }
+}
+
 // Canvas 22: offscreen counterpart to gtk_clear_cache.
 static void gtk_off_clear_cache(OffEngine *e) {
     if (!e || !e->web) return;
@@ -3124,6 +3272,11 @@ static OffEngine *gtk_off_adopt_popup(JNIEnv *env, jlong popupId,
     // gtk_off_set_popup_callback / gtk_off_set_dialog_callback at attach).
     e->popup_callback = pe->popup_callback;
     pe->popup_callback = nullptr;
+    // Canvas 21 (1.5.0): the resolver rides along with the callbacks so an
+    // adopted popup keeps resolving its own children's UAs until the
+    // component's attach installs its own.
+    e->ua_resolver = pe->ua_resolver;
+    pe->ua_resolver = nullptr;
     e->dialog_callback = pe->dialog_callback;
     pe->dialog_callback = nullptr;
     // The adopted child keeps the DownloadSink it was created with, so an
@@ -3651,6 +3804,12 @@ struct Engine {
     // the opener's PopupDispatcher.  Cleared before ui_delegate is
     // released.
     jobject popup_callback = nullptr;
+    // Canvas 21 (1.5.0): per-destination User-Agent resolver
+    // (java.util.function.Function<String,String>) as a JNI global ref.
+    // Consulted at the popup-child creation site with the CHILD's target
+    // URL; a decline falls back to copying the opener's UA.  Deleted on
+    // replacement and on engine destroy.
+    jobject ua_resolver = nullptr;
 
     // For a child (popup) engine only: the NSWindow the engine created to
     // host the popup web view, and the opaque id correlating the
@@ -4599,6 +4758,51 @@ static int fire_popup_disposition(JavaVM *jvm, jobject cb,
     return disposition;
 }
 
+// Canvas 21 (1.5.0): ask the per-destination User-Agent resolver which UA to
+// present for a navigation to `url`.  Returns a freshly allocated UTF-8 string
+// the CALLER must free(), or nullptr when there is no resolver, no url, or the
+// resolver declines (a null/empty return) or throws.  A resolver must never be
+// able to break a navigation, so a pending exception is cleared and treated as
+// a decline -- the caller then falls back to the opener-copy behaviour.
+// Invoked on the engine UI thread, which is not necessarily attached to the
+// JVM, so it attaches and detaches symmetrically.  The resolver object is
+// java.util.function.Function, invoked reflectively as apply(Object)Object.
+static char *resolve_ua_for(JavaVM *jvm, jobject resolver, const char *url) {
+    if (!jvm || !resolver || !url || !*url) return nullptr;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return nullptr;
+        detach = true;
+    }
+    char *out = nullptr;
+    jstring ju = env->NewStringUTF(url);
+    jclass cls = env->GetObjectClass(resolver);
+    if (cls && ju) {
+        jmethodID mid = env->GetMethodID(cls, "apply",
+            "(Ljava/lang/Object;)Ljava/lang/Object;");
+        if (mid) {
+            jobject r = env->CallObjectMethod(resolver, mid, ju);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+                r = nullptr;
+            }
+            if (r) {
+                const char *cs = env->GetStringUTFChars((jstring)r, nullptr);
+                if (cs && *cs) out = strdup(cs);
+                if (cs) env->ReleaseStringUTFChars((jstring)r, cs);
+                env->DeleteLocalRef(r);
+            }
+        }
+    }
+    if (cls) env->DeleteLocalRef(cls);
+    if (ju) env->DeleteLocalRef(ju);
+    if (detach) jvm->DetachCurrentThread();
+    return out;
+}
+
 // Canvas 18: async notification that a popup child has been retained and is
 // ready to adopt.  Fire-and-forget on a detached worker thread (the Java
 // dispatcher marshals popupAdoptable to the EDT via invokeLater), mirroring
@@ -4724,9 +4928,24 @@ static id impl_create_web_view(id self, SEL, id webView, id configuration,
     // opener correctly leaves the child at the engine default.  Applied here
     // (before the `if (!adopt)` window setup) so it covers BOTH the ADOPT and
     // NATIVE_WINDOW dispositions.
-    id openerUA = e ? msg(e->webview, sel("customUserAgent")) : nullptr;
-    if (openerUA) {
-        msg<void, id>(child, sel("setCustomUserAgent:"), openerUA);
+    //
+    // Canvas 21 (1.5.0): when a per-destination resolver is installed, the
+    // child's UA is chosen from the CHILD's own target URL rather than copied
+    // from the opener -- the case that matters is an OAuth sign-in popped out
+    // of a site that requires a spoofed UA, landing on an identity provider
+    // that penalises exactly that spoof.  A resolver that declines (or none at
+    // all) falls through to the opener-copy, so pre-1.5.0 behaviour is
+    // preserved byte-for-byte for callers that never set one.
+    char *resolvedUA = e ? resolve_ua_for(jvm, e->ua_resolver, target.c_str())
+                         : nullptr;
+    if (resolvedUA) {
+        msg<void, id>(child, sel("setCustomUserAgent:"), ns_str(resolvedUA));
+        free(resolvedUA);
+    } else {
+        id openerUA = e ? msg(e->webview, sel("customUserAgent")) : nullptr;
+        if (openerUA) {
+            msg<void, id>(child, sel("setCustomUserAgent:"), openerUA);
+        }
     }
 
     // Attach a JNIEnv to create the child engine's inherited global refs.
@@ -4776,6 +4995,10 @@ static id impl_create_web_view(id self, SEL, id webView, id configuration,
         // it (Canvas 23).
         if (e->download_callback)
             child_e->download_callback = env->NewGlobalRef(e->download_callback);
+        // Canvas 21 (1.5.0): a nested popup resolves its own child's UA the
+        // same way its opener did, so the resolver is inherited transitively.
+        if (e->ua_resolver)
+            child_e->ua_resolver = env->NewGlobalRef(e->ua_resolver);
     }
     Class uicls = get_webview_embed_ui_delegate_cls();
     id ui = msg((id)uicls, sel("new"));
@@ -6432,6 +6655,21 @@ static void cocoa_set_user_agent(Engine *e, const char *ua) {
     });
 }
 
+// Canvas 21 (1.5.0): install/clear the per-destination User-Agent resolver.
+// Held as a JNI global ref so it survives the setting call; the previous ref is
+// released first.  Consulted only at the popup-child creation site (navigations
+// Java drives are resolved on the Java side before navigate).
+static void cocoa_set_user_agent_resolver(Engine *e, JNIEnv *env, jobject r) {
+    if (!e || !env) return;
+    if (e->ua_resolver) {
+        env->DeleteGlobalRef(e->ua_resolver);
+        e->ua_resolver = nullptr;
+    }
+    if (r) {
+        e->ua_resolver = env->NewGlobalRef(r);
+    }
+}
+
 // Canvas 22: purge the WKWebView's HTTP resource cache (disk + memory) via its
 // configuration's WKWebsiteDataStore.  Only the cache data types are removed,
 // so cookies / local storage / service workers survive (an active login is
@@ -6498,6 +6736,20 @@ static void cocoa_clear_cache(Engine *e) {
 //   6. delete e.
 static void cocoa_destroy_engine(Engine *e) {
     if (!e) return;
+    // Canvas 21 (1.5.0): drop the User-Agent resolver's global ref.  Only the
+    // popup-child creation path reads it, but a late popup during teardown
+    // would follow a freed ref, so it goes with the other callbacks.
+    if (e->ua_resolver) {
+        JNIEnv *env = nullptr;
+        bool detach = false;
+        if (e->jvm && e->jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+            e->jvm->AttachCurrentThread((void **)&env, nullptr);
+            detach = true;
+        }
+        if (env) env->DeleteGlobalRef(e->ua_resolver);
+        e->ua_resolver = nullptr;
+        if (detach) e->jvm->DetachCurrentThread();
+    }
     // Drop the webview from the engine map BEFORE any teardown work --
     // the swizzled responder hooks can fire at any moment during destroy
     // (AppKit unwinds the view hierarchy and resigns first responder),
@@ -7466,6 +7718,32 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_
     (void)peer;
 #endif
     if (ua && s) env->ReleaseStringUTFChars(ua, s);
+}
+
+// Install/clear the per-destination User-Agent resolver — Canvas 21 (1.5.0).
+// The resolver is a java.util.function.Function<String,String>; it is held as a
+// JNI global ref and consulted at the popup-child creation site with the
+// child's own target URL.  resolver == nullptr clears it.  Never throws.
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1user_1agent_1resolver
+  (JNIEnv *env, jclass, jlong wv, jobject resolver) {
+    if (wv == 0) return;
+#ifdef WEBVIEW_GTK
+    embed::gtk_set_user_agent_resolver((embed::Engine *)wv, env, resolver);
+#elif defined(WEBVIEW_COCOA)
+    embed::cocoa_set_user_agent_resolver((embed::Engine *)wv, env, resolver);
+#else
+    (void)wv; (void)env; (void)resolver;
+#endif
+}
+
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1set_1user_1agent_1resolver
+  (JNIEnv *env, jclass, jlong peer, jobject resolver) {
+    if (peer == 0) return;
+#ifdef WEBVIEW_GTK
+    embed::gtk_off_set_user_agent_resolver((embed::OffEngine *)peer, env, resolver);
+#else
+    (void)peer; (void)env; (void)resolver;
+#endif
 }
 
 // Clear the embedded WebView's HTTP resource cache — Canvas 22.  Resource

--- a/test/ca/weblite/webview/WebViewComponentUserAgentResolverTest.java
+++ b/test/ca/weblite/webview/WebViewComponentUserAgentResolverTest.java
@@ -1,0 +1,189 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Steve Hannah
+ */
+package ca.weblite.webview;
+
+import ca.weblite.webview.swing.WebViewComponent;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+/**
+ * Unit tests for the per-destination User-Agent resolver contract (Canvas 21,
+ * 1.5.0) — precedence, fall-through, and failure containment — without a native
+ * peer.  On-device verification that a pop-up child's <em>first</em> request
+ * carries the resolver's UA is a manual step (per the no-automated-GUI-tests
+ * policy); see the resolver toggle in {@code WebViewAdoptPopupDemo}.
+ */
+public class WebViewComponentUserAgentResolverTest {
+
+    private static final String CHROME =
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                    + "(KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36";
+    private static final String SAFARI =
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 "
+                    + "(KHTML, like Gecko) Version/18.6 Safari/605.1.15";
+
+    /** Minimal {@link WebViewComponent} that records what reaches the peer and
+     *  reports {@code setUrl} through the resolved-UA path, as the real
+     *  subclasses do; never attaches to a native peer. */
+    private static final class StubComponent extends WebViewComponent {
+        final AtomicReference<String> lastApplied = new AtomicReference<String>();
+        final AtomicInteger applyCount = new AtomicInteger(0);
+        final AtomicReference<Function<String, String>> lastResolver =
+                new AtomicReference<Function<String, String>>();
+
+        @Override protected void applyUserAgentToPeer(String ua) {
+            lastApplied.set(ua);
+            applyCount.incrementAndGet();
+        }
+
+        @Override protected void applyUserAgentResolverToPeer(Function<String, String> r) {
+            lastResolver.set(r);
+        }
+
+        /** Expose the protected precedence helper to the tests. */
+        String resolveFor(String url) { return resolveUserAgentFor(url); }
+
+        /** Drive the live-navigation path the real subclasses use. */
+        void navigate(String url) { applyResolvedUserAgentFor(url); }
+
+        @Override public WebViewComponent setUrl(String url) { return this; }
+        @Override public String getUrl() { return ""; }
+        @Override public WebViewComponent setDebug(boolean debug) { return this; }
+        @Override public WebViewComponent addOnBeforeLoad(String js) { return this; }
+        @Override public WebViewComponent eval(String js) { return this; }
+        @Override public CompletableFuture<String> evalAsync(String js) {
+            CompletableFuture<String> f = new CompletableFuture<String>();
+            f.completeExceptionally(new IllegalStateException("stub"));
+            return f;
+        }
+        @Override public WebViewComponent addJavascriptCallback(
+                String name, WebView.JavascriptCallback cb) { return this; }
+        @Override public WebViewComponent addJavascriptFunction(
+                String name, JavascriptFunction fn) { return this; }
+        @Override public WebViewComponent addJavascriptFunction(
+                String name, AsyncJavascriptFunction fn) { return this; }
+        @Override public WebViewComponent dispatch(Runnable r) { return this; }
+        @Override public void dispose() { }
+    }
+
+    /** A resolver that answers only for hosts containing {@code needle}. */
+    private static Function<String, String> only(final String needle, final String ua) {
+        return new Function<String, String>() {
+            @Override public String apply(String url) {
+                return url != null && url.contains(needle) ? ua : null;
+            }
+        };
+    }
+
+    @Test
+    public void testDefaultResolverIsNull() {
+        StubComponent c = new StubComponent();
+        assertNull("no resolver by default", c.getUserAgentResolver());
+        assertNull("no UA at all resolves to the engine default", c.resolveFor("https://x/"));
+    }
+
+    @Test
+    public void testResolverRoundTripsAndChains() {
+        StubComponent c = new StubComponent();
+        Function<String, String> r = only("slack.com", CHROME);
+        assertSame("setter chains", c, c.setUserAgentResolver(r));
+        assertSame("getter round-trips", r, c.getUserAgentResolver());
+        assertSame("resolver reaches the peer", r, c.lastResolver.get());
+        c.setUserAgentResolver(null);
+        assertNull("null clears the resolver", c.getUserAgentResolver());
+    }
+
+    @Test
+    public void testResolverWinsOverStaticUserAgent() {
+        StubComponent c = new StubComponent();
+        c.setUserAgent(SAFARI);
+        c.setUserAgentResolver(only("slack.com", CHROME));
+        assertEquals("the resolver decides for its own host",
+                CHROME, c.resolveFor("https://app.slack.com/client"));
+    }
+
+    @Test
+    public void testNullReturnFallsThroughToStaticUserAgent() {
+        StubComponent c = new StubComponent();
+        c.setUserAgent(SAFARI);
+        c.setUserAgentResolver(only("slack.com", CHROME));
+        assertEquals("a declining resolver yields to the static UA",
+                SAFARI, c.resolveFor("https://accounts.google.com/signin"));
+    }
+
+    @Test
+    public void testBlankReturnFallsThroughRatherThanClearing() {
+        StubComponent c = new StubComponent();
+        c.setUserAgent(SAFARI);
+        c.setUserAgentResolver(new Function<String, String>() {
+            @Override public String apply(String url) { return "   "; }
+        });
+        assertEquals("a blank return is a decline, not the engine default",
+                SAFARI, c.resolveFor("https://example.com/"));
+    }
+
+    @Test
+    public void testNoStaticUserAgentAndDecliningResolverYieldsEngineDefault() {
+        StubComponent c = new StubComponent();
+        c.setUserAgentResolver(only("slack.com", CHROME));
+        assertNull("neither level answers, so the engine default stands",
+                c.resolveFor("https://example.com/"));
+    }
+
+    @Test
+    public void testThrowingResolverFallsThroughInsteadOfPropagating() {
+        StubComponent c = new StubComponent();
+        c.setUserAgent(SAFARI);
+        c.setUserAgentResolver(new Function<String, String>() {
+            @Override public String apply(String url) {
+                throw new IllegalStateException("resolver blew up");
+            }
+        });
+        assertEquals("a throwing resolver must never break a navigation",
+                SAFARI, c.resolveFor("https://example.com/"));
+    }
+
+    @Test
+    public void testBlankUrlIsNotHandedToTheResolver() {
+        StubComponent c = new StubComponent();
+        c.setUserAgent(SAFARI);
+        c.setUserAgentResolver(new Function<String, String>() {
+            @Override public String apply(String url) { return CHROME; }
+        });
+        assertEquals("a blank destination has no host to key on",
+                SAFARI, c.resolveFor("   "));
+        assertEquals("a null destination likewise", SAFARI, c.resolveFor(null));
+    }
+
+    @Test
+    public void testNavigationAppliesPerDestinationAndSkipsUnchanged() {
+        StubComponent c = new StubComponent();
+        c.setUserAgent(SAFARI);
+        c.setUserAgentResolver(only("slack.com", CHROME));
+        c.applyCount.set(0);
+
+        c.navigate("https://app.slack.com/client");
+        assertEquals("Slack gets the resolver's UA", CHROME, c.lastApplied.get());
+        assertEquals(1, c.applyCount.get());
+
+        c.navigate("https://app.slack.com/client/other");
+        assertEquals("an unchanged UA is not re-entered into the engine",
+                1, c.applyCount.get());
+
+        c.navigate("https://accounts.google.com/signin");
+        assertEquals("Google falls through to the static UA", SAFARI, c.lastApplied.get());
+        assertEquals(2, c.applyCount.get());
+    }
+}

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -1656,6 +1656,48 @@ static std::wstring resolve_ua_for_win(Engine *e, const char *url) {
     return out;
 }
 
+// Canvas 21 Op 7.5: sets the User-Agent on a pop-up child's FIRST request.
+//
+// put_UserAgent on the child returns S_OK and does not affect that request --
+// by the time NewWindowRequested hands us the child, WebView2 has committed the
+// navigation and a settings write cannot overtake it. The request HEADER can
+// still be rewritten, and a request cannot lose a race with itself.
+//
+// Scoped as narrowly as possible: filtered to the DOCUMENT resource context, so
+// only the child's main-document request is seen, and latched so it acts once
+// and is inert thereafter. Nothing is cancelled or re-issued -- only a header is
+// set -- so window.opener and the in-flight POST body (Canvas 18 D7) survive.
+class PopupUaHeaderHandler : public CallbackBase<
+    ICoreWebView2WebResourceRequestedEventHandler> {
+public:
+    explicit PopupUaHeaderHandler(std::wstring ua) : m_ua(std::move(ua)) {}
+    HRESULT STDMETHODCALLTYPE Invoke(
+        ICoreWebView2 *,
+        ICoreWebView2WebResourceRequestedEventArgs *args) override {
+        if (m_done || !args) return S_OK;
+        ICoreWebView2WebResourceRequest *req = nullptr;
+        if (SUCCEEDED(args->get_Request(&req)) && req) {
+            ICoreWebView2HttpRequestHeaders *headers = nullptr;
+            if (SUCCEEDED(req->get_Headers(&headers)) && headers) {
+                HRESULT hr = headers->SetHeader(L"User-Agent", m_ua.c_str());
+                WV_LOG("popup_ua: first-request header rewrite hr=0x%08lx ua=%ls",
+                       (unsigned long)hr, m_ua.c_str());
+                if (SUCCEEDED(hr)) m_done = true;
+                headers->Release();
+            } else {
+                WV_LOG("popup_ua: first-request get_Headers failed");
+            }
+            req->Release();
+        } else {
+            WV_LOG("popup_ua: first-request get_Request failed");
+        }
+        return S_OK;
+    }
+private:
+    std::wstring m_ua;
+    bool m_done = false;
+};
+
 static void propagate_popup_user_agent(Engine *opener, ICoreWebView2 *child,
                                        const char *target_uri) {
     // Canvas 21 Op 7.4: this function has three silent exits and an unchecked
@@ -1706,6 +1748,22 @@ static void propagate_popup_user_agent(Engine *opener, ICoreWebView2 *child,
         WV_LOG("popup_ua: child get_Settings failed hr=0x%08lx",
                (unsigned long)hrGet);
     }
+
+    // The settings write above cannot reach the child's FIRST request, so hook
+    // that one request and set the header directly (Op 7.5). Registered here,
+    // inside the deferral and before Complete(), which is the only window in
+    // which the request has not yet gone out. put_UserAgent still covers every
+    // request after this one.
+    auto *hook = new PopupUaHeaderHandler(ua);
+    EventRegistrationToken hookToken{};
+    HRESULT hrFilter = child->AddWebResourceRequestedFilter(
+        L"*", COREWEBVIEW2_WEB_RESOURCE_CONTEXT_DOCUMENT);
+    HRESULT hrAdd = child->add_WebResourceRequested(hook, &hookToken);
+    WV_LOG("popup_ua: first-request hook filter=0x%08lx add=0x%08lx",
+           (unsigned long)hrFilter, (unsigned long)hrAdd);
+    // WebView2 holds its own reference on success; on failure this is the last
+    // one and the handler deletes itself.
+    hook->Release();
 }
 
 // NewWindowRequested -> allow/deny via Java, then create the linked child in an

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -209,6 +209,13 @@ struct Engine {
     // cannot distinguish an override from the default, so we cache it here.
     // Written / read on this engine's WebView2 worker thread only.
     std::wstring user_agent;
+
+    // Canvas 21 (1.5.0): per-destination User-Agent resolver
+    // (java.util.function.Function<String,String>) held as a JNI global ref.
+    // Consulted at the popup-child creation site with the CHILD's own target
+    // URL; a decline falls back to the tracked `user_agent` above.  Deleted on
+    // replacement and on engine destroy.
+    jobject ua_resolver = nullptr;
 };
 
 static void fire_focus_callback(Engine *e, bool became) {
@@ -1591,15 +1598,68 @@ private:
 // interface (mirrors the embed setter's tolerance).  Nested popups reuse the
 // opener engine, so they inherit the same override.  Covers BOTH the ADOPT and
 // NATIVE_WINDOW dispositions.
-static void propagate_popup_user_agent(Engine *opener, ICoreWebView2 *child) {
-    if (!opener || !child || opener->user_agent.empty()) return;
+// Canvas 21 (1.5.0): ask the per-destination User-Agent resolver which UA to
+// present for a navigation to `url`.  Returns the empty string when there is no
+// resolver, no url, or the resolver declines (a null/empty return) or throws --
+// a resolver must never be able to break a navigation, so a pending exception
+// is cleared and treated as a decline.  Runs on the WebView2 worker thread,
+// which is not attached to the JVM, so it attaches and detaches symmetrically.
+static std::wstring resolve_ua_for_win(Engine *e, const char *url) {
+    std::wstring out;
+    if (!e || !e->ua_resolver || !e->jvm || !url || !*url) return out;
+    JavaVM *jvm = e->jvm;
+    JNIEnv *env = nullptr;
+    bool detach = false;
+    if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread((void **)&env, nullptr) != JNI_OK || !env)
+            return out;
+        detach = true;
+    }
+    jstring ju = env->NewStringUTF(url);
+    jclass cls = env->GetObjectClass(e->ua_resolver);
+    if (cls && ju) {
+        jmethodID mid = env->GetMethodID(cls, "apply",
+            "(Ljava/lang/Object;)Ljava/lang/Object;");
+        if (mid) {
+            jobject r = env->CallObjectMethod(e->ua_resolver, mid, ju);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+                r = nullptr;
+            }
+            if (r) {
+                const char *cs = env->GetStringUTFChars((jstring)r, nullptr);
+                if (cs && *cs) out = utf8_to_wide(cs);
+                if (cs) env->ReleaseStringUTFChars((jstring)r, cs);
+                env->DeleteLocalRef(r);
+            }
+        }
+    }
+    if (cls) env->DeleteLocalRef(cls);
+    if (ju) env->DeleteLocalRef(ju);
+    if (detach) jvm->DetachCurrentThread();
+    return out;
+}
+
+static void propagate_popup_user_agent(Engine *opener, ICoreWebView2 *child,
+                                       const char *target_uri) {
+    if (!opener || !child) return;
+    // Canvas 21 (1.5.0): a resolver keyed on the CHILD's own target URL wins --
+    // the case that matters is an OAuth sign-in popped out of a site that
+    // requires a spoofed UA, landing on an identity provider that penalises
+    // exactly that spoof.  A resolver that declines (or none at all) falls
+    // through to the opener's tracked override, so pre-1.5.0 behaviour is
+    // preserved byte-for-byte for callers that never set one.
+    std::wstring ua = resolve_ua_for_win(opener, target_uri);
+    if (ua.empty()) ua = opener->user_agent;
+    if (ua.empty()) return;
     ICoreWebView2Settings *settings = nullptr;
     if (SUCCEEDED(child->get_Settings(&settings)) && settings) {
         ICoreWebView2Settings2 *settings2 = nullptr;
         if (SUCCEEDED(settings->QueryInterface(
                 __uuidof(ICoreWebView2Settings2),
                 reinterpret_cast<void **>(&settings2))) && settings2) {
-            settings2->put_UserAgent(opener->user_agent.c_str());
+            settings2->put_UserAgent(ua.c_str());
             settings2->Release();
         }
         settings->Release();
@@ -1769,7 +1829,7 @@ public:
 
                             // Canvas 21: inherit the opener's custom UA before
                             // the child's in-flight initial navigation.
-                            propagate_popup_user_agent(e, child);
+                            propagate_popup_user_agent(e, child, uri.c_str());
 
                             // Return the LINKED child to WebView2 so it drives
                             // the original request (POST verb+body,
@@ -1890,7 +1950,7 @@ public:
 
                         // Canvas 21: inherit the opener's custom UA before the
                         // child's in-flight initial navigation.
-                        propagate_popup_user_agent(e, child);
+                        propagate_popup_user_agent(e, child, uri.c_str());
 
                         args->put_NewWindow(child);   // LINKED to opener
                         args->put_Handled(TRUE);
@@ -2420,6 +2480,11 @@ static void destroy_engine(Engine *e) {
         }
         if (env) env->DeleteGlobalRef(e->popup_callback);
         e->popup_callback = nullptr;
+        // Canvas 21 (1.5.0): the User-Agent resolver's global ref goes with the
+        // popup callback -- only the popup path reads it, and a late popup
+        // during teardown would otherwise follow a freed ref.
+        if (env && e->ua_resolver) env->DeleteGlobalRef(e->ua_resolver);
+        e->ua_resolver = nullptr;
         if (detach) e->jvm->DetachCurrentThread();
     }
     // Release the environment ref taken at environment-ready (Canvas 17).
@@ -3015,6 +3080,31 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set
             settings->Release();
         }
     });
+}
+
+// Install/clear the per-destination User-Agent resolver — Canvas 21 (1.5.0).
+// The resolver is a java.util.function.Function<String,String>; it is held as a
+// JNI global ref and consulted by the NewWindowRequested handler with the popup
+// child's own target URL.  resolver == nullptr clears it.  The global ref is
+// created/deleted on the CALLING thread (which holds a JNIEnv); the worker
+// thread only reads the jobject, which is safe for a global ref.  Never throws.
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set_1user_1agent_1resolver
+  (JNIEnv *env, jclass, jlong wv, jobject resolver) {
+    auto *e = (embed_win::Engine *)wv;
+    if (!e) return;
+    if (e->ua_resolver) {
+        env->DeleteGlobalRef(e->ua_resolver);
+        e->ua_resolver = nullptr;
+    }
+    if (resolver) {
+        e->ua_resolver = env->NewGlobalRef(resolver);
+    }
+}
+
+// Offscreen counterpart — no offscreen engine on Windows, so a silent no-op
+// (mirrors webview_offscreen_set_user_agent).
+JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1offscreen_1set_1user_1agent_1resolver
+  (JNIEnv *, jclass, jlong, jobject) {
 }
 
 // Clear the embedded WebView's HTTP resource cache — Canvas 22.  Purges the

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -3067,17 +3067,35 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set
         // propagate it to popup children (empty == engine default).  Recorded
         // on the worker thread, where the popup handler also reads it.
         e->user_agent = w;
-        if (!e->webview) return;
+        if (!e->webview) {
+            WV_LOG("set_user_agent: no webview yet, stored only");
+            return;
+        }
+        // Canvas 21 Op 7.3: report the outcome. WebView2's failure mode for an
+        // unavailable _2 interface is a silent no-op, so without this a UA that
+        // never changes is indistinguishable from one the engine ignored.
         ICoreWebView2Settings *settings = nullptr;
-        if (SUCCEEDED(e->webview->get_Settings(&settings)) && settings) {
+        HRESULT hrGet = e->webview->get_Settings(&settings);
+        if (SUCCEEDED(hrGet) && settings) {
             ICoreWebView2Settings2 *settings2 = nullptr;
-            if (SUCCEEDED(settings->QueryInterface(
+            HRESULT hrQi = settings->QueryInterface(
                     __uuidof(ICoreWebView2Settings2),
-                    reinterpret_cast<void **>(&settings2))) && settings2) {
-                settings2->put_UserAgent(w.c_str()); // empty -> default
+                    reinterpret_cast<void **>(&settings2));
+            if (SUCCEEDED(hrQi) && settings2) {
+                HRESULT hrPut = settings2->put_UserAgent(w.c_str()); // empty -> default
+                WV_LOG("set_user_agent: put_UserAgent hr=0x%08lx ua=%ls",
+                       (unsigned long)hrPut,
+                       w.empty() ? L"(engine default)" : w.c_str());
                 settings2->Release();
+            } else {
+                WV_LOG("set_user_agent: ICoreWebView2Settings2 UNAVAILABLE "
+                       "hr=0x%08lx -- the runtime is too old to set a UA; "
+                       "this call is a no-op", (unsigned long)hrQi);
             }
             settings->Release();
+        } else {
+            WV_LOG("set_user_agent: get_Settings failed hr=0x%08lx",
+                   (unsigned long)hrGet);
         }
     });
 }

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -210,6 +210,14 @@ struct Engine {
     // Written / read on this engine's WebView2 worker thread only.
     std::wstring user_agent;
 
+    // Canvas 21 Op 7.3: the PRISTINE engine User-Agent, captured from
+    // get_UserAgent on the first setter call -- necessarily before any
+    // override, since the setter is the only thing that overrides. WebView2
+    // has no "clear" verb: put_UserAgent(L"") returns S_OK and leaves the
+    // previous override in force, so a reset has to write this string back
+    // literally. Worker thread only.
+    std::wstring default_user_agent;
+
     // Canvas 21 (1.5.0): per-destination User-Agent resolver
     // (java.util.function.Function<String,String>) held as a JNI global ref.
     // Consulted at the popup-child creation site with the CHILD's own target
@@ -3082,10 +3090,31 @@ JNIEXPORT void JNICALL Java_ca_weblite_webview_WebViewNative_webview_1embed_1set
                     __uuidof(ICoreWebView2Settings2),
                     reinterpret_cast<void **>(&settings2));
             if (SUCCEEDED(hrQi) && settings2) {
-                HRESULT hrPut = settings2->put_UserAgent(w.c_str()); // empty -> default
-                WV_LOG("set_user_agent: put_UserAgent hr=0x%08lx ua=%ls",
-                       (unsigned long)hrPut,
-                       w.empty() ? L"(engine default)" : w.c_str());
+                // Capture the pristine default before the first override, so a
+                // later reset has something literal to write back.
+                if (e->default_user_agent.empty()) {
+                    LPWSTR cur = nullptr;
+                    if (SUCCEEDED(settings2->get_UserAgent(&cur)) && cur) {
+                        e->default_user_agent.assign(cur);
+                        CoTaskMemFree(cur);
+                    }
+                }
+                // A reset restores the captured default. put_UserAgent(L"") is
+                // NOT a reset on this engine -- it succeeds and does nothing.
+                const bool reset = w.empty();
+                const std::wstring &target =
+                    reset ? e->default_user_agent : w;
+                if (reset && target.empty()) {
+                    WV_LOG("set_user_agent: cannot reset -- the engine default "
+                           "was never captured; the previous override stays in "
+                           "force");
+                } else {
+                    HRESULT hrPut = settings2->put_UserAgent(target.c_str());
+                    WV_LOG("set_user_agent: put_UserAgent hr=0x%08lx %sua=%ls",
+                           (unsigned long)hrPut,
+                           reset ? "(restoring captured default) " : "",
+                           target.c_str());
+                }
                 settings2->Release();
             } else {
                 WV_LOG("set_user_agent: ICoreWebView2Settings2 UNAVAILABLE "

--- a/windows/webview_embed.cc
+++ b/windows/webview_embed.cc
@@ -1614,7 +1614,14 @@ private:
 // which is not attached to the JVM, so it attaches and detaches symmetrically.
 static std::wstring resolve_ua_for_win(Engine *e, const char *url) {
     std::wstring out;
-    if (!e || !e->ua_resolver || !e->jvm || !url || !*url) return out;
+    // Canvas 21 Op 7.4: "declined" and "never installed" imply different bugs,
+    // so say which.
+    if (!e || !e->jvm) { WV_LOG("resolve_ua: no engine/jvm"); return out; }
+    if (!e->ua_resolver) {
+        WV_LOG("resolve_ua: NO RESOLVER INSTALLED on this engine");
+        return out;
+    }
+    if (!url || !*url) { WV_LOG("resolve_ua: no target url"); return out; }
     JavaVM *jvm = e->jvm;
     JNIEnv *env = nullptr;
     bool detach = false;
@@ -1651,26 +1658,53 @@ static std::wstring resolve_ua_for_win(Engine *e, const char *url) {
 
 static void propagate_popup_user_agent(Engine *opener, ICoreWebView2 *child,
                                        const char *target_uri) {
-    if (!opener || !child) return;
+    // Canvas 21 Op 7.4: this function has three silent exits and an unchecked
+    // put_UserAgent, and a child left on the engine default is consistent with
+    // every one of them. Log which path was taken.
+    WV_LOG("popup_ua: enter uri=%s opener=%p child=%p",
+           target_uri ? target_uri : "(null)", (void *)opener, (void *)child);
+    if (!opener || !child) {
+        WV_LOG("popup_ua: no opener or child -- nothing to propagate");
+        return;
+    }
     // Canvas 21 (1.5.0): a resolver keyed on the CHILD's own target URL wins --
     // the case that matters is an OAuth sign-in popped out of a site that
     // requires a spoofed UA, landing on an identity provider that penalises
     // exactly that spoof.  A resolver that declines (or none at all) falls
     // through to the opener's tracked override, so pre-1.5.0 behaviour is
     // preserved byte-for-byte for callers that never set one.
-    std::wstring ua = resolve_ua_for_win(opener, target_uri);
-    if (ua.empty()) ua = opener->user_agent;
+    std::wstring resolved = resolve_ua_for_win(opener, target_uri);
+    std::wstring ua = resolved;
+    const char *source = "resolver";
+    if (ua.empty()) {
+        ua = opener->user_agent;
+        source = "opener tracked override";
+    }
+    WV_LOG("popup_ua: resolver=%ls openerTracked=%ls chose=%s",
+           resolved.empty() ? L"(declined)" : resolved.c_str(),
+           opener->user_agent.empty() ? L"(none)" : opener->user_agent.c_str(),
+           ua.empty() ? "(nothing -- child keeps the engine default)" : source);
     if (ua.empty()) return;
     ICoreWebView2Settings *settings = nullptr;
-    if (SUCCEEDED(child->get_Settings(&settings)) && settings) {
+    HRESULT hrGet = child->get_Settings(&settings);
+    if (SUCCEEDED(hrGet) && settings) {
         ICoreWebView2Settings2 *settings2 = nullptr;
-        if (SUCCEEDED(settings->QueryInterface(
+        HRESULT hrQi = settings->QueryInterface(
                 __uuidof(ICoreWebView2Settings2),
-                reinterpret_cast<void **>(&settings2))) && settings2) {
-            settings2->put_UserAgent(ua.c_str());
+                reinterpret_cast<void **>(&settings2));
+        if (SUCCEEDED(hrQi) && settings2) {
+            HRESULT hrPut = settings2->put_UserAgent(ua.c_str());
+            WV_LOG("popup_ua: put_UserAgent hr=0x%08lx ua=%ls",
+                   (unsigned long)hrPut, ua.c_str());
             settings2->Release();
+        } else {
+            WV_LOG("popup_ua: ICoreWebView2Settings2 UNAVAILABLE on the child "
+                   "hr=0x%08lx -- cannot set its UA", (unsigned long)hrQi);
         }
         settings->Release();
+    } else {
+        WV_LOG("popup_ua: child get_Settings failed hr=0x%08lx",
+               (unsigned long)hrGet);
     }
 }
 


### PR DESCRIPTION
> **Three canvases in one PR.** The main change is the Canvas 21 User-Agent resolver. Two others rode along because they blocked testing it: a Canvas 8 build-script fix (`e924c9d`) and **two pre-existing WebView2 defects** (`de8df45`, `50c6f71`). Happy to split any of them out.

## Why

One static User-Agent cannot satisfy two sites that want opposite things.

Slack rejects the engine's own UA as an unsupported browser and wants a mainstream desktop Chrome string. Google's sign-in, handed that *same* Chrome UA by a WebKit engine, scores it as a spoof — the claimed Chrome build has no `navigator.userAgentData`, sends no `Sec-CH-UA` client hints, and carries a WebKit TLS fingerprint — and answers with a CAPTCHA that cannot be passed at any score, no matter how many are solved correctly.

The case that actually bites: a Slack tab set to the Chrome UA opens a **Sign in with Google** popup, and Canvas 21's existing popup inheritance faithfully copies that Chrome UA onto the child. The identity provider then penalises exactly the spoof the opener needed.

## What

`WebViewComponent.setUserAgentResolver(Function<String,String>)` — a function from the URL a navigation is about to load to the UA to present for it.

**Precedence:** resolver answer (non-null, non-blank) → static `setUserAgent` value → engine default. A `null`/blank return means *fall through*, never "force the engine default".

**Consulted at exactly three points**, each a navigation about to start that this library controls:
1. a view's initial navigation (peer attach),
2. a Java-initiated `setUrl` on a live view,
3. a browser-initiated popup child's first navigation — **keyed on the popup's own target URL**.

Point 3 supersedes the opener-copy inheritance when a resolver is installed. With **no** resolver, every path is byte-for-byte 1.4.0, opener-copy included.

## How

Points 1 and 2 are Java-driven and already know the target, so they resolve entirely in Java. Only the popup child is engine-driven, so it alone needs a native upcall — keeping the new native surface to one helper per engine:

- **macOS** `impl_create_web_view` — resolves off `navigationAction.request.URL`, falls back to the opener's `customUserAgent`.
- **Linux** `handle_create_web_view` — resolves off the `WebKitNavigationAction` request URI, falls back to the opener's `WebKitSettings` UA.
- **Windows** `propagate_popup_user_agent` — resolves off the `NewWindowRequested` args' `Uri`, falls back to the engine's tracked override. On this engine the UA is applied to the **request header**, not the setting — see below.

The resolver is held as a JNI global ref (deleted on replacement and on engine destroy, inherited transitively by nested popups and transferred on adopt). The upcall attaches the engine UI thread when needed and clears any pending exception, so a throwing resolver falls through instead of breaking a navigation.

## Deliberately not per-request on macOS

A server-side redirect that crosses hosts *during* a navigation keeps the UA it started with. Intercepting every navigation via `decidePolicyForNavigationAction` was considered and **rejected**: WebKit does not reliably expose `NSURLRequest.HTTPBody` to that delegate for form POSTs, so cancel-set-UA-reissue would silently drop OAuth form-post bodies — the same breakage Canvas 18 D7 avoids by never re-`setUrl`-ing an adopted popup. A slightly stale UA beats a lost sign-in.

## Verification status

**All three engines verified on-device by the PR author**, not inferred.

| | macOS | Windows | Linux |
|---|---|---|---|
| Point (b) — per-host UA on a live navigation | ✅ verified | ✅ verified | ✅ verified |
| Point (c) — popup child keyed on its own URL | ✅ verified | ✅ verified | ✅ verified |
| Native build | ✅ CI | ✅ CI | ✅ CI |

**Automated:** `WebViewComponentUserAgentResolverTest` — 9 headless tests covering precedence, fall-through on null/blank, throwing-resolver containment, blank-URL guard, and unchanged-UA suppression. Full suite: **69 tests, no regressions.** CI green on all 7 jobs including all six native targets.

## Before release — two open items

1. **Diagnostic logging is unconditional.** `WV_LOG` writes to stderr with no gate (the file's existing convention), but the new lines fire on *every* UA application, not only on error — so a consuming app gets stderr output on every navigation. They earned their keep finding both defects below; the per-navigation ones should be gated behind the engine's `debug` flag, leaving the error paths always-on. Not done in this PR.
2. **Windows offscreen stub asymmetry.** I added a no-op `webview_offscreen_set_user_agent_resolver` for Windows, though the 1.4.0 `webview_offscreen_set_user_agent` has no such stub. Harmless (the offscreen engine is Linux-only) but inconsistent — happy to drop it.

## Two pre-existing WebView2 defects found and fixed

Both were found by instrumenting rather than guessing, and both are the same shape: **WebView2 accepts a settings write and does not necessarily act on it.**

### `de8df45` — `put_UserAgent(L"")` is not a reset

After the resolver set a UA for one host, every later navigation kept it. The log showed Java resolving correctly and asking the engine to reset, `put_UserAgent` returning `S_OK`, and nothing changing.

The canvas asserted the opposite in as many words ("*WebView2 `put_UserAgent(L"")` — empty restores default*") and the setter implemented that faithfully. macOS `customUserAgent = nil` and GTK `..._set_user_agent(NULL)` genuinely do reset, which is why only Windows was wrong.

**This affects anyone who has ever called `setUserAgent(null)` on Windows** — Reset UA has never worked there. `ICoreWebView2Settings2` has no clear verb, so `Engine` now captures the pristine UA from `get_UserAgent` on the first setter call — necessarily before any override — and a reset writes that string back.

### `50c6f71` — a popup child's UA cannot be set through its settings

Same instrument, one level down. Every step succeeded — call site reached, resolver consulted and answered, `put_UserAgent` returning `S_OK` **on the child** — and the child's first request still carried the engine default. By the time `NewWindowRequested` hands us the child, WebView2 has committed that navigation and a settings write cannot overtake it.

This writes through the same call as the 1.3.1 opener-copy, so **popup UA propagation had never worked on Windows either**.

A request header, however, cannot lose a race with itself. The child now gets a `WebResourceRequested` hook — registered inside the deferral, **before `Complete()`**, the only window in which the request has not yet gone out — that sets the `User-Agent` header on its first document request. Scoped tight: filtered to `CONTEXT_DOCUMENT` so only the main document is seen, latched so it acts once, and nothing is cancelled or re-issued so `window.opener` and the in-flight POST body survive. `put_UserAgent` stays and covers every request after the first, by which point the settings write has landed — so the document and its subresources agree.

> Both defects were claims this canvas made about Windows without the on-device validation its Safeguards have always required. Both were false. The canvas text is corrected in each commit.

## Also in this PR

### `e924c9d` — Canvas 8 developer build scripts

`build-mac.sh` failed to link on a stock macOS JDK with `ld: library 'jawt' not found`, blocking the demo. Canvas 8 already pre-loads `libjawt` from Java and tolerates JDKs that don't ship it standalone, so a `-ljawt` link flag required exactly the file the loader was written to survive the absence of. Both CI workflows already build without it. Also fixes `build-mac.sh` hardcoding `natives/osx_64` on Apple Silicon, and drops `-ljawt` from `build-linux.sh` for consistency with the new safeguard.

**Known gap, deliberately not closed:** `build-linux.sh` and `build-windows.sh` still hardcode `linux_64` / `windows_64` and mis-place the library on an arm64 host. Recorded in Op 8.5.

### `9701345` / `926acb3` — demo address bar

Consultation point (b) was previously unverifiable on any engine: the demo's opener sat on a `data:` URL, which has no host, so the resolver never fired for it. Adds a URL field plus one-click **httpbin (overridden)** / **httpbingo (not overridden)** / **Home** buttons — which is what made every finding above reproducible. `926acb3` then fixes the control rows, which had overflowed the window and hidden three controls entirely; Canvas 21 Op 14.4 records the constraint so it can't regress.

## Downstream

[webliteca/agentic-app-framework#223](https://github.com/webliteca/agentic-app-framework/pull/223) consumes this as per-host User-Agent rules and is blocked on `1.5.0` reaching the `webliteca/webview-run` Packages feed — its CI fails at dependency resolution until then. Release order: merge this → publish `1.5.0` → #223 goes green on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMLb7bXcSxdh7Uyb5KgEXK