### PR TITLE
Publish tagged releases to GitHub Packages as well as Maven Central

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -1,6 +1,17 @@
-# Release workflow: build cross-platform natives, then publish to Maven Central.
+# Release workflow: build cross-platform natives, then publish the assembled
+# jar to BOTH GitHub Packages and Maven Central, in that order.
 #
-# Uses the modern Central Publishing Maven Plugin (org.sonatype.central:central-publishing-maven-plugin).
+# GitHub Packages is readable the instant the deploy returns, so it is the fast
+# lane that unblocks downstream first-party builds while Maven Central syncs.
+# Maven Central remains the canonical public channel (GitHub Packages requires
+# an authenticated read even for public packages, so external adopters cannot
+# use it).  Central publication uses the modern Central Publishing Maven Plugin
+# (org.sonatype.central:central-publishing-maven-plugin); GitHub Packages uses
+# the ordinary maven-deploy-plugin.  Each lives in its own Maven profile —
+# see the comment above <profiles> in pom.xml for why that split is required.
+#
+# GitHub Packages authenticates with the built-in GITHUB_TOKEN; no secret is
+# needed for that leg.
 #
 # Required GitHub Secrets (provided as webliteca org-level secrets):
 #   GPG_PRIVATE_KEY        - Base64-encoded GPG private key
@@ -12,7 +23,7 @@
 #   git tag v1.0.0
 #   git push origin v1.0.0
 
-name: Release to Maven Central
+name: Release to GitHub Packages and Maven Central
 
 on:
   push:
@@ -191,14 +202,19 @@ jobs:
           if-no-files-found: error
 
   # ---------------------------------------------------------------------------
-  # Deploy job: assemble all natives into src/<arch>/, set version from tag,
-  # sign artifacts, and publish to Maven Central via the Central Publishing
-  # Maven Plugin.  Only runs on v* tag pushes (and manual dispatch).
+  # Deploy job: assemble all natives into natives/<arch>/, set version from the
+  # tag, then publish the same jar twice — GitHub Packages first, Maven Central
+  # second.  The six-platform presence assertion gates BOTH deploys, so an
+  # incomplete release publishes to neither repository.  Only runs on v* tag
+  # pushes (and manual dispatch); build.yml never publishes anywhere.
   # ---------------------------------------------------------------------------
   deploy:
-    name: Deploy to Maven Central
+    name: Deploy to GitHub Packages and Maven Central
     needs: native
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 
@@ -219,10 +235,31 @@ jobs:
           distribution: liberica
           java-version: '11'
           cache: maven
-          server-id: central
-          server-username: MAVEN_CENTRAL_USERNAME
-          server-password: MAVEN_CENTRAL_PASSWORD
-          overwrite-settings: true
+
+      # setup-java's server-id input configures exactly one server; this
+      # release authenticates two, so write the settings file directly.
+      # Credentials stay as ${env.*} lookups resolved per deploy step.
+      - name: Write Maven settings with both deploy servers
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml <<'EOF'
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+            <servers>
+              <server>
+                <id>github</id>
+                <username>${env.GITHUB_ACTOR}</username>
+                <password>${env.GITHUB_TOKEN}</password>
+              </server>
+              <server>
+                <id>central</id>
+                <username>${env.MAVEN_CENTRAL_USERNAME}</username>
+                <password>${env.MAVEN_CENTRAL_PASSWORD}</password>
+              </server>
+            </servers>
+          </settings>
+          EOF
 
       - name: Download all native artifacts
         uses: actions/download-artifact@v4
@@ -278,13 +315,30 @@ jobs:
             -DgenerateBackupPoms=false \
             --batch-mode -ntp
 
-      - name: Build and deploy
+      # Fast lane first: available to downstream builds immediately, and
+      # deliberately unsigned — GitHub Packages does not require GPG, so this
+      # leg never touches the private key.
+      - name: Publish to GitHub Packages
         shell: bash
         run: |
           mvn -B clean deploy \
             --batch-mode -ntp \
             -DskipTests \
-            -Psign-artifacts \
+            -Pgithub-deploy
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Canonical channel second.  No `clean`: this republishes the very same
+      # tree the step above deployed, plus the sources/javadoc jars and GPG
+      # signatures that Central requires.
+      - name: Publish to Maven Central
+        shell: bash
+        run: |
+          mvn -B deploy \
+            --batch-mode -ntp \
+            -DskipTests \
+            -Pcentral-deploy,sign-artifacts \
             -Dgpg.passphrase="$GPG_PASSPHRASE"
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/README.md
+++ b/README.md
@@ -31,6 +31,45 @@ web engine:
   hard-linked), so a single jar runs on both.
 * **macOS** needs nothing extra — WKWebView ships with the OS.
 
+### Early access via GitHub Packages
+
+Every tagged release is published to GitHub Packages *before* Maven
+Central, and is resolvable there the moment the release build finishes —
+useful when a downstream project needs to build against a new version
+without waiting for Central to sync.
+
+GitHub Packages requires an authenticated read even for public packages,
+so this channel is only practical for first-party projects and CI that
+already hold a token.  **Maven Central is the canonical channel; external
+consumers should use the coordinates above.**
+
+Add the repository to your `pom.xml`:
+
+```xml
+<repositories>
+    <repository>
+        <id>github-webliteca</id>
+        <url>https://maven.pkg.github.com/webliteca/swingwebview</url>
+    </repository>
+</repositories>
+```
+
+and a matching server entry in `~/.m2/settings.xml`, where the password is
+a personal access token with the `read:packages` scope (in GitHub Actions,
+use `${{ github.actor }}` and the built-in `GITHUB_TOKEN` instead):
+
+```xml
+<server>
+    <id>github-webliteca</id>
+    <username>YOUR_GITHUB_USERNAME</username>
+    <password>YOUR_PAT_WITH_READ_PACKAGES</password>
+</server>
+```
+
+The `<id>` values must match.  Once Maven Central has synced the same
+version, the repository entry can be dropped again — the artifacts are
+identical.
+
 ## Platform support
 
 | Platform | Heavyweight | Lightweight |

--- a/pom.xml
+++ b/pom.xml
@@ -74,22 +74,52 @@
                 </includes>
             </resource>
         </resources>
-
-        <plugins>
-            <plugin>
-                <groupId>org.sonatype.central</groupId>
-                <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.7.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <publishingServerId>central</publishingServerId>
-                    <autoPublish>true</autoPublish>
-                </configuration>
-            </plugin>
-        </plugins>
     </build>
 
     <profiles>
+        <!--
+            Deploy targets live in profiles, one per repository, and none
+            is active by default.  central-publishing-maven-plugin declares
+            build extensions that REPLACE deploy:deploy in the jar
+            lifecycle; while it is active every `mvn deploy` goes to Maven
+            Central and a <distributionManagement> entry is ignored.  Keeping
+            it profile-scoped is what lets the release publish to GitHub
+            Packages as well.  A bare `mvn deploy` has no target at all —
+            that is deliberate.  `mvn package` / `mvn install` are unaffected.
+
+            Release order (see .github/workflows/maven-release.yml):
+              mvn deploy -Pgithub-deploy                     (fast lane)
+              mvn deploy -Pcentral-deploy,sign-artifacts     (canonical)
+        -->
+        <profile>
+            <id>github-deploy</id>
+            <distributionManagement>
+                <repository>
+                    <id>github</id>
+                    <name>GitHub Packages — webliteca/swingwebview</name>
+                    <url>https://maven.pkg.github.com/webliteca/swingwebview</url>
+                </repository>
+            </distributionManagement>
+        </profile>
+
+        <profile>
+            <id>central-deploy</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.7.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <profile>
             <id>sign-artifacts</id>
             <build>

--- a/spdd/prompt/8-20260516-0719-[Feat]-Native-Library-Loading-And-Packaging.md
+++ b/spdd/prompt/8-20260516-0719-[Feat]-Native-Library-Loading-And-Packaging.md
@@ -32,6 +32,17 @@ generated_at: 2026-05-16T07:19:13-07:00
   `.github/workflows/build.yml:171`). The system Microsoft Edge
   WebView2 Runtime provides the actual Chromium binaries
   (`README.md ("Platform support" section)`).
+- Publish each tagged release of the assembled six-platform jar
+  to **two** repositories: GitHub Packages first, then Maven
+  Central. Both receive the same coordinates and the same
+  tag-derived version. Maven Central's post-publish sync delay
+  blocks downstream first-party projects from building against a
+  freshly released version; GitHub Packages is readable the moment
+  the deploy returns, so it serves as a fast lane while Central
+  propagates. Publication remains gated on `v*` tags — there is no
+  snapshot channel and no publication from `master`
+  (`.github/workflows/maven-release.yml`, `pom.xml` profiles
+  `github-deploy` and `central-deploy`).
 - Definition of Done: indirectly validated by every other feature
   in this repo — if the native loader is broken, nothing else
   works. No standalone unit tests; smoke tested by the demos
@@ -106,6 +117,23 @@ generated_at: 2026-05-16T07:19:13-07:00
   gitignored; its contents are produced by `build-*.sh` locally or
   the per-platform CI matrix on release. At runtime, the extractor
   maps `Architecture.LINUX_64` → `linux_64/libwebview.so`, etc.
+- **One deploy target per Maven profile, because the Central
+  plugin owns the deploy lifecycle.**
+  `central-publishing-maven-plugin` is declared with build
+  extensions enabled, which *replaces* the standard deploy goal in
+  the `jar` packaging lifecycle. While it is active unconditionally,
+  `mvn deploy` can reach Maven Central and nothing else — adding a
+  `<distributionManagement>` repository has no effect. The dual
+  target is therefore expressed as two mutually exclusive profiles:
+  `central-deploy` carries the Central publishing plugin,
+  `github-deploy` carries a `<distributionManagement>` entry for the
+  GitHub Packages endpoint and the ordinary deploy plugin. The
+  release job runs `mvn deploy` twice over one already-assembled
+  tree, once per profile. With neither profile active there is no
+  deploy target at all, which is the intended outcome: a bare
+  `mvn deploy` must not silently publish anywhere, while
+  `mvn package` and `mvn install` are untouched for local
+  developers.
 - **Leftover cleanup, not pinning.** Extracted native files live
   in the OS temp directory and are deleted if older than 5
   minutes when the next process starts
@@ -147,6 +175,17 @@ generated_at: 2026-05-16T07:19:13-07:00
   via `webkit_shim.h`. GTK3/GLib remain normally linked. macOS
   (WKWebView) and Windows (WebView2) builds are untouched — the
   loader compiles only under `WEBVIEW_GTK` / `__linux__`.
+- `README.md` ("Installation" section) — the consumer-facing
+  record of both channels: the Maven Central coordinates every
+  adopter uses, plus the GitHub Packages repository and the
+  authenticated `settings.xml` server entry a first-party
+  consumer needs to resolve a release before Central has synced.
+- `pom.xml` profiles `github-deploy` and `central-deploy` — the
+  two release targets (Operation 9). Exactly one is activated per
+  `mvn deploy` invocation; neither is active by default. The
+  pre-existing `sign-artifacts` profile is orthogonal and supplies
+  the sources jar, javadoc jar and GPG signatures required by
+  Central.
 - `pom.xml:65-75` — Maven resource entries that copy each
   per-architecture directory from `natives/<arch>/` into
   `target/classes/<arch>/` at JAR-build time, so they land at the
@@ -167,7 +206,8 @@ generated_at: 2026-05-16T07:19:13-07:00
   uploads one artifact; an assembly/deploy job downloads all six,
   lays them into `natives/<arch>/`, asserts all six are present,
   and runs `mvn package`/`deploy`. This is the only path that
-  produces the cross-platform fat jar shipped to Maven Central.
+  produces the cross-platform fat jar shipped to GitHub Packages
+  and Maven Central.
 
 ## O · Operations
 
@@ -291,8 +331,9 @@ File: `pom.xml`
 Files: `.github/workflows/build.yml`,
 `.github/workflows/maven-release.yml`
 
-1. Responsibility: produce a single Maven-Central-ready jar that
-   contains all six platform+arch native libraries. Each native
+1. Responsibility: produce a single release-ready jar that
+   contains all six platform+arch native libraries, and hand it to
+   the two publication targets of Operation 9. Each native
    must be compiled on a runner of its matching OS/arch — there
    is no cross-compilation path.
 2. Logic (two-phase, identical structure in both workflows):
@@ -310,8 +351,8 @@ Files: `.github/workflows/build.yml`,
      artifact, copies each into `natives/<arch>/`, then runs a
      **6-platform-presence assertion** that fails the job if
      any of the six expected directories is empty
-     (`maven-release.yml:234-249`). Only then does
-     `mvn deploy` run.
+     (`maven-release.yml:234-249`). Only then does either
+     `mvn deploy` invocation run.
 3. Constraints / Invariants:
    - The presence assertion's `required=(...)` array is the
      authoritative list of platforms shipped. It must stay in
@@ -327,8 +368,15 @@ Files: `.github/workflows/build.yml`,
      so the published jar carries only `webview.dll`, no
      `WebView2Loader.dll` (`build.yml:171`).
    - `build.yml` runs on every push/PR to `master`, producing
-     a downloadable jar artifact but not publishing. Only
-     `maven-release.yml` publishes, gated on `v*` tag pushes.
+     a downloadable jar artifact but not publishing — to any
+     repository, including GitHub Packages. Only
+     `maven-release.yml` publishes, gated on `v*` tag pushes
+     (plus manual `workflow_dispatch`). There is no snapshot
+     channel.
+   - The six-platform presence assertion gates **both** deploys.
+     A release missing any platform publishes to neither target,
+     so the two repositories can never disagree about what a
+     given version contains.
    - The Linux `native` job asserts, via `readelf -d` on the
      built `libwebview.so`, that it has **no** `NEEDED` entry
      matching `webkit2gtk` or `javascriptcoregtk` (4.0 or 4.1)
@@ -461,6 +509,51 @@ Files: `build-mac.sh`, `build-linux.sh`
    corrected in `build-linux.sh`; `build-windows.sh` is untouched
    (it links no JAWT and delegates to `windows/script/build.bat`).
 
+### 9. Dual-Target Release Publication
+Files: `pom.xml`, `.github/workflows/maven-release.yml`
+
+1. Responsibility: publish one tagged release to GitHub Packages
+   and to Maven Central, in that order, from the single
+   fully-assembled jar produced by Operation 6.
+2. Logic:
+   - `pom.xml` defines two deploy profiles, neither active by
+     default. `github-deploy` declares a
+     `<distributionManagement>` repository with id `github`
+     pointing at the repository's GitHub Packages Maven endpoint,
+     and relies on the standard deploy plugin. `central-deploy`
+     declares `central-publishing-maven-plugin` with build
+     extensions enabled and the pre-existing `central` server id
+     and auto-publish setting. The Central plugin must live
+     **inside** its profile — see the Approach note on lifecycle
+     ownership.
+   - The deploy job authenticates two servers in one Maven
+     settings file: `github`, with the workflow's built-in
+     repository token, and `central`, with the portal API token
+     credentials. The job requests `packages: write` permission
+     in addition to `contents: read`.
+   - After the version is set from the tag, the job deploys twice
+     over the same tree: first `github-deploy`, then
+     `central-deploy` with the `sign-artifacts` profile and the
+     GPG passphrase. GitHub Packages goes first so the fast lane
+     opens before the slower Central publication begins.
+3. Constraints / Invariants:
+   - Ordering is load-bearing, not cosmetic: the whole point of
+     the second target is to shorten the wait, so a failure in
+     the Central leg must still leave the GitHub Packages
+     artifact published and usable.
+   - GPG signing is required for Central and unnecessary for
+     GitHub Packages. The `github-deploy` leg therefore runs
+     without `sign-artifacts`, which also keeps the private key
+     out of the first deploy entirely.
+   - Both legs publish identical coordinates and version. Never
+     let the two diverge — a consumer resolving
+     `ca.weblite:webview:<v>` must get the same artifact
+     whichever repository answers first.
+   - A given version can be published to each repository only
+     once; neither target accepts a redeploy of an existing
+     release version. Re-running a release therefore requires a
+     new tag, not a retry of the old one.
+
 ## N · Norms
 - The developer `build-*.sh` scripts must quote every shell
   expansion that carries a filesystem path — `"${JAVA_HOME}"`
@@ -495,6 +588,15 @@ Files: `build-mac.sh`, `build-linux.sh`
     are present" step of both workflows,
   - one of the `build-*.sh` scripts (or a new one) for local
     builds on the matching OS/arch.
+- **Maven Central is the canonical public distribution channel.**
+  GitHub Packages requires authentication for *reads* even when
+  the repository and package are public, so a consumer must hold a
+  token with package-read scope to resolve from it. That is fine
+  for first-party projects and for CI inside the owning
+  organisation, which have such a token already, and unusable for
+  external adopters. Document Central coordinates in `README.md`
+  for external users; treat GitHub Packages as an internal fast
+  lane and never as a replacement for the Central release.
 - The Linux native resolves WebKitGTK/JavaScriptCore at **runtime**
   (Operation 7), never via a link-time `-l`. Any newly-used
   `webkit_*` / `jsc_*` symbol must be added to the `webkit_loader`
@@ -527,6 +629,19 @@ Files: `build-mac.sh`, `build-linux.sh`
   diverge, the script is wrong, not CI — CI builds the artifact that
   ships, so a local smoke test against a differently-linked library
   proves nothing about the release.
+- **A release publishes to both targets or to neither.** The
+  six-platform presence assertion runs before either deploy, so a
+  jar missing a platform never reaches GitHub Packages or Maven
+  Central. Do not move a deploy step ahead of that assertion, and
+  do not add a deploy step to `build.yml` — publication belongs to
+  tag-triggered releases only.
+- **Deploy targets stay inside their profiles (never-relax).**
+  Moving `central-publishing-maven-plugin` back into the top-level
+  build silently re-breaks the GitHub Packages leg: with its
+  extensions active unconditionally it replaces the deploy goal for
+  every invocation, so the `github-deploy` profile deploys to
+  Central instead, or not at all. A bare `mvn deploy` having no
+  target is the intended behaviour, not an oversight to fix.
 - The extractor cleans up leftover libraries older than 5
   minutes (`BaseJniExtractor.java:66`), bounded by the
   `org.scijava.nativelib.leftoverMinAgeMs` system property.


### PR DESCRIPTION
## Why

Maven Central's post-publish sync delay blocks downstream first-party projects from building against a freshly released version. GitHub Packages is resolvable the moment the deploy returns, so each `v*` tag now publishes **there first**, then to Maven Central. Same coordinates, same tag-derived version, same six-platform fat jar.

Scope is tagged releases only — no snapshot channel, nothing publishes from `master`, and `build.yml` is untouched.

## The obstacle this had to work around

`central-publishing-maven-plugin` is declared with `<extensions>true</extensions>`, which *replaces* `deploy:deploy` in the `jar` lifecycle. While it sat in the default build, `mvn deploy` could only ever reach Central — adding a `<distributionManagement>` repository had no effect at all.

So each target moves into its own profile, neither active by default:

| Invocation | Deploy goal that runs | Target |
|---|---|---|
| `mvn deploy -Pgithub-deploy` | `maven-deploy-plugin:deploy` | GitHub Packages |
| `mvn deploy -Pcentral-deploy` | `central-publishing:publish` | Maven Central |
| `mvn deploy` (bare) | `maven-deploy-plugin:deploy` | none — fails loudly |

The release job runs `mvn deploy` twice over one assembled tree. A bare `mvn deploy` having no target is intended, not an oversight; `mvn package` and `mvn install` are unchanged for local developers.

## Changes

- **`pom.xml`** — `central-publishing-maven-plugin` moves out of the default build into a `central-deploy` profile; new sibling `github-deploy` profile carries the GitHub Packages `<distributionManagement>` entry. `sign-artifacts` is untouched and still supplies sources, javadoc and GPG signatures for the Central leg.
- **`.github/workflows/maven-release.yml`** — `packages: write` on the deploy job only (the native matrix jobs keep the read-only default); a settings file authenticating both `github` and `central` servers, written directly because `setup-java` configures only one; the single deploy step becomes two sequential steps, GitHub Packages first.
- **`README.md`** — documents the early-access channel and the `settings.xml` server entry a consumer needs.
- **Canvas 8** (`spdd/prompt/8-...-Native-Library-Loading-And-Packaging.md`) — amended first per the SPDD workflow: Requirements, Approach, Structure, Operation 6, a new Operation 9 (Dual-Target Release Publication), Norms and Safeguards.

## Verification

The profile split was verified empirically against this pom, not just by inspection:

- `-Pgithub-deploy` with `-DaltDeploymentRepository` pointed at a local file repo → `maven-deploy-plugin:deploy` ran and wrote jar + pom. The extension is no longer hijacking the deploy phase.
- `-Pcentral-deploy` → log shows `central-publishing:0.7.0:publish (injected-central-publishing)`, reaching the upload and failing only on `401 Unauthorized` (no credentials locally, as expected). The extension still works from inside a profile.
- Bare `mvn deploy` → fails with *"repository element was not specified in the POM inside distributionManagement"*. Publishes nowhere.
- The generated `settings.xml` was rendered through the YAML block scalar and fed to `mvn help:effective-settings`: parses cleanly and `${env.*}` interpolates.

`pom.xml` is well-formed XML; the workflow is valid YAML.

## Notes for review

- **Ordering is load-bearing.** Shortening the wait is the whole point, so a failure in the Central leg still leaves the GitHub Packages artifact published and usable.
- **The GitHub Packages leg is deliberately unsigned and jar-only** — no GPG (not required there, and it keeps the private key out of the first deploy), which also means no sources/javadoc jars on that channel. Fine for building against; IDE source attachment would need Central or a follow-up splitting `sign-artifacts` into "attach extras" and "sign". Say the word if you'd rather have that now.
- **GitHub Packages requires an authenticated read even for public packages**, so it serves first-party projects and org CI only. Maven Central remains the canonical public channel for external adopters — this is a private fast lane, not a second public one.
- Neither repository accepts a redeploy of an existing release version, so re-running a release needs a new tag rather than a retry of the old one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxpU7TVWXeUJjSmQgbJLSu

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxpU7TVWXeUJjSmQgbJLSu)_