### PR TITLE
macOS: a credential with no user name is written and never readable

### DIFF
--- a/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
+++ b/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
@@ -202,6 +202,26 @@ generated_at: 2026-08-13T15:30:00-07:00
 - Add `-framework Security` to `build-mac.sh` (Keychain access). This is
   the only build-script change in this canvas; libsecret / Advapi32
   linkage is added by canvases 27 / 28.
+- **A credential with no user name is a first-class credential.** A
+  two-step login — the pattern Google, Microsoft and Okta use, where the
+  page carrying the password field has no username field at all — yields
+  a capture whose username is the empty string. It must save, find,
+  enumerate, update and delete exactly like any other credential. This is
+  not a corner case: it is most corporate sign-ins.
+
+  Found in the field on macOS: such a credential was written to the
+  Keychain correctly (the item exists under
+  `"<namespace>:<origin>"` with a blank Account and the correct
+  `millis\npassword` value) and was then invisible to **every** read, so a
+  consumer could not show, copy, fill, update or delete it — and a
+  consumer that verifies its own write by reading it back concluded the
+  save had failed. The macOS reads dropped any item whose
+  `kSecAttrAccount` came back absent, which is how macOS reports an empty
+  account attribute. The Linux/libsecret backend (canvas 27) already
+  handles this correctly: a missing `username` attribute leaves the
+  username empty and the row is kept. Operation 16 below carries the
+  macOS fix.
+
 - Definition of Done:
   - All 22 STORY-006-001 ACs pass on macOS with the new code (AC21/AC22
     cover the no-re-prompt-for-unchanged / changed-password-still-prompts
@@ -223,6 +243,14 @@ generated_at: 2026-08-13T15:30:00-07:00
     JavaScript cannot reach the enumeration (macOS native round-trip
     verified via the demo; Linux / Windows native bodies in canvases
     27 / 28).
+  - The **empty-user-name** round trip holds on macOS, against the real
+    Keychain: `save` of a credential whose username is `""` is followed by
+    a `find(origin)` that returns it with its password intact, a
+    `findAll()` that includes it, a second `save` for the same
+    `{origin, ""}` that updates rather than duplicates it, and a
+    `delete(origin, "")` that removes it. The same four hold for a
+    credential that has a username, so the fix costs the ordinary case
+    nothing.
   - A `WebViewPasswordDemo` under `demos/` exercises capture + save
     prompt + autofill in default-handler, custom-handler, and
     in-memory-store modes, plus a fill-consent toggle (install `CONFIRM`)
@@ -1340,18 +1368,41 @@ File: `src_c/webview_embed.cpp` (guarded `#if defined(WEBVIEW_COCOA)`)
      UTF-8 of `millis + "\n" + password`; if present `SecItemUpdate`
      (set `kSecValueData`), else `SecItemAdd` (add `kSecValueData` +
      `kSecAttrSynchronizable=kCFBooleanFalse`). Return `errSecSuccess`.
+     **When the add returns `errSecDuplicateItem`, fall back to
+     `SecItemUpdate` and return that result instead.** The existence
+     check said the item was absent and the add says it is a duplicate:
+     the two queries disagree about an attribute — an empty
+     `kSecAttrAccount` is the case that produced this — and a write must
+     not be silently lost because of that disagreement. Nothing else
+     distinguishes the fallback from the ordinary update path.
    - `webview_cred_store_find`: the macOS keychain rejects
      `kSecMatchLimitAll` combined with `kSecReturnData` (it returns
      `errSecParam`, not results), so read in **two phases**. Phase 1 —
      query `service` + `kSecMatchLimitAll` + `kSecReturnAttributes=true`
-     and **no** `kSecReturnData`, to enumerate every matching item's
-     `kSecAttrAccount` (the username). Phase 2 — for each account from
-     phase 1, issue a second query `service` + `kSecAttrAccount` +
-     `kSecMatchLimitOne` + `kSecReturnData=true` to fetch that one item's
-     `kSecValueData`; split it on the first `\n` into millis + password.
-     Collect `[username, millis, password]` per item. Return a
-     `jobjectArray` of the flat triples (Java sorts). Empty array when
-     phase 1 yields `errSecItemNotFound` or no accounts.
+     + **`kSecReturnRef=true`** and **no** `kSecReturnData`, to enumerate
+     every matching item's `kSecAttrAccount` (the username) **and its
+     item reference**. Phase 2 — for each item from phase 1, issue a
+     second query of **`kSecValueRef` + `kSecReturnData=true`** to fetch
+     that one item's `kSecValueData`; split it on the first `\n` into
+     millis + password. Collect `[username, millis, password]` per item.
+     Return a `jobjectArray` of the flat triples (Java sorts). Empty array
+     when phase 1 yields `errSecItemNotFound` or no items.
+
+     Two rules make this work for a credential saved with **no user
+     name**, and both are load-bearing:
+
+     1. **An absent or empty `kSecAttrAccount` is an empty user name, not
+        a row to drop.** macOS reports an empty account attribute as
+        absent, so skipping such rows hid an entire class of credential —
+        every two-step login — from every read while it sat in the
+        keychain. Keep the item; the username is `""`.
+     2. **Phase 2 fetches by item reference, never by re-matching
+        `{service, account}`.** Re-matching makes the secret fetch depend
+        on the very attribute round-trip that rule 1 has just established
+        cannot be relied on. The reference names the row phase 1 already
+        found, so no attribute has to match itself. This is the
+        root-cause fix; rule 1 alone would leave the same fragility one
+        query further down.
    - `webview_cred_store_find_all` (STORY-006-005): the enumerate-all
      variant of `find`, across every origin. Because each item's
      `kSecAttrService` is `"<namespace>:<origin>"` (origin embedded in the
@@ -1363,12 +1414,14 @@ File: `src_c/webview_embed.cpp` (guarded `#if defined(WEBVIEW_COCOA)`)
      `kSecReturnData` combination still returns `errSecParam`). Phase 1 —
      query `kSecClass=kSecClassGenericPassword` + `kSecMatchLimitAll` +
      `kSecReturnAttributes=true` (no `kSecReturnData`, no service filter)
-     to enumerate every item's `kSecAttrService` + `kSecAttrAccount`;
-     keep only items whose service begins with `"<service>:"`, take
-     `origin` = the service text after that prefix and `username` = the
-     account. Phase 2 — for each kept item, issue a single-item
-     `kSecAttrService=<that full service>` + `kSecAttrAccount=<username>`
-     + `kSecMatchLimitOne` + `kSecReturnData=true` query to fetch its
+     plus **`kSecReturnRef=true`**, to enumerate every item's
+     `kSecAttrService` + `kSecAttrAccount` + item reference; keep only
+     items whose service begins with `"<service>:"`, take `origin` = the
+     service text after that prefix and `username` = the account. The
+     **service is required** here (the origin is derived from it) but the
+     **account is not**: an absent account is an empty user name, exactly
+     as in `find` above. Phase 2 — for each kept item, issue a
+     **`kSecValueRef` + `kSecReturnData=true`** query to fetch its
      `kSecValueData`; split on the first `\n` into millis + password.
      Emit a flat **quad** `[origin, username, millis, password]` per
      kept item. Return a `jobjectArray` of the flat quads (Java sorts).
@@ -1737,6 +1790,14 @@ Files under `test/ca/weblite/webview/`:
   engine; `PasswordDispatcher` derives the origin solely from that. This
   is the anti-cross-origin-theft/injection invariant — a page can only
   ever cause its *own* origin's credential to be saved or filled.
+- **A credential the store accepted is a credential the store can
+  return.** No read may drop a row on the strength of an attribute that
+  the OS is free not to round-trip: on macOS the account is optional on
+  the way out (absent means no user name) and the secret is fetched by
+  item reference, so what `save` wrote is what `find` and `findAll` hand
+  back. A backend that silently filters its own rows is worse than one
+  that fails loudly — the write looks successful, the credential is
+  unreachable, and nothing anywhere reports a fault.
 - **Autofill is exact-origin.** `store.find` is keyed by the canonical
   origin; a credential for `https://example.com` is never offered on
   `https://evil.com`, `http://example.com`, or

--- a/src_c/webview_embed.cpp
+++ b/src_c/webview_embed.cpp
@@ -8140,7 +8140,21 @@ JNIEXPORT jboolean JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cred_1
                              cfVal, kCFBooleanFalse };
         CFDictionaryRef add = CFDictionaryCreate(kCFAllocatorDefault, ak, av, 5,
             &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
-        ok = (SecItemAdd(add, nullptr) == errSecSuccess) ? JNI_TRUE : JNI_FALSE;
+        OSStatus addSt = SecItemAdd(add, nullptr);
+        if (addSt == errSecDuplicateItem) {
+            // The existence check above said no and the add says duplicate:
+            // the query and the item disagree on an attribute (an empty
+            // account is the case that produced this).  Update rather than
+            // report a failure the caller cannot act on.
+            const void *uk[] = { kSecValueData };
+            const void *uv[] = { cfVal };
+            CFDictionaryRef upd = CFDictionaryCreate(kCFAllocatorDefault,
+                uk, uv, 1, &kCFTypeDictionaryKeyCallBacks,
+                &kCFTypeDictionaryValueCallBacks);
+            addSt = SecItemUpdate(query, upd);
+            CFRelease(upd);
+        }
+        ok = (addSt == errSecSuccess) ? JNI_TRUE : JNI_FALSE;
         CFRelease(add);
     }
     CFRelease(query); CFRelease(cfSvc); CFRelease(cfAcct); CFRelease(cfVal);
@@ -8196,14 +8210,13 @@ JNIEXPORT jobjectArray JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cr
     std::vector<std::string> triples;
     // The macOS keychain rejects kSecMatchLimitAll combined with
     // kSecReturnData (errSecParam), so read in two phases: phase 1
-    // enumerates the matching accounts (attributes only, no data); phase 2
-    // fetches each account's secret with a single-item, data-returning
-    // query.
+    // enumerates the matching items (attributes and refs, no data); phase 2
+    // fetches each item's secret by reference with a data-returning query.
     const void *q1k[] = { kSecClass, kSecAttrService, kSecMatchLimit,
-                          kSecReturnAttributes };
+                          kSecReturnAttributes, kSecReturnRef };
     const void *q1v[] = { kSecClassGenericPassword, cfSvc, kSecMatchLimitAll,
-                          kCFBooleanTrue };
-    CFDictionaryRef q1 = CFDictionaryCreate(kCFAllocatorDefault, q1k, q1v, 4,
+                          kCFBooleanTrue, kCFBooleanTrue };
+    CFDictionaryRef q1 = CFDictionaryCreate(kCFAllocatorDefault, q1k, q1v, 5,
         &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
     CFTypeRef listResult = nullptr;
     OSStatus st = SecItemCopyMatching(q1, &listResult);
@@ -8213,25 +8226,36 @@ JNIEXPORT jobjectArray JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cr
         for (CFIndex i = 0; i < n; i++) {
             CFDictionaryRef item =
                 (CFDictionaryRef)CFArrayGetValueAtIndex(arr, i);
+            // A credential saved with NO user name -- a two-step login, where
+            // the page carrying the password field has no username field --
+            // comes back with kSecAttrAccount empty or absent.  Skipping it
+            // here hid the credential from every lookup while it sat in the
+            // keychain: the save wrote it, and nothing could ever read it
+            // back.  An absent account is an empty user name, not a bad row.
             CFStringRef acct =
                 (CFStringRef)CFDictionaryGetValue(item, kSecAttrAccount);
-            if (!acct) continue;
             std::string username, millisStr = "0", password;
-            CFIndex maxlen = CFStringGetMaximumSizeForEncoding(
-                CFStringGetLength(acct), kCFStringEncodingUTF8) + 1;
-            std::vector<char> buf((size_t)maxlen);
-            if (!CFStringGetCString(acct, buf.data(), maxlen,
-                                    kCFStringEncodingUTF8)) {
-                continue;
+            if (acct) {
+                CFIndex maxlen = CFStringGetMaximumSizeForEncoding(
+                    CFStringGetLength(acct), kCFStringEncodingUTF8) + 1;
+                std::vector<char> buf((size_t)maxlen);
+                if (!CFStringGetCString(acct, buf.data(), maxlen,
+                                        kCFStringEncodingUTF8)) {
+                    continue;
+                }
+                username = buf.data();
             }
-            username = buf.data();
-            // Phase 2: fetch this account's secret.
-            const void *q2k[] = { kSecClass, kSecAttrService, kSecAttrAccount,
-                                  kSecMatchLimit, kSecReturnData };
-            const void *q2v[] = { kSecClassGenericPassword, cfSvc, acct,
-                                  kSecMatchLimitOne, kCFBooleanTrue };
+            // Phase 2: fetch this item's secret BY REFERENCE.  Matching on
+            // {service, account} a second time cannot fetch an item whose
+            // account did not round-trip; the ref names the row phase 1 has
+            // already found, so the fetch no longer depends on an attribute
+            // matching itself.
+            CFTypeRef ref = CFDictionaryGetValue(item, kSecValueRef);
+            if (!ref) continue;
+            const void *q2k[] = { kSecValueRef, kSecReturnData };
+            const void *q2v[] = { ref, kCFBooleanTrue };
             CFDictionaryRef q2 = CFDictionaryCreate(kCFAllocatorDefault,
-                q2k, q2v, 5, &kCFTypeDictionaryKeyCallBacks,
+                q2k, q2v, 2, &kCFTypeDictionaryKeyCallBacks,
                 &kCFTypeDictionaryValueCallBacks);
             CFTypeRef dataResult = nullptr;
             if (SecItemCopyMatching(q2, &dataResult) == errSecSuccess
@@ -8349,10 +8373,11 @@ JNIEXPORT jobjectArray JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cr
     // service starts with "<service>:".  Two phases as in find: the
     // kSecMatchLimitAll + kSecReturnData combination returns errSecParam.
     std::vector<std::string> quads;
-    const void *q1k[] = { kSecClass, kSecMatchLimit, kSecReturnAttributes };
+    const void *q1k[] = { kSecClass, kSecMatchLimit, kSecReturnAttributes,
+                          kSecReturnRef };
     const void *q1v[] = { kSecClassGenericPassword, kSecMatchLimitAll,
-                          kCFBooleanTrue };
-    CFDictionaryRef q1 = CFDictionaryCreate(kCFAllocatorDefault, q1k, q1v, 3,
+                          kCFBooleanTrue, kCFBooleanTrue };
+    CFDictionaryRef q1 = CFDictionaryCreate(kCFAllocatorDefault, q1k, q1v, 4,
         &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
     CFTypeRef listResult = nullptr;
     OSStatus st = SecItemCopyMatching(q1, &listResult);
@@ -8366,7 +8391,9 @@ JNIEXPORT jobjectArray JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cr
                 (CFStringRef)CFDictionaryGetValue(item, kSecAttrService);
             CFStringRef acct =
                 (CFStringRef)CFDictionaryGetValue(item, kSecAttrAccount);
-            if (!svcAttr || !acct) continue;
+            // An absent account is a credential saved with no user name (a
+            // two-step login), not a row to drop -- see find() above.
+            if (!svcAttr) continue;
             // Read the full service string.
             CFIndex svcMax = CFStringGetMaximumSizeForEncoding(
                 CFStringGetLength(svcAttr), kCFStringEncodingUTF8) + 1;
@@ -8382,23 +8409,27 @@ JNIEXPORT jobjectArray JNICALL Java_ca_weblite_webview_WebViewNative_webview_1cr
                 continue;
             }
             std::string origin = fullSvc.substr(prefix.size());
-            // Read the account (username).
-            CFIndex acctMax = CFStringGetMaximumSizeForEncoding(
-                CFStringGetLength(acct), kCFStringEncodingUTF8) + 1;
-            std::vector<char> acctBuf((size_t)acctMax);
-            if (!CFStringGetCString(acct, acctBuf.data(), acctMax,
-                                    kCFStringEncodingUTF8)) {
-                continue;
+            // Read the account (username); absent means none was captured.
+            std::string username;
+            if (acct) {
+                CFIndex acctMax = CFStringGetMaximumSizeForEncoding(
+                    CFStringGetLength(acct), kCFStringEncodingUTF8) + 1;
+                std::vector<char> acctBuf((size_t)acctMax);
+                if (!CFStringGetCString(acct, acctBuf.data(), acctMax,
+                                        kCFStringEncodingUTF8)) {
+                    continue;
+                }
+                username = acctBuf.data();
             }
-            std::string username = acctBuf.data();
             std::string millisStr = "0", password;
-            // Phase 2: fetch this item's secret by exact service+account.
-            const void *q2k[] = { kSecClass, kSecAttrService, kSecAttrAccount,
-                                  kSecMatchLimit, kSecReturnData };
-            const void *q2v[] = { kSecClassGenericPassword, svcAttr, acct,
-                                  kSecMatchLimitOne, kCFBooleanTrue };
+            // Phase 2: fetch this item's secret by reference, not by matching
+            // {service, account} again -- see find() above.
+            CFTypeRef ref = CFDictionaryGetValue(item, kSecValueRef);
+            if (!ref) continue;
+            const void *q2k[] = { kSecValueRef, kSecReturnData };
+            const void *q2v[] = { ref, kCFBooleanTrue };
             CFDictionaryRef q2 = CFDictionaryCreate(kCFAllocatorDefault,
-                q2k, q2v, 5, &kCFTypeDictionaryKeyCallBacks,
+                q2k, q2v, 2, &kCFTypeDictionaryKeyCallBacks,
                 &kCFTypeDictionaryValueCallBacks);
             CFTypeRef dataResult = nullptr;
             if (SecItemCopyMatching(q2, &dataResult) == errSecSuccess


### PR DESCRIPTION
## The bug

A **two-step login** — the pattern Google, Microsoft and Okta use, where the page carrying the password field has no username field — yields a capture whose username is the empty string. On macOS such a credential is written to the Keychain correctly and is then **invisible to every read**.

Confirmed in Keychain Access: the item is there, under `ca.weblite.webview.passwords:<origin>`, with a blank Account and the correct `millis\npassword` value — while `find(origin)` and `findAll()` both return nothing for it. The consumer cannot show, copy, fill, update or delete it, and a consumer that reads back what it just wrote concludes the save failed. Nothing anywhere reports a fault.

Found from the other side: the Agentic App Framework's password screen started verifying its own writes, and this credential class failed verification every time while sitting in the Keychain intact.

## Cause

In the two-phase read, phase 1 enumerates attributes and both `find` and `find_all` skipped any item whose `kSecAttrAccount` came back absent — which is how macOS reports an empty account attribute:

- `src_c/webview_embed.cpp:8218` — `if (!acct) continue;`
- `src_c/webview_embed.cpp:8369` — `if (!svcAttr || !acct) continue;`

Phase 2 then re-matched on `{kSecAttrService, kSecAttrAccount}`, so the secret fetch depended on the very attribute round-trip phase 1 had just proved unreliable.

## The fix

1. **An absent or empty `kSecAttrAccount` is an empty user name**, not a row to drop — in both `find` and `find_all`. `find_all` still requires the service, since the origin is derived from it.
2. **Phase 1 also requests `kSecReturnRef`, and phase 2 fetches the secret with `{kSecValueRef, kSecReturnData}`** instead of re-matching `{service, account}`. The ref names the row phase 1 already found, so no attribute has to match itself. This is the root-cause fix; rule 1 alone would leave the same fragility one query further down.
3. **`save`: `SecItemAdd` returning `errSecDuplicateItem` falls back to `SecItemUpdate`.** The existence check said absent and the add says duplicate — the two queries disagree about an attribute, and a write must not be silently lost because of that.

Credentials already stranded in a user's Keychain by this bug become visible and readable as soon as this lands: the data was correct all along.

## Other platforms

- **Linux** is unaffected — the libsecret path already keeps a row whose `username` attribute is missing (`if (uname) username = uname;`).
- **Windows** encodes the username into the target name; worth confirming `pw_b64url_decode("")` returns true there, which I could not check.

## ⚠️ Not built, not run

**I have no macOS in this environment, so this code has never been compiled or executed.** What I did verify: the file's brace/paren balance is unchanged, and the three edits are confined to the `WEBVIEW_COCOA` branches. The Security.framework usage — `kSecReturnRef` results carrying `kSecValueRef` under `kSecMatchLimitAll` with `kSecReturnAttributes`, and a `{kSecValueRef, kSecReturnData}` fetch — is standard but unverified here. Please build with `./build-mac.sh` and exercise the empty-user-name round trip before merging.

## SPDD

Canvas 26 amended first — Requirements (the empty-user-name credential is first class, with the field report), Operation 16 (all three rules), a new Safeguard ("a credential the store accepted is a credential the store can return"), and a DoD entry covering the save → find → findAll → re-save → delete round trip for a credential with no user name — then the code generated from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2bxT5MRdifMAM6AX6tPs9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2bxT5MRdifMAM6AX6tPs9)_