### PR TITLE
Carry the user name across a two-step login (Canvas 26 4a)

### DIFF
--- a/demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDemo.java
+++ b/demos/WebViewPasswordDemo/src/ca/weblite/webview/demos/WebViewPasswordDemo.java
@@ -77,6 +77,8 @@ public class WebViewPasswordDemo {
 
         HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
         server.createContext("/", new LoginHandler());
+        // Canvas 26 4a: a two-step login, the shape the username-first flow exists for.
+        server.createContext("/two-step", new TwoStepHandler());
         server.setExecutor(null);
         server.start();
         int port = server.getAddress().getPort();
@@ -186,6 +188,9 @@ public class WebViewPasswordDemo {
 
         append("Serving login form at " + origin + "/");
         append("Submit the form to trigger the Save prompt; Reload to autofill.");
+        append("Open " + origin + "/two-step for the two-step login: the user name is");
+        append("typed on the first page, the password on the second, and the Save prompt");
+        append("should still name the user (Canvas 26 4a).");
         wv.setUrl(origin + "/");
     }
 
@@ -218,6 +223,57 @@ public class WebViewPasswordDemo {
                     + "</form>"
                     + "<script>document.querySelector('input[type=password]')"
                     + ".addEventListener('input',function(){console.log('password field input event');});</script>";
+            }
+            byte[] body = html.getBytes(StandardCharsets.UTF_8);
+            ex.getResponseHeaders().add("Content-Type", "text/html; charset=utf-8");
+            ex.sendResponseHeaders(200, body.length);
+            try (OutputStream os = ex.getResponseBody()) {
+                os.write(body);
+            }
+        }
+    }
+
+    /**
+     * A two-step login (Canvas 26 4a): the user name on one page, the password on
+     * the next, with no user name field anywhere near the password. This is what
+     * Google, Microsoft and Okta do, and without the username-first flow the Save
+     * prompt has no name to offer. The two pages are separate documents on one
+     * origin, so the candidate has to survive a real navigation.
+     */
+    private static final class TwoStepHandler implements HttpHandler {
+        @Override public void handle(HttpExchange ex) throws IOException {
+            String path = ex.getRequestURI().getPath();
+            String html;
+            if (path.endsWith("/done")) {
+                ex.getRequestBody().read(new byte[4096]);
+                html = "<!doctype html><meta charset=utf-8><title>Logged in</title>"
+                    + "<body style='font-family:sans-serif;padding:2rem'>"
+                    + "<h2>Logged in.</h2>"
+                    + "<p>The Save prompt should have named the user you typed on step 1.</p>"
+                    + "<p><a href='/two-step'>Start over</a></p>";
+            } else if (path.endsWith("/password")) {
+                // Step 2: a password and nothing else -- exactly the Okta shape. The
+                // user name is shown as text, which no password manager can read.
+                html = "<!doctype html><meta charset=utf-8><title>Verify with your password</title>"
+                    + "<body style='font-family:sans-serif;padding:2rem'>"
+                    + "<h2>Verify with your password</h2>"
+                    + "<p><span id='who' style='color:#555'></span></p>"
+                    + "<form method='post' action='/two-step/done'>"
+                    + "<p><label>Password<br><input type='password' name='password' "
+                    + "autocomplete='current-password'></label></p>"
+                    + "<p><button type='submit'>Verify</button></p>"
+                    + "</form>"
+                    + "<script>try{document.getElementById('who').textContent="
+                    + "new URLSearchParams(location.search).get('u')||'';}catch(e){}</script>";
+            } else {
+                // Step 1: a user name and nothing else.
+                html = "<!doctype html><meta charset=utf-8><title>Sign in</title>"
+                    + "<body style='font-family:sans-serif;padding:2rem'>"
+                    + "<h2>Sign in</h2>"
+                    + "<form method='get' action='/two-step/password'>"
+                    + "<p><label>Username<br><input name='u' autocomplete='username'></label></p>"
+                    + "<p><button type='submit'>Next</button></p>"
+                    + "</form>";
             }
             byte[] body = html.getBytes(StandardCharsets.UTF_8);
             ex.getResponseHeaders().add("Content-Type", "text/html; charset=utf-8");

--- a/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
+++ b/spdd/prompt/26-202608131530-[Feat]-Webview-Native-Password-Manager-And-Macos-Coverage.md
@@ -202,6 +202,29 @@ generated_at: 2026-08-13T15:30:00-07:00
 - Add `-framework Security` to `build-mac.sh` (Keychain access). This is
   the only build-script change in this canvas; libsecret / Advapi32
   linkage is added by canvases 27 / 28.
+- **Carry the user name across a two-step login (the "username-first
+  flow").** When the password page has no username field, the name the
+  user typed on the site's *previous* step is what the credential should
+  be stored under. The shim therefore remembers the last user name typed
+  on an origin and supplies it with the capture when — and only when —
+  the submitted form has no user name of its own. Chrome does the same
+  thing: its password manager records a `PossibleUsernameData` when the
+  user modifies a non-password text field, keyed to the signon realm, and
+  consults it when a password form is submitted without a username; the
+  candidate goes stale after
+  [`kSingleUsernameTimeToLive = base::Minutes(5)`](https://raw.githubusercontent.com/chromium/chromium/main/components/password_manager/core/browser/password_manager_constants.h),
+  and candidates that look like one-time codes are excluded. This canvas
+  mirrors the local heuristic — the same five-minute window, the same
+  same-origin rule, an OTP guard of its own — and deliberately does **not**
+  attempt Chrome's server-side field predictions, which have no analogue
+  here.
+
+  It is a **heuristic, and it never overrides the page**: a form that has
+  a user name field uses that field's value, empty or not. The remembered
+  name is only ever a fallback for a form that offers nothing, and a
+  credential with no user name at all stays legal (below), because the
+  user may have arrived some way the heuristic cannot see.
+
 - **A credential with no user name is a first-class credential.** A
   two-step login — the pattern Google, Microsoft and Okta use, where the
   page carrying the password field has no username field at all — yields
@@ -243,6 +266,14 @@ generated_at: 2026-08-13T15:30:00-07:00
     JavaScript cannot reach the enumeration (macOS native round-trip
     verified via the demo; Linux / Windows native bodies in canvases
     27 / 28).
+  - The **username-first flow** carries the name across a two-step login:
+    in `WebViewPasswordDemo`, `/two-step` collects a user name and posts
+    to a second page that has only a password field; submitting it raises
+    a Save prompt whose user name is the one typed on the first page, and
+    the credential is stored under it. The same page submitted more than
+    five minutes later, or with a one-time-code-shaped value, saves with
+    no user name rather than a wrong one. A single-page login form is
+    unaffected: its own field wins, empty or not.
   - The **empty-user-name** round trip holds on macOS, against the real
     Keychain: `save` of a credential whose username is `""` is followed by
     a `find(origin)` that returns it with its password intact, a
@@ -1239,11 +1270,52 @@ File: `src/ca/weblite/webview/PasswordDispatcher.java` (string constant)
      first text/email/tel input; if no form: the nearest preceding
      text/email/tel input in document order. May be null (password-only
      forms) — then username is treated as empty string.
+4a. Username-first flow — remembering a name typed on an earlier step:
+   - `rememberUserName(el)` records `{value, typedAt, name, autocomplete,
+     origin}` for a text/email/tel input the user has just committed a
+     value to, **only** when that input's form (if any) contains no
+     password field: a form that has both is an ordinary login form whose
+     user name is captured properly by `findFields()`, and recording from
+     it would only pollute the candidate.
+   - It is stored in `sessionStorage` under a private key, with an
+     in-page variable as the fallback when `sessionStorage` throws
+     (sandboxed frames, storage disabled). `sessionStorage` is what makes
+     the flow work across a real navigation — the two steps of a
+     multi-page login are two documents, and a variable would not
+     survive. It is origin- and tab-scoped by the browser, which is the
+     same-origin rule enforced for free; the stored `origin` is compared
+     anyway rather than trusted implicitly. Nothing secret is written:
+     the value is a user name the page itself just received, and it is
+     never a password — a password field is never a candidate, because
+     `isTexty()` excludes it.
+   - Recorded on `change` (the value committed, on blur or Enter) and on
+     `submit` of a form that has a text field and **no** password field —
+     the first step of a two-step login, which is the case this exists
+     for.
+   - `rememberedUserName()` returns the stored value, or `''`, applying
+     the guards: not older than **five minutes** (Chromium's
+     `kSingleUsernameTimeToLive`), same origin, non-empty, and not
+     one-time-code-shaped. The OTP guard rejects a field whose name,
+     id or autocomplete matches `otp`, `one-time`, `passcode`,
+     `verification`/`verify`, `2fa`/`mfa`, `security code`, `token` or
+     `pin`, and rejects a value that is 3–8 digits and nothing else. A
+     one-time code stored as a user name is worse than no user name: it
+     is wrong, it is stable-looking, and the user would have to notice it
+     to fix it.
+   - The candidate is **not** cleared when used. It expires on its own,
+     exactly as Chromium's does; a second submission of the same login
+     (a mistyped password, a server round trip) must not lose the name.
+
 5. Save capture:
    - Attach a capturing `submit` listener on `document` that, when the
      submitted form contains the password field, reads `user?.value ?? ''`
      and `pass.value`, and if `pass.value` is non-empty calls
      `post('S|' + b64e(user) + '|' + b64e(passVal))`.
+   - **When that user name is empty**, substitute `rememberedUserName()`
+     (4a) before posting. Only then: a form that has a user name field
+     uses that field's value, and this never overrides a page that
+     supplied one. An empty result leaves the capture exactly as it is
+     today — a credential with no user name, which remains legal.
    - Best-effort SPA: a capturing `click` listener on `document` for
      `button, input[type=submit], [role=button]` that, if a password
      field currently has a non-empty value and there is no enclosing

--- a/src/ca/weblite/webview/PasswordDispatcher.java
+++ b/src/ca/weblite/webview/PasswordDispatcher.java
@@ -80,10 +80,38 @@ public final class PasswordDispatcher {
         "try{el.dispatchEvent(new Event('input',{bubbles:true}));el.dispatchEvent(new Event('change',{bubbles:true}));}catch(e){}}\n" +
         "window.__webview_pw_fill__=function(bu,bp){try{var f=findFields();if(!f)return;" +
         "if(f.user&&bu)setVal(f.user,b64d(bu));if(f.pass)setVal(f.pass,b64d(bp));}catch(e){}};\n" +
+        // Canvas 26 4a: the username-first flow. A two-step login (Google, Microsoft,
+        // Okta) puts the user name on a page of its own, so the password page has no
+        // field to read. Remember what was typed on the earlier step -- in
+        // sessionStorage, which is origin- and tab-scoped and survives the navigation
+        // between the two documents -- and supply it only when the submitted form
+        // offers no user name of its own. Five-minute window and the OTP guard mirror
+        // Chromium's kSingleUsernameTimeToLive and its is_likely_otp rule.
+        "var UKEY='__webview_pw_user__';var UTTL=300000;var memU=null;\n" +
+        "function uPut(o){try{sessionStorage.setItem(UKEY,JSON.stringify(o));}catch(e){}memU=o;}\n" +
+        "function uRead(){try{var r=sessionStorage.getItem(UKEY);if(r)return JSON.parse(r);}catch(e){}return memU;}\n" +
+        "function isOtpish(n,a,v){var h=((n||'')+' '+(a||'')).toLowerCase();" +
+        "if(/otp|one[-_ ]?time|passcode|verification|verify|2fa|mfa|security[-_ ]?code|token|pin/.test(h))return true;" +
+        "return /^[0-9]{3,8}$/.test(v);}\n" +
+        "function hasPassword(form){try{return !!(form&&form.querySelector&&" +
+        "form.querySelector('input[type=password]'));}catch(e){return false;}}\n" +
+        "function rememberUserName(el){try{if(!isTexty(el))return;var v=(el.value||'').trim();if(!v)return;" +
+        "if(hasPassword(el.form))return;" +
+        "uPut({v:v,t:Date.now(),n:(el.name||el.id||''),a:(el.getAttribute&&el.getAttribute('autocomplete'))||''," +
+        "o:location.origin});}catch(e){}}\n" +
+        "function rememberedUserName(){try{var c=uRead();if(!c||!c.v)return '';" +
+        "if(c.o!==location.origin)return '';if(Date.now()-c.t>UTTL)return '';" +
+        "if(isOtpish(c.n,c.a,c.v))return '';return c.v;}catch(e){return '';}}\n" +
+        "document.addEventListener('change',function(ev){try{rememberUserName(ev.target);}catch(e){}},true);\n" +
+        "document.addEventListener('submit',function(ev){try{var t=ev.target;" +
+        "if(t&&!hasPassword(t)&&t.elements){for(var i=0;i<t.elements.length;i++){" +
+        "if(isTexty(t.elements[i])&&(t.elements[i].value||'').trim()){rememberUserName(t.elements[i]);break;}}}}" +
+        "catch(e){}},true);\n" +
         "var lastPost=0;\n" +
         "function capture(){try{var f=findFields();if(!f||!f.pass)return;var pv=f.pass.value;if(!pv)return;" +
         "var now=Date.now();if(now-lastPost<400)return;lastPost=now;" +
-        "var uv=f.user?f.user.value:'';post('S|'+b64e(uv)+'|'+b64e(pv));}catch(e){}}\n" +
+        "var uv=f.user?f.user.value:'';if(!uv)uv=rememberedUserName();" +
+        "post('S|'+b64e(uv)+'|'+b64e(pv));}catch(e){}}\n" +
         "document.addEventListener('submit',function(ev){try{var t=ev.target;" +
         "if(t&&t.querySelector&&t.querySelector('input[type=password]'))capture();}catch(e){}},true);\n" +
         "document.addEventListener('click',function(ev){try{var el=ev.target;" +


### PR DESCRIPTION
## Why

A two-step login — Google, Microsoft, Okta — puts the user name on a page of its own, so the page carrying the password field has no username field to read. The capture's user name is empty and the credential is stored under no name at all: the consumer's password screen shows *(no user name)*, two accounts on one site can't be told apart, and the account chooser offers a row that names nobody.

The Okta DOM that prompted this shows the identifier as a `<span class="identifier" title="…">` — display text, not a field. Nothing in the password page is readable as a user name.

## What Chrome does

Its password manager records a `PossibleUsernameData` when the user modifies a non-password text field, keyed to the signon realm, and consults it when a password form is submitted with no username. The candidate expires after [`kSingleUsernameTimeToLive = base::Minutes(5)`](https://raw.githubusercontent.com/chromium/chromium/main/components/password_manager/core/browser/password_manager_constants.h), and candidates that look like one-time codes are excluded.

## What this does

The same thing, locally, entirely inside `SHIM_JS`:

- **`rememberUserName()`** records `{value, typedAt, name, autocomplete, origin}` for a text/email/tel input the user commits a value to — and only when that input's form has **no** password field. A form with both is an ordinary login form whose user name is captured properly, and recording from it would only pollute the candidate. Fires on `change` and on submit of a password-less form (the first step of a two-step login).
- **It lives in `sessionStorage`**, with an in-page variable as the fallback when that throws (sandboxed frames, storage disabled). That's what makes it work across a real navigation: the two steps are two documents, and a variable wouldn't survive. `sessionStorage` is origin- and tab-scoped, which gives the same-origin rule for free; the stored origin is compared anyway. Nothing secret is written — the value is a user name the page itself just received, and a password field is never a candidate.
- **`rememberedUserName()`** applies the guards: five minutes, same origin, non-empty, and not one-time-code-shaped (name/id/autocomplete matching `otp`, `one-time`, `passcode`, `verification`, `2fa`/`mfa`, `security code`, `token`, `pin`; or a bare 3–8 digit value). A one-time code stored as a user name is worse than no user name: it's wrong and it looks stable.
- **`capture()` substitutes it only when the submitted form's own user name is empty.** A page that supplies a name always wins. An empty result leaves the capture exactly as it is today — a nameless credential stays legal.

**No native or Java API change.** The `'S|user|pass'` message already carries a username slot, so this fits in the shim; the C-side protocol parser is untouched.

Chrome's server-side field predictions have no analogue here and aren't attempted.

## Verification

- **187 Java tests pass.**
- The shim parses (`node --check` on the extracted string constant).
- The flow was driven against a **stubbed DOM**, covering: the user name carried across a navigation, the page's own field winning, no pollution from a login form, all three OTP guards, the five-minute expiry, a cross-origin candidate rejected, and recording on a step-1 submit — 11 checks, all passing. That harness is a scratch tool, not part of this repo; there's no JS test infrastructure here to put it in, and adding one is a bigger call than this PR should make.
- **Behaviour in a real engine is demo-verified only.** `WebViewPasswordDemo` gains `/two-step` — user name on one page, password on the next, the name shown only as text like Okta does — so the flow can be exercised by hand on each platform.

## SPDD

Canvas 26 amended first (Requirements — the flow and its heuristic nature; Operation 11 step 4a; DoD), then the code generated from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2bxT5MRdifMAM6AX6tPs9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2bxT5MRdifMAM6AX6tPs9)_